### PR TITLE
fix: trust domains blocks

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -68,6 +68,7 @@ tags:
 - name: sharding-tags
 - name: theme
 - name: trust-domain
+- name: trusted-domain
 - name: user
 - name: user notifications
 paths:
@@ -8360,6 +8361,7 @@ paths:
       - domain
   /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trust-domains:
     get:
+      deprecated: true
       description: "User must have the DOMAIN_TRUST_DOMAIN[LIST] permission on the\
         \ specified domain or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified\
         \ environment or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified organization"
@@ -8396,9 +8398,11 @@ paths:
       - trust-domain
       - domain
     post:
+      deprecated: true
       description: "User must have the DOMAIN_TRUST_DOMAIN[CREATE] permission on the\
         \ specified domain or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified\
-        \ environment or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization"
+        \ environment or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization.\
+        \ Deprecated: use POST /trusted-domains instead."
       operationId: createTrustDomain
       parameters:
       - in: path
@@ -8439,6 +8443,7 @@ paths:
       - domain
   /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trust-domains/{trustDomainId}:
     delete:
+      deprecated: true
       description: "User must have the DOMAIN_TRUST_DOMAIN[DELETE] permission on the\
         \ specified domain or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified\
         \ environment or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified organization"
@@ -8474,6 +8479,7 @@ paths:
       - trust-domain
       - domain
     get:
+      deprecated: true
       description: "User must have the DOMAIN_TRUST_DOMAIN[READ] permission on the\
         \ specified domain or DOMAIN_TRUST_DOMAIN[READ] permission on the specified\
         \ environment or DOMAIN_TRUST_DOMAIN[READ] permission on the specified organization"
@@ -8513,9 +8519,11 @@ paths:
       - trust-domain
       - domain
     put:
+      deprecated: true
       description: "User must have the DOMAIN_TRUST_DOMAIN[UPDATE] permission on the\
         \ specified domain or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified\
-        \ environment or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified organization"
+        \ environment or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified organization.\
+        \ Deprecated: use PUT /trusted-domains/{trustedDomainId} instead."
       operationId: updateTrustDomain
       parameters:
       - in: path
@@ -8558,6 +8566,207 @@ paths:
       summary: Update a trust domain
       tags:
       - trust-domain
+      - domain
+  /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trusted-domains:
+    get:
+      description: "User must have the DOMAIN_TRUST_DOMAIN[LIST] permission on the\
+        \ specified domain or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified\
+        \ environment or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified organization"
+      operationId: listTrustedDomains
+      parameters:
+      - in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TrustedDomain"
+          description: List of trusted domains
+        "500":
+          description: Internal server error
+      summary: List trusted domains registered against the security domain
+      tags:
+      - trusted-domain
+      - domain
+    post:
+      description: "User must have the DOMAIN_TRUST_DOMAIN[CREATE] permission on the\
+        \ specified domain or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified\
+        \ environment or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization"
+      operationId: createTrustedDomain
+      parameters:
+      - in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NewTrustedDomain"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrustedDomain"
+          description: Trusted domain successfully created
+        "400":
+          description: Invalid trusted domain configuration
+        "500":
+          description: Internal server error
+      summary: Register a trusted domain on the security domain
+      tags:
+      - trusted-domain
+      - domain
+  /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trusted-domains/{trustedDomainId}:
+    delete:
+      description: "User must have the DOMAIN_TRUST_DOMAIN[DELETE] permission on the\
+        \ specified domain or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified\
+        \ environment or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified organization"
+      operationId: deleteTrustedDomain
+      parameters:
+      - in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: trustedDomainId
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Trusted domain successfully deleted
+        "500":
+          description: Internal server error
+      summary: Delete a trusted domain
+      tags:
+      - trusted-domain
+      - domain
+    get:
+      description: "User must have the DOMAIN_TRUST_DOMAIN[READ] permission on the\
+        \ specified domain or DOMAIN_TRUST_DOMAIN[READ] permission on the specified\
+        \ environment or DOMAIN_TRUST_DOMAIN[READ] permission on the specified organization"
+      operationId: getTrustedDomain
+      parameters:
+      - in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: trustedDomainId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrustedDomain"
+          description: Trusted domain
+        "404":
+          description: Trusted domain not found
+      summary: Get a trusted domain
+      tags:
+      - trusted-domain
+      - domain
+    put:
+      description: "User must have the DOMAIN_TRUST_DOMAIN[UPDATE] permission on the\
+        \ specified domain or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified\
+        \ environment or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified organization"
+      operationId: updateTrustedDomain
+      parameters:
+      - in: path
+        name: organizationId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: domain
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: trustedDomainId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTrustedDomain"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrustedDomain"
+          description: Trusted domain successfully updated
+        "404":
+          description: Trusted domain not found
+        "500":
+          description: Internal server error
+      summary: Update a trusted domain
+      tags:
+      - trusted-domain
       - domain
   /organizations/{organizationId}/environments/{environmentId}/domains/{domain}/users:
     get:
@@ -14900,6 +15109,7 @@ components:
           type: string
     JWKSet:
       type: object
+      description: Inline JWK set. Required when source is JWK_SET.
       properties:
         keys:
           type: array
@@ -15838,8 +16048,12 @@ components:
       properties:
         allowedAlgorithms:
           type: array
+          deprecated: true
+          description: Use spiffe.allowedAlgorithms instead.
           items:
             type: string
+            deprecated: true
+            description: Use spiffe.allowedAlgorithms instead.
         bundleSource:
           type: string
           deprecated: true
@@ -15849,16 +16063,10 @@ components:
           - STATIC_JWKS
         description:
           type: string
-        issuer:
-          type: string
-          maxLength: 512
-          minLength: 0
         jwksUrl:
           type: string
           deprecated: true
           description: Use keyMaterial.jwksUrl instead.
-        keyMaterial:
-          $ref: "#/components/schemas/TrustDomainKeyMaterial"
         name:
           type: string
           maxLength: 255
@@ -15866,22 +16074,35 @@ components:
         refreshIntervalSeconds:
           type: integer
           format: int32
-        scopeMappings:
-          type: object
-          additionalProperties:
-            type: string
-        spiffeTrustDomain:
+          deprecated: true
+          description: Use keyMaterial.refreshIntervalSeconds instead.
+    NewTrustedDomain:
+      type: object
+      properties:
+        description:
           type: string
-          description: SPIFFE trust domain matched against the "sub" of a JWT-SVID.
-            Defaults to the name when no matcher is supplied.
+        domainIdentifier:
+          type: string
+          description: "Issuer identifier of this authority's authorization server.\
+            \ Matched against the \"iss\" of an external JWT inbound, and carried\
+            \ as the \"aud\" of an ID-JAG outbound. Required when tokenExchange is\
+            \ present."
+          example: https://sso.acme.com
+          maxLength: 512
+          minLength: 0
+        keyMaterial:
+          $ref: "#/components/schemas/TrustDomainKeyMaterial"
+        name:
+          type: string
+          description: Label the trusted domain is known by. Unique within the security
+            domain.
+          example: acme-corp
           maxLength: 255
           minLength: 0
-        userBindingCriteria:
-          type: array
-          items:
-            $ref: "#/components/schemas/UserBindingCriterion"
-        userBindingEnabled:
-          type: boolean
+        spiffe:
+          $ref: "#/components/schemas/SpiffeTrustSettings"
+        tokenExchange:
+          $ref: "#/components/schemas/TokenExchangeTrustSettings"
     NewUser:
       type: object
       properties:
@@ -18050,6 +18271,25 @@ components:
           format: int32
           deprecated: true
           description: "Deprecated: moved to keyRetrievalSettings.maxResponseSizeKb."
+    SpiffeTrustSettings:
+      type: object
+      description: Accepts JWT-SVIDs from this authority as client assertions.
+      properties:
+        allowedAlgorithms:
+          type: array
+          description: Signature algorithms accepted for JWT-SVID validation. Defaults
+            to workloadIdentitySettings.defaultAllowedAlgorithms when absent.
+          items:
+            type: string
+            description: Signature algorithms accepted for JWT-SVID validation. Defaults
+              to workloadIdentitySettings.defaultAllowedAlgorithms when absent.
+        spiffeTrustDomain:
+          type: string
+          description: "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID,\
+            \ without the \"spiffe://\" scheme. Lowercased on write. Unique within\
+            \ the security domain."
+          example: acme.org
+      title: SPIFFE trust settings
     StatusEntity:
       type: object
       properties:
@@ -18282,13 +18522,45 @@ components:
           items:
             $ref: "#/components/schemas/TrustedIssuer"
       title: Token exchange settings
+    TokenExchangeTrustSettings:
+      type: object
+      description: "Accepts this authority's JWTs as subject or actor tokens during\
+        \ an RFC 8693 exchange, matched by domainIdentifier."
+      properties:
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
+            description: One-to-one mapping from external scope to domain scope. Unmapped
+              issuer scopes are dropped (fail-closed).
+          description: One-to-one mapping from external scope to domain scope. Unmapped
+            issuer scopes are dropped (fail-closed).
+        userBindingCriteria:
+          type: array
+          description: Criteria used to locate a domain user when user binding is
+            enabled. All criteria are combined with AND.
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
+          default: false
+          description: "Whether the external JWT subject is resolved to a single domain\
+            \ user using the user binding criteria. When false, a virtual user is\
+            \ built from the token claims only."
+      title: Token exchange trust settings
     TrustDomain:
       type: object
+      deprecated: true
+      description: "Deprecated: use the /trusted-domains endpoint instead."
       properties:
         allowedAlgorithms:
           type: array
+          deprecated: true
+          description: Use spiffe.allowedAlgorithms instead.
           items:
             type: string
+            deprecated: true
+            description: Use spiffe.allowedAlgorithms instead.
         bundleSource:
           type: string
           deprecated: true
@@ -18303,17 +18575,114 @@ components:
           description: Epoch timestamp in milliseconds.
         description:
           type: string
+        domainIdentifier:
+          type: string
         id:
           type: string
         issuer:
           type: string
-          description: Expected value of the "iss" claim in an external JWT. Required
-            to accept tokens during an RFC 8693 exchange.
-          example: https://sso.acme.com
+          deprecated: true
+          description: Use domainIdentifier instead.
         jwksUrl:
           type: string
           deprecated: true
           description: Use keyMaterial.jwksUrl instead.
+        keyMaterial:
+          $ref: "#/components/schemas/TrustDomainKeyMaterial"
+        name:
+          type: string
+        referenceId:
+          type: string
+        referenceType:
+          type: string
+          enum:
+          - PLATFORM
+          - DOMAIN
+          - APPLICATION
+          - ORGANIZATION
+          - ENVIRONMENT
+          - PROTECTED_RESOURCE
+        refreshIntervalSeconds:
+          type: integer
+          format: int32
+          deprecated: true
+          description: Use keyMaterial.refreshIntervalSeconds instead.
+        scopeMappings:
+          type: object
+          additionalProperties:
+            type: string
+            deprecated: true
+            description: Use tokenExchange.scopeMappings instead.
+          deprecated: true
+          description: Use tokenExchange.scopeMappings instead.
+        spiffe:
+          $ref: "#/components/schemas/SpiffeTrustSettings"
+        spiffeTrustDomain:
+          type: string
+          deprecated: true
+          description: Use spiffe.spiffeTrustDomain instead.
+        staticJwks:
+          $ref: "#/components/schemas/JWKSet"
+        tokenExchange:
+          $ref: "#/components/schemas/TokenExchangeTrustSettings"
+        updatedAt:
+          type: integer
+          format: int64
+          description: Epoch timestamp in milliseconds.
+        userBindingCriteria:
+          type: array
+          deprecated: true
+          description: Use tokenExchange.userBindingCriteria instead.
+          items:
+            $ref: "#/components/schemas/UserBindingCriterion"
+        userBindingEnabled:
+          type: boolean
+          deprecated: true
+          description: Use tokenExchange.userBindingEnabled instead.
+      title: Trust domain
+    TrustDomainKeyMaterial:
+      type: object
+      description: Where the trusted domain's signing keys come from. Exactly one
+        source applies.
+      properties:
+        certificate:
+          type: string
+          description: PEM-encoded X.509 certificate. Required when source is PEM.
+        jwkSet:
+          $ref: "#/components/schemas/JWKSet"
+        jwksUrl:
+          type: string
+          description: JWKS endpoint URL. Required when source is JWKS_URL.
+          example: https://issuer.example.com/.well-known/jwks.json
+        refreshIntervalSeconds:
+          type: integer
+          format: int32
+          description: "How often the JWKS endpoint is re-polled, clamped by keyRetrievalSettings.cacheTtlSeconds.\
+            \ Applies only when source is JWKS_URL."
+        source:
+          type: string
+          description: Which of the three key sources this trusted domain uses.
+          enum:
+          - JWKS_URL
+          - JWK_SET
+          - PEM
+      title: Trusted domain key material
+    TrustedDomain:
+      type: object
+      properties:
+        createdAt:
+          type: integer
+          format: int64
+          description: Epoch timestamp in milliseconds.
+        description:
+          type: string
+        domainIdentifier:
+          type: string
+          description: Issuer identifier of this authority's authorization server.
+            Matched against the "iss" of an external JWT during an RFC 8693 exchange.
+          example: https://sso.acme.com
+        id:
+          type: string
         keyMaterial:
           $ref: "#/components/schemas/TrustDomainKeyMaterial"
         name:
@@ -18332,64 +18701,14 @@ components:
           - ORGANIZATION
           - ENVIRONMENT
           - PROTECTED_RESOURCE
-        refreshIntervalSeconds:
-          type: integer
-          format: int32
-        scopeMappings:
-          type: object
-          additionalProperties:
-            type: string
-            description: One-to-one mapping from external scope to domain scope. Unmapped
-              issuer scopes are dropped (fail-closed). Applies to tokens matched by
-              "issuer".
-          description: One-to-one mapping from external scope to domain scope. Unmapped
-            issuer scopes are dropped (fail-closed). Applies to tokens matched by
-            "issuer".
-        spiffeTrustDomain:
-          type: string
-          description: "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID,\
-            \ without the \"spiffe://\" scheme. Required to accept SPIFFE client assertions."
-          example: acme.org
-        staticJwks:
-          $ref: "#/components/schemas/JWKSet"
+        spiffe:
+          $ref: "#/components/schemas/SpiffeTrustSettings"
+        tokenExchange:
+          $ref: "#/components/schemas/TokenExchangeTrustSettings"
         updatedAt:
           type: integer
           format: int64
           description: Epoch timestamp in milliseconds.
-        userBindingCriteria:
-          type: array
-          description: Criteria used to locate a domain user when user binding is
-            enabled. All criteria are combined with AND.
-          items:
-            $ref: "#/components/schemas/UserBindingCriterion"
-        userBindingEnabled:
-          type: boolean
-          default: false
-          description: "Whether the external JWT subject is resolved to a single domain\
-            \ user using the user binding criteria. When false, a virtual user is\
-            \ built from the token claims only."
-    TrustDomainKeyMaterial:
-      type: object
-      description: Where the trusted domain's signing keys come from. Exactly one
-        source applies.
-      properties:
-        certificate:
-          type: string
-          description: PEM-encoded X.509 certificate. Required when source is PEM.
-        jwkSet:
-          $ref: "#/components/schemas/JWKSet"
-        jwksUrl:
-          type: string
-          description: JWKS endpoint URL. Required when source is JWKS_URL.
-          example: https://issuer.example.com/.well-known/jwks.json
-        source:
-          type: string
-          description: Which of the three key sources this trusted domain uses.
-          enum:
-          - JWKS_URL
-          - JWK_SET
-          - PEM
-      title: Trusted domain key material
     TrustedIssuer:
       type: object
       deprecated: true
@@ -18855,8 +19174,12 @@ components:
       properties:
         allowedAlgorithms:
           type: array
+          deprecated: true
+          description: Use spiffe.allowedAlgorithms instead.
           items:
             type: string
+            deprecated: true
+            description: Use spiffe.allowedAlgorithms instead.
         bundleSource:
           type: string
           deprecated: true
@@ -18866,41 +19189,40 @@ components:
           - STATIC_JWKS
         description:
           type: string
-        issuer:
-          type: string
-          maxLength: 512
-          minLength: 0
         jwksUrl:
           type: string
           deprecated: true
           description: Use keyMaterial.jwksUrl instead.
+        refreshIntervalSeconds:
+          type: integer
+          format: int32
+          deprecated: true
+          description: Use keyMaterial.refreshIntervalSeconds instead.
+    UpdateTrustedDomain:
+      type: object
+      properties:
+        description:
+          type: string
+        domainIdentifier:
+          type: string
+          description: "Issuer identifier of this authority's authorization server.\
+            \ Matched against the \"iss\" of an external JWT inbound, and carried\
+            \ as the \"aud\" of an ID-JAG outbound. Required when tokenExchange is\
+            \ present."
+          example: https://sso.acme.com
+          maxLength: 512
+          minLength: 0
         keyMaterial:
           $ref: "#/components/schemas/TrustDomainKeyMaterial"
         name:
           type: string
-          description: New label for the trusted domain. Left unchanged when absent.
+          description: New label for the trusted domain. Kept unchanged when absent.
           maxLength: 255
           minLength: 0
-        refreshIntervalSeconds:
-          type: integer
-          format: int32
-        scopeMappings:
-          type: object
-          additionalProperties:
-            type: string
-        spiffeTrustDomain:
-          type: string
-          description: SPIFFE trust domain matched against the "sub" of a JWT-SVID.
-            Supplying either matcher replaces both; supplying neither leaves them
-            unchanged.
-          maxLength: 255
-          minLength: 0
-        userBindingCriteria:
-          type: array
-          items:
-            $ref: "#/components/schemas/UserBindingCriterion"
-        userBindingEnabled:
-          type: boolean
+        spiffe:
+          $ref: "#/components/schemas/SpiffeTrustSettings"
+        tokenExchange:
+          $ref: "#/components/schemas/TokenExchangeTrustSettings"
     UpdateUser:
       type: object
       properties:

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidator.java
@@ -34,7 +34,7 @@ import io.gravitee.am.model.application.AgentType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Maybe;
 import lombok.CustomLog;
 
@@ -153,7 +153,7 @@ public class SpiffeClientAssertionValidator implements ClientAssertionValidator 
         return client;
     }
 
-    private Maybe<Boolean> verifySpiffeSignature(SignedJWT signedJWT, TrustDomain td) {
+    private Maybe<Boolean> verifySpiffeSignature(SignedJWT signedJWT, TrustedDomain td) {
         String kid = signedJWT.getHeader().getKeyID();
         if (kid == null || kid.isBlank()) {
             return Maybe.error(new InvalidClientException("SVID missing kid"));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/TrustedIssuerResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/TrustedIssuerResolver.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange;
 
 import com.nimbusds.jwt.JWTClaimsSet;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -36,5 +36,5 @@ public interface TrustedIssuerResolver {
      *         exception when its key material is unusable or its JWKS URL is refused by the
      *         security domain's retrieval policy
      */
-    Single<JWTClaimsSet> resolve(String rawToken, TrustDomain trustedDomain);
+    Single<JWTClaimsSet> resolve(String rawToken, TrustedDomain trustedDomain);
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/ValidatedToken.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/ValidatedToken.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange;
 
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -104,7 +104,7 @@ public class ValidatedToken {
      * external issuer. Null when validated with the domain certificate. Used for scope mapping and
      * user binding (EL context and criteria).
      */
-    private final TrustDomain trustedDomain;
+    private final TrustedDomain trustedDomain;
 
     /**
      * Whether this token was validated via a trusted external issuer (not the domain certificate).

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtils.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtils.java
@@ -19,7 +19,7 @@ import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,7 +74,7 @@ final class TokenValidationUtils {
                                                long exp, long iat, long nbf,
                                                Set<String> scopes, List<String> audience,
                                                String tokenType, Domain domain,
-                                               TrustDomain trustedDomain) {
+                                               TrustedDomain trustedDomain) {
         return ValidatedToken.builder()
                 .subject(Objects.toString(claims.get(Claims.SUB), null))
                 .issuer(Objects.toString(claims.get(Claims.ISS), null))

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImpl.java
@@ -23,7 +23,7 @@ import io.gravitee.am.gateway.handler.oidc.service.jws.JWSService;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainKeyService;
 import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.oidc.JWKSet;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
@@ -58,7 +58,7 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
     }
 
     @Override
-    public Single<JWTClaimsSet> resolve(String rawToken, TrustDomain trustedDomain) {
+    public Single<JWTClaimsSet> resolve(String rawToken, TrustedDomain trustedDomain) {
         final SignedJWT signedJWT;
         try {
             signedJWT = SignedJWT.parse(rawToken);
@@ -68,23 +68,23 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
         JWSAlgorithm algorithm = signedJWT.getHeader().getAlgorithm();
         if (!SUPPORTED_ALGORITHMS.contains(algorithm)) {
             return Single.error(new SecurityException(
-                    "Unsupported signature algorithm " + algorithm + " for trusted issuer: " + trustedDomain.getIssuer()));
+                    "Unsupported signature algorithm " + algorithm + " for trusted issuer: " + trustedDomain.getDomainIdentifier()));
         }
         return verify(signedJWT, trustedDomain);
     }
 
-    private Single<JWTClaimsSet> verify(SignedJWT signedJWT, TrustDomain trustedDomain) {
+    private Single<JWTClaimsSet> verify(SignedJWT signedJWT, TrustedDomain trustedDomain) {
         String kid = signedJWT.getHeader().getKeyID();
         Maybe<Boolean> verified = kid == null || kid.isBlank()
                 ? trustDomainKeyService.getKeys(trustedDomain).map(jwks -> anyKeyVerifies(signedJWT, jwks))
                 : trustDomainKeyService.getKey(trustedDomain, kid).map(jwk -> isValidSignature(signedJWT, jwk));
         return verified
                 .switchIfEmpty(Single.error(() -> new SecurityException(
-                        "No signing key available for trusted issuer: " + trustedDomain.getIssuer())))
+                        "No signing key available for trusted issuer: " + trustedDomain.getDomainIdentifier())))
                 .flatMap(valid -> valid
                         ? claimsOf(signedJWT, trustedDomain)
                         : Single.error(new SecurityException(
-                                "JWT signature verification failed for trusted issuer: " + trustedDomain.getIssuer())));
+                                "JWT signature verification failed for trusted issuer: " + trustedDomain.getDomainIdentifier())));
     }
 
     private boolean anyKeyVerifies(SignedJWT signedJWT, JWKSet jwks) {
@@ -106,7 +106,7 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
         }
     }
 
-    private static Single<JWTClaimsSet> claimsOf(SignedJWT signedJWT, TrustDomain trustedDomain) {
+    private static Single<JWTClaimsSet> claimsOf(SignedJWT signedJWT, TrustedDomain trustedDomain) {
         try {
             return Single.just(signedJWT.getJWTClaimsSet());
         } catch (ParseException e) {
@@ -114,7 +114,7 @@ public class TrustedIssuerResolverImpl implements TrustedIssuerResolver {
         }
     }
 
-    private static SecurityException malformed(TrustDomain trustedDomain) {
-        return new SecurityException("Malformed JWT from trusted issuer: " + trustedDomain.getIssuer());
+    private static SecurityException malformed(TrustedDomain trustedDomain) {
+        return new SecurityException("Malformed JWT from trusted issuer: " + trustedDomain.getDomainIdentifier());
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidator.java
@@ -27,7 +27,7 @@ import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManage
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.oidc.Client;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
@@ -104,7 +104,7 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
                         return Single.error(new InvalidRequestException("JWT missing 'iss' claim"));
                     }
 
-                    TrustDomain trustedDomain = trustDomainManager.findByIssuer(issuer).orElse(null);
+                    TrustedDomain trustedDomain = trustDomainManager.findByIssuer(issuer).orElse(null);
                     if (trustedDomain == null) {
                         return Single.error(untrusted(issuer));
                     }
@@ -127,7 +127,7 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
     }
 
     private ValidatedToken buildValidatedToken(JWTClaimsSet claimsSet, Domain domain,
-                                               TrustDomain trustedDomain) {
+                                               TrustedDomain trustedDomain) {
         long exp = claimsSet.getExpirationTime() != null ? claimsSet.getExpirationTime().getTime() / 1000 : 0;
         long iat = claimsSet.getIssueTime() != null ? claimsSet.getIssueTime().getTime() / 1000 : 0;
         long nbf = claimsSet.getNotBeforeTime() != null ? claimsSet.getNotBeforeTime().getTime() / 1000 : 0;
@@ -144,7 +144,7 @@ public class TrustedIssuerTokenValidator implements TokenValidator {
                 supportedTokenType, domain, trustedDomain);
     }
 
-    private Set<String> applyScopeMapping(Set<String> originalScopes, TrustDomain trustedDomain) {
+    private Set<String> applyScopeMapping(Set<String> originalScopes, TrustedDomain trustedDomain) {
         Map<String, String> mappings = trustedDomain.getScopeMappings();
         if (mappings == null || mappings.isEmpty()) {
             return originalScopes;

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
@@ -22,7 +22,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.Validat
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.repository.management.api.search.FilterCriteria;
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
@@ -53,7 +53,7 @@ public class TrustedIssuerUserResolver implements TokenExchangeUserResolver {
 
     @Override
     public Maybe<User> resolve(ValidatedToken subjectToken) {
-        TrustDomain trustedDomain = subjectToken.getTrustedDomain();
+        TrustedDomain trustedDomain = subjectToken.getTrustedDomain();
         if (trustedDomain == null || !trustedDomain.isUserBindingEnabled()) {
             return Maybe.empty();
         }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidator.java
@@ -19,7 +19,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 
 import java.text.ParseException;
 import java.time.Duration;
@@ -52,7 +52,7 @@ public final class SpiffeJwtSvidValidator {
      * @return null on success, or a short, audit-friendly failure reason.
      */
     public String validate(SignedJWT jwt,
-                           TrustDomain trustDomain,
+                           TrustedDomain trustDomain,
                            SpiffeApplicationSettings spiffeApplicationSettings,
                            String tokenEndpoint) {
         if (jwt == null || trustDomain == null) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainKeyService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainKeyService.java
@@ -17,19 +17,19 @@ package io.gravitee.am.gateway.handler.oidc.service.trustdomain;
 
 import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.oidc.JWKSet;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Maybe;
 
 /**
- * Resolves the signing keys of a {@link TrustDomain}.
+ * Resolves the signing keys of a {@link TrustedDomain}.
  * Keys are read from the key material configured on the trust domain (JWKS URL or inline),
  * cached with the domain's refresh interval, and re-fetched on a {@code kid} miss.
  */
 public interface TrustDomainKeyService {
 
-    Maybe<JWKSet> getKeys(TrustDomain trustDomain);
+    Maybe<JWKSet> getKeys(TrustedDomain trustDomain);
 
-    Maybe<JWK> getKey(TrustDomain trustDomain, String kid);
+    Maybe<JWK> getKey(TrustedDomain trustDomain, String kid);
 
     /**
      * Drop the cached bundle for {@code trustDomainId}. Called on management events

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManager.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oidc.service.trustdomain;
 
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.common.service.Service;
 
 import java.util.Optional;
@@ -31,12 +31,12 @@ public interface TrustDomainManager extends Service {
     /**
      * The trusted domain that vouches for this SPIFFE trust domain, if any.
      */
-    Optional<TrustDomain> findBySpiffeTrustDomain(String spiffeTrustDomain);
+    Optional<TrustedDomain> findBySpiffeTrustDomain(String spiffeTrustDomain);
 
     /**
      * The trusted domain that vouches for this issuer, if any.
      */
-    Optional<TrustDomain> findByIssuer(String issuer);
+    Optional<TrustedDomain> findByIssuer(String issuer);
 
     /**
      * Whether the security domain vouches for any external issuer.

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainKeyServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainKeyServiceImpl.java
@@ -25,7 +25,7 @@ import io.gravitee.am.model.jose.JWK;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.KeyRetrievalSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
 import io.gravitee.am.service.utils.jwk.converter.JWKConverter;
@@ -78,7 +78,7 @@ public class TrustDomainKeyServiceImpl implements TrustDomainKeyService {
     }
 
     @Override
-    public Maybe<JWKSet> getKeys(TrustDomain trustDomain) {
+    public Maybe<JWKSet> getKeys(TrustedDomain trustDomain) {
         if (trustDomain == null) {
             return Maybe.empty();
         }
@@ -97,7 +97,7 @@ public class TrustDomainKeyServiceImpl implements TrustDomainKeyService {
     }
 
     @Override
-    public Maybe<JWK> getKey(TrustDomain trustDomain, String kid) {
+    public Maybe<JWK> getKey(TrustedDomain trustDomain, String kid) {
         if (trustDomain == null || kid == null || kid.isBlank()) {
             return Maybe.empty();
         }
@@ -122,13 +122,13 @@ public class TrustDomainKeyServiceImpl implements TrustDomainKeyService {
                         })));
     }
 
-    private static KeyMaterialSource sourceOf(TrustDomain trustDomain) {
+    private static KeyMaterialSource sourceOf(TrustedDomain trustDomain) {
         return Optional.ofNullable(trustDomain.getKeyMaterial())
                 .map(TrustDomainKeyMaterial::getSource)
                 .orElse(null);
     }
 
-    private Maybe<JWKSet> inlineKeys(TrustDomain trustDomain, KeyMaterialSource source) {
+    private Maybe<JWKSet> inlineKeys(TrustedDomain trustDomain, KeyMaterialSource source) {
         TrustDomainKeyMaterial keyMaterial = trustDomain.getKeyMaterial();
         return switch (source) {
             case JWK_SET -> keyMaterial.getJwkSet() != null
@@ -139,7 +139,7 @@ public class TrustDomainKeyServiceImpl implements TrustDomainKeyService {
         };
     }
 
-    private Maybe<JWKSet> parseCertificate(TrustDomain trustDomain, String certificate) {
+    private Maybe<JWKSet> parseCertificate(TrustedDomain trustDomain, String certificate) {
         X509Certificate cert = X509CertUtils.parse(certificate);
         if (cert == null) {
             return Maybe.error(new IllegalStateException(
@@ -169,19 +169,19 @@ public class TrustDomainKeyServiceImpl implements TrustDomainKeyService {
         }
     }
 
-    private boolean isStale(CachedBundle entry, TrustDomain trustDomain) {
+    private boolean isStale(CachedBundle entry, TrustedDomain trustDomain) {
         long softTtl = softTtlSeconds(trustDomain);
         return softTtl <= 0 || entry.fetchedAt.plusSeconds(softTtl).isBefore(Instant.now());
     }
 
-    private long softTtlSeconds(TrustDomain trustDomain) {
+    private long softTtlSeconds(TrustedDomain trustDomain) {
         long perDomain = trustDomain.getRefreshIntervalSeconds() > 0
                 ? trustDomain.getRefreshIntervalSeconds()
                 : settings.getCacheTtlSeconds();
         return Math.min(perDomain, settings.getCacheTtlSeconds());
     }
 
-    private Maybe<JWKSet> fetch(TrustDomain trustDomain, CachedBundle existing) {
+    private Maybe<JWKSet> fetch(TrustedDomain trustDomain, CachedBundle existing) {
         String jwksUrl = trustDomain.getKeyMaterial().getJwksUrl();
         if (jwksUrl == null || jwksUrl.isBlank()) {
             return Maybe.empty();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainManagerImpl.java
@@ -23,9 +23,9 @@ import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManage
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.monitoring.DomainReadinessService;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.service.AbstractService;
@@ -50,7 +50,7 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
     private EventManager eventManager;
 
     @Autowired
-    private TrustDomainRepository trustDomainRepository;
+    private TrustedDomainRepository trustDomainRepository;
 
     @Autowired
     private TrustDomainKeyService trustDomainKeyService;
@@ -58,9 +58,9 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
     @Autowired
     private DomainReadinessService domainReadinessService;
 
-    private final ConcurrentMap<String, TrustDomain> byId = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, TrustDomain> bySpiffeTrustDomain = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, TrustDomain> byIssuer = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TrustedDomain> byId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TrustedDomain> bySpiffeTrustDomain = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, TrustedDomain> byIssuer = new ConcurrentHashMap<>();
 
     @Override
     public void afterPropertiesSet() {
@@ -111,12 +111,12 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
     }
 
     @Override
-    public Optional<TrustDomain> findBySpiffeTrustDomain(String spiffeTrustDomain) {
+    public Optional<TrustedDomain> findBySpiffeTrustDomain(String spiffeTrustDomain) {
         return spiffeTrustDomain == null ? Optional.empty() : Optional.ofNullable(bySpiffeTrustDomain.get(spiffeTrustDomain));
     }
 
     @Override
-    public Optional<TrustDomain> findByIssuer(String issuer) {
+    public Optional<TrustedDomain> findByIssuer(String issuer) {
         return issuer == null ? Optional.empty() : Optional.ofNullable(byIssuer.get(issuer));
     }
 
@@ -148,7 +148,7 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
     }
 
     private void unload(String trustDomainId) {
-        TrustDomain removed = byId.remove(trustDomainId);
+        TrustedDomain removed = byId.remove(trustDomainId);
         if (removed != null) {
             unindex(removed);
             log.info("Trusted domain {} has been removed for domain {}", removed.getName(), domain.getName());
@@ -157,21 +157,21 @@ public class TrustDomainManagerImpl extends AbstractService implements TrustDoma
         domainReadinessService.pluginRemoved(domain.getId(), trustDomainId);
     }
 
-    private void index(TrustDomain trustDomain) {
-        TrustDomain previous = byId.put(trustDomain.getId(), trustDomain);
+    private void index(TrustedDomain trustDomain) {
+        TrustedDomain previous = byId.put(trustDomain.getId(), trustDomain);
         if (previous != null) {
             unindex(previous);
         }
         Optional.ofNullable(trustDomain.getSpiffeTrustDomain())
                 .ifPresent(spiffeTrustDomain -> bySpiffeTrustDomain.put(spiffeTrustDomain, trustDomain));
-        Optional.ofNullable(trustDomain.getIssuer())
+        Optional.ofNullable(trustDomain.getDomainIdentifier())
                 .ifPresent(issuer -> byIssuer.put(issuer, trustDomain));
     }
 
-    private void unindex(TrustDomain trustDomain) {
+    private void unindex(TrustedDomain trustDomain) {
         Optional.ofNullable(trustDomain.getSpiffeTrustDomain())
                 .ifPresent(spiffeTrustDomain -> bySpiffeTrustDomain.remove(spiffeTrustDomain, trustDomain));
-        Optional.ofNullable(trustDomain.getIssuer())
+        Optional.ofNullable(trustDomain.getDomainIdentifier())
                 .ifPresent(issuer -> byIssuer.remove(issuer, trustDomain));
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/assertion/impl/SpiffeClientAssertionValidatorTest.java
@@ -39,7 +39,7 @@ import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
@@ -284,7 +284,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings();
-        TrustDomain td = TrustDomain.builder()
+        TrustedDomain td = TrustedDomain.builder()
                 .name(TRUST_DOMAIN_NAME)
                 .build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
@@ -307,7 +307,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings();
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
         when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
                 .thenReturn(Optional.of(td));
@@ -326,7 +326,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings();
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
         when(trustDomainManager.findBySpiffeTrustDomain(TRUST_DOMAIN_NAME))
                 .thenReturn(Optional.of(td));
@@ -342,7 +342,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings();
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
@@ -362,7 +362,7 @@ class SpiffeClientAssertionValidatorTest {
         // sub is the SPIFFE URI but the form-level client_id should win as lookup id.
         Client client = clientWithSpiffeSettings();
         client.setClientId("hint-client-id");
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
 
@@ -383,7 +383,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings();
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
@@ -417,7 +417,7 @@ class SpiffeClientAssertionValidatorTest {
         appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
         blueprint.setWorkloadIdentitySettings(appSettings);
 
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
@@ -454,7 +454,7 @@ class SpiffeClientAssertionValidatorTest {
         appSettings.setSubjectMatchMode(SpiffeApplicationSettings.SubjectMatchMode.PREFIX);
         blueprint.setWorkloadIdentitySettings(appSettings);
 
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(blueprintClientId)).thenReturn(Maybe.just(blueprint));
@@ -473,7 +473,7 @@ class SpiffeClientAssertionValidatorTest {
         stubDiscovery();
         stubDomainOidc();
         Client client = clientWithSpiffeSettings(); // SERVICE-style, no appType=AGENT
-        TrustDomain td = TrustDomain.builder().name(TRUST_DOMAIN_NAME).build();
+        TrustedDomain td = TrustedDomain.builder().name(TRUST_DOMAIN_NAME).build();
         RSAKey jwk = new RSAKey();
         jwk.setKid(KID);
         when(clientLookupService.findByClientId(SUBJECT)).thenReturn(Maybe.just(client));
@@ -498,7 +498,7 @@ class SpiffeClientAssertionValidatorTest {
                 clientLookupService, new JWSServiceImpl(), openIDDiscoveryService, domain,
                 new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainManager);
 
-        TrustDomain td = TrustDomain.builder()
+        TrustedDomain td = TrustedDomain.builder()
                 .id("td-pem")
                 .name(TRUST_DOMAIN_NAME)
                 .keyMaterial(TrustDomainKeyMaterial.builder()
@@ -528,7 +528,7 @@ class SpiffeClientAssertionValidatorTest {
                 clientLookupService, new JWSServiceImpl(), openIDDiscoveryService, domain,
                 new TrustDomainKeyServiceImpl(mock(JWKSetFetcher.class), realDomain), trustDomainManager);
 
-        TrustDomain td = TrustDomain.builder()
+        TrustedDomain td = TrustedDomain.builder()
                 .id("td-pem")
                 .name(TRUST_DOMAIN_NAME)
                 .keyMaterial(TrustDomainKeyMaterial.builder()

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -32,7 +32,8 @@ import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.Validat
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.TokenExchangeSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.application.ApplicationScopeSettings;
@@ -2515,13 +2516,16 @@ public class TokenExchangeServiceImplTest {
 
     private TokenValidator trustedIssuerValidator(String issuer, Map<String, Object> additionalClaims,
                                                   List<UserBindingCriterion> bindingCriteria) {
-        TrustDomain.TrustDomainBuilder trustedDomainBuilder = TrustDomain.builder()
-                .name(issuer)
-                .issuer(issuer);
+        TokenExchangeTrustSettings tokenExchange = new TokenExchangeTrustSettings();
         if (bindingCriteria != null) {
-            trustedDomainBuilder.userBindingEnabled(true).userBindingCriteria(bindingCriteria);
+            tokenExchange.setUserBindingEnabled(true);
+            tokenExchange.setUserBindingCriteria(bindingCriteria);
         }
-        TrustDomain trustedDomain = trustedDomainBuilder.build();
+        TrustedDomain trustedDomain = TrustedDomain.builder()
+                .name(issuer)
+                .domainIdentifier(issuer)
+                .tokenExchange(tokenExchange)
+                .build();
         return new TokenValidator() {
             @Override
             public Single<ValidatedToken> validate(String token, TokenExchangeSettings settings, Domain domain, Client client) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtilsTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenValidationUtilsTest.java
@@ -19,7 +19,8 @@ import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.model.Domain;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -193,8 +194,9 @@ public class TokenValidationUtilsTest {
     public void buildValidatedToken_withTrustedIssuer() {
         Domain domain = mock(Domain.class);
 
-        TrustDomain trustedDomain = TrustDomain.builder()
-                .issuer("https://external.example.com")
+        TrustedDomain trustedDomain = TrustedDomain.builder()
+                .domainIdentifier("https://external.example.com")
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
 
         Map<String, Object> claims = new HashMap<>();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerResolverImplTest.java
@@ -31,7 +31,8 @@ import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.KeyRetrievalSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.jwk.JWKSetFetcher;
 import io.gravitee.am.service.jwk.JWKSetFetcher.JWKSetFetchResponse;
@@ -233,7 +234,7 @@ class TrustedIssuerResolverImplTest {
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES))
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustDomain issuer = jwksIssuer(JWKS_URL);
+        TrustedDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-1"), issuer).test().assertNoErrors();
@@ -248,7 +249,7 @@ class TrustedIssuerResolverImplTest {
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)))
                 .thenReturn(Maybe.error(new RuntimeException("upstream down")));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustDomain issuer = jwksIssuer(JWKS_URL);
+        TrustedDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-1"), issuer).test()
@@ -264,7 +265,7 @@ class TrustedIssuerResolverImplTest {
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-1"), null)))
                 .thenReturn(Maybe.just(new JWKSetFetchResponse(jwks("kid-2"), null)));
         TrustedIssuerResolverImpl resolver = resolver();
-        TrustDomain issuer = jwksIssuer(JWKS_URL);
+        TrustedDomain issuer = jwksIssuer(JWKS_URL);
 
         resolver.resolve(signJwt(trustedPrivateKey, "user-1", "kid-1"), issuer).test().assertNoErrors();
         resolver.resolve(signJwt(trustedPrivateKey, "user-2", "kid-2"), issuer).test()
@@ -313,26 +314,27 @@ class TrustedIssuerResolverImplTest {
         return new TrustedIssuerResolverImpl(new TrustDomainKeyServiceImpl(jwkSetFetcher, domain), new JWSServiceImpl());
     }
 
-    private static TrustDomain pemIssuer(String certificate) {
+    private static TrustedDomain pemIssuer(String certificate) {
         return trustedDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate(certificate)
                 .build());
     }
 
-    private static TrustDomain jwksIssuer(String jwksUri) {
+    private static TrustedDomain jwksIssuer(String jwksUri) {
         return trustedDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl(jwksUri)
                 .build());
     }
 
-    private static TrustDomain trustedDomain(TrustDomainKeyMaterial keyMaterial) {
-        return TrustDomain.builder()
+    private static TrustedDomain trustedDomain(TrustDomainKeyMaterial keyMaterial) {
+        return TrustedDomain.builder()
                 .id("trust-domain-1")
                 .name("trusted.example.com")
                 .keyMaterial(keyMaterial)
-                .issuer(ISSUER)
+                .domainIdentifier(ISSUER)
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerTokenValidatorTest.java
@@ -29,7 +29,8 @@ import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.gateway.handler.oidc.service.trustdomain.TrustDomainManager;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.model.oidc.Client;
 import io.reactivex.rxjava3.core.Maybe;
@@ -235,7 +236,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_success() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -276,7 +277,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_signatureVerificationFails() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -302,8 +303,8 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_scopeMapping() throws Exception {
-        TrustDomain ti = createTrustedDomain();
-        ti.setScopeMappings(Map.of("ext:read", "domain:read", "ext:write", "domain:write"));
+        TrustedDomain ti = createTrustedDomain();
+        ti.getTokenExchange().setScopeMappings(Map.of("ext:read", "domain:read", "ext:write", "domain:write"));
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -340,7 +341,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_noScopeMapping_passThrough() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -375,7 +376,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_allFieldsCopied() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -427,7 +428,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_expiredToken() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -459,7 +460,7 @@ public class TrustedIssuerTokenValidatorTest {
 
     @Test
     public void testTrustedIssuer_nullTimestamps() throws Exception {
-        TrustDomain ti = createTrustedDomain();
+        TrustedDomain ti = createTrustedDomain();
         when(trustDomainManager.hasTokenExchangeTrust()).thenReturn(true);
         when(trustDomainManager.findByIssuer(EXTERNAL_ISSUER)).thenReturn(Optional.of(ti));
 
@@ -492,15 +493,16 @@ public class TrustedIssuerTokenValidatorTest {
 
     // --- Helpers ---
 
-    private TrustDomain createTrustedDomain() {
-        return TrustDomain.builder()
+    private TrustedDomain createTrustedDomain() {
+        return TrustedDomain.builder()
                 .id("trust-domain-1")
                 .name("external-idp.example.com")
                 .keyMaterial(TrustDomainKeyMaterial.builder()
                         .source(KeyMaterialSource.PEM)
                         .certificate("some-pem")
                         .build())
-                .issuer(EXTERNAL_ISSUER)
+                .domainIdentifier(EXTERNAL_ISSUER)
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
@@ -18,7 +18,8 @@ package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.impl;
 import io.gravitee.am.common.exception.oauth2.InvalidRequestException;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.ValidatedToken;
 import io.gravitee.am.gateway.handler.common.user.UserGatewayService;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.reactivex.rxjava3.core.Single;
@@ -52,7 +53,17 @@ class TrustedIssuerUserResolverTest {
         resolver = new TrustedIssuerUserResolver(userGatewayService);
     }
 
-    private ValidatedToken subjectTokenWith(TrustDomain trustedDomain) {
+    private static TrustedDomain trustedDomain(boolean userBindingEnabled, List<UserBindingCriterion> criteria) {
+        return TrustedDomain.builder()
+                .domainIdentifier(ISSUER)
+                .tokenExchange(TokenExchangeTrustSettings.builder()
+                        .userBindingEnabled(userBindingEnabled)
+                        .userBindingCriteria(criteria)
+                        .build())
+                .build();
+    }
+
+    private ValidatedToken subjectTokenWith(TrustedDomain trustedDomain) {
         return ValidatedToken.builder()
                 .subject("sub-1")
                 .claims(Map.of("email", "user@example.com", "preferred_username", "joe"))
@@ -62,7 +73,7 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_returnsEmptyWhenUserBindingDisabled() {
-        TrustDomain trusted = TrustDomain.builder().issuer(ISSUER).userBindingEnabled(false).build();
+        TrustedDomain trusted = trustedDomain(false, null);
 
         User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
 
@@ -78,9 +89,7 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_returnsEmptyWhenNoCriteria() {
-        TrustDomain trusted = TrustDomain.builder()
-                .issuer(ISSUER)
-                .userBindingEnabled(true).userBindingCriteria(Collections.emptyList()).build();
+        TrustedDomain trusted = trustedDomain(true, Collections.emptyList());
 
         User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
 
@@ -89,12 +98,10 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenZeroUsersMatch() {
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of()));
 
@@ -105,12 +112,10 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_returnsUserWhenOneMatch() {
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         User domainUser = new User();
         domainUser.setId("domain-user-id");
@@ -124,12 +129,10 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenMultipleUsersMatch() {
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         User u1 = new User();
         User u2 = new User();
@@ -143,12 +146,10 @@ class TrustedIssuerUserResolverTest {
     @Test
     void resolve_throwsWhenNullClaims() {
         // T3: ValidatedToken with null claims should produce InvalidRequestException
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         ValidatedToken noClaims = ValidatedToken.builder()
                 .subject("sub-1")
@@ -164,12 +165,10 @@ class TrustedIssuerUserResolverTest {
     @Test
     void resolve_throwsWhenExpressionEvaluatesToWhitespace() {
         // T4: EL expression evaluating to whitespace should produce InvalidRequestException
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['email']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         ValidatedToken whitespaceToken = ValidatedToken.builder()
                 .subject("sub-1")
@@ -184,12 +183,10 @@ class TrustedIssuerUserResolverTest {
 
     @Test
     void resolve_throwsWhenExpressionEvaluatesToNull() {
-        TrustDomain.TrustDomainBuilder trustedBuilder =
-                TrustDomain.builder().issuer(ISSUER).userBindingEnabled(true);
-        UserBindingCriterion c = new UserBindingCriterion();
+                UserBindingCriterion c = new UserBindingCriterion();
         c.setAttribute("emails.value");
         c.setExpression("{#token['nonexistent']}");
-        TrustDomain trusted = trustedBuilder.userBindingCriteria(List.of(c)).build();
+        TrustedDomain trusted = trustedDomain(true, List.of(c));
 
         assertThatThrownBy(() -> resolver.resolve(subjectTokenWith(trusted)).blockingGet())
                 .isInstanceOf(InvalidRequestException.class)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/spiffe/SpiffeJwtSvidValidatorTest.java
@@ -24,7 +24,8 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ class SpiffeJwtSvidValidatorTest {
     private static RSAPrivateKey rsaPrivateKey;
 
     private SpiffeDomainSettings domainSettings;
-    private TrustDomain trustDomain;
+    private TrustedDomain trustDomain;
     private SpiffeApplicationSettings appSettings;
     private SpiffeJwtSvidValidator validator;
 
@@ -58,7 +59,7 @@ class SpiffeJwtSvidValidatorTest {
         rsaPrivateKey = (RSAPrivateKey) pair.getPrivate();
 
         domainSettings = new SpiffeDomainSettings();
-        trustDomain = TrustDomain.builder().name(TRUST_DOMAIN).build();
+        trustDomain = TrustedDomain.builder().name(TRUST_DOMAIN).build();
         appSettings = new SpiffeApplicationSettings();
         appSettings.setTrustDomain(TRUST_DOMAIN);
         appSettings.setSubject(SUBJECT);
@@ -99,7 +100,7 @@ class SpiffeJwtSvidValidatorTest {
 
     @Test
     void validate_rejectsAlgorithm_notInAllowList() throws Exception {
-        trustDomain.setAllowedAlgorithms(List.of("ES256"));
+        spiffeOf(trustDomain).setAllowedAlgorithms(List.of("ES256"));
         SignedJWT jwt = signedJwt(defaultClaims().build(), JWSAlgorithm.RS256);
 
         assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT))
@@ -108,7 +109,7 @@ class SpiffeJwtSvidValidatorTest {
 
     @Test
     void validate_usesDomainDefaults_whenTrustDomainAllowListEmpty() throws Exception {
-        trustDomain.setAllowedAlgorithms(List.of());
+        spiffeOf(trustDomain).setAllowedAlgorithms(List.of());
         SignedJWT jwt = signedJwt(defaultClaims().build(), JWSAlgorithm.RS256);
 
         assertThat(validator.validate(jwt, trustDomain, appSettings, TOKEN_ENDPOINT)).isNull();
@@ -331,4 +332,12 @@ class SpiffeJwtSvidValidatorTest {
         jwt.sign(new RSASSASigner(rsaPrivateKey));
         return jwt;
     }
+
+    private static SpiffeTrustSettings spiffeOf(TrustedDomain trustDomain) {
+        if (trustDomain.getSpiffe() == null) {
+            trustDomain.setSpiffe(new SpiffeTrustSettings());
+        }
+        return trustDomain.getSpiffe();
+    }
+
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManagerImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/TrustDomainManagerImplTest.java
@@ -23,9 +23,11 @@ import io.gravitee.am.gateway.handler.oidc.service.trustdomain.impl.TrustDomainM
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Payload;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.monitoring.DomainReadinessService;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.common.event.Event;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -57,7 +59,7 @@ class TrustDomainManagerImplTest {
     @Mock
     private Domain domain;
     @Mock
-    private TrustDomainRepository trustDomainRepository;
+    private TrustedDomainRepository trustDomainRepository;
     @Mock
     private TrustDomainKeyService trustDomainKeyService;
     @Mock
@@ -87,19 +89,21 @@ class TrustDomainManagerImplTest {
         when(payload.getReferenceId()).thenReturn(referenceId);
     }
 
-    private static TrustDomain spiffe(String id, String name) {
-        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
+    private static TrustedDomain spiffe(String id, String name) {
+        return TrustedDomain.builder().id(id).name(name)
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain(name).build()).build();
     }
 
-    private static TrustDomain tokenExchange(String id, String name, String issuer) {
-        return TrustDomain.builder()
+    private static TrustedDomain tokenExchange(String id, String name, String issuer) {
+        return TrustedDomain.builder()
                 .id(id)
                 .name(name)
-                .issuer(issuer)
+                .domainIdentifier(issuer)
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 
-    private void preload(TrustDomain... trustDomains) {
+    private void preload(TrustedDomain... trustDomains) {
         when(trustDomainRepository.findByReference(ReferenceType.DOMAIN, DOMAIN_ID)).thenReturn(Flowable.fromArray(trustDomains));
         manager.afterPropertiesSet();
         await().atMost(5, TimeUnit.SECONDS)
@@ -123,11 +127,12 @@ class TrustDomainManagerImplTest {
 
     @Test
     void shouldIndexATrustedDomainThatServesBothUsagesUnderBothMatchers() {
-        TrustDomain both = TrustDomain.builder()
+        TrustedDomain both = TrustedDomain.builder()
                 .id("td-3")
                 .name("acme-corp")
-                .spiffeTrustDomain("acme.org")
-                .issuer("https://sso.acme.com")
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("acme.org").build())
+                .domainIdentifier("https://sso.acme.com")
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
         preload(both);
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainKeyServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/trustdomain/impl/TrustDomainKeyServiceImplTest.java
@@ -25,7 +25,7 @@ import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.model.KeyRetrievalSettings;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_returnsEmpty_whenKeyMaterialMissing() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.setKeyMaterial(null);
 
         service.getKeys(td).test().assertNoErrors().assertComplete().assertNoValues();
@@ -110,7 +110,7 @@ class TrustDomainKeyServiceImplTest {
     void shouldReturnInlineJwkSet_withoutFetching() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
         JWKSet inline = jwks("kid-1");
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWK_SET)
                 .jwkSet(inline)
@@ -125,7 +125,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void shouldReturnPemKeyRegardlessOfKid() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate(PEM_CERTIFICATE)
@@ -140,7 +140,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void shouldErrorOnUnparseablePemCertificate() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate("not-a-certificate")
@@ -152,7 +152,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_returnsEmpty_whenJwksUrlBlank() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.getKeyMaterial().setJwksUrl("");
 
         service.getKeys(td).test().assertNoErrors().assertComplete().assertNoValues();
@@ -162,7 +162,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_rejectsFetch_whenUrlResolvesToPrivateAddress() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.getKeyMaterial().setJwksUrl("https://10.0.0.5/keys");
 
         service.getKeys(td).test()
@@ -175,7 +175,7 @@ class TrustDomainKeyServiceImplTest {
     void getKeys_allowsPrivateAddress_whenDomainPolicyPermits() {
         settings.setAllowPrivateIpAddress(true);
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.getKeyMaterial().setJwksUrl("https://10.0.0.5/keys");
         JWKSet bundle = jwks("kid-1");
         when(jwkSetFetcher.getKeys("https://10.0.0.5/keys", DEFAULT_MAX_RESPONSE_SIZE_BYTES)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
@@ -194,7 +194,7 @@ class TrustDomainKeyServiceImplTest {
         Domain legacyDomain = new Domain();
         legacyDomain.setOidc(legacyOidc);
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, legacyDomain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.getKeyMaterial().setJwksUrl("https://10.0.0.5/keys");
         JWKSet bundle = jwks("kid-1");
         when(jwkSetFetcher.getKeys("https://10.0.0.5/keys", 8 * 1024L)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
@@ -205,7 +205,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_rejectsHttp_unlessAllowedByPolicy() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         td.getKeyMaterial().setJwksUrl("http://bundle.example.org/keys");
 
         service.getKeys(td).test()
@@ -215,7 +215,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_cachesBundle_betweenCalls() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet bundle = jwks("kid-1");
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
 
@@ -230,7 +230,7 @@ class TrustDomainKeyServiceImplTest {
         // Force soft-TTL = 0 so the second call always refreshes.
         settings.setCacheTtlSeconds(0);
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet bundle = jwks("kid-1");
 
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES))
@@ -248,7 +248,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKeys_propagatesError_whenNoStaleAvailable() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES)).thenReturn(Maybe.error(new RuntimeException("upstream down")));
 
         service.getKeys(td).test().assertError(RuntimeException.class);
@@ -257,7 +257,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKey_returnsEmpty_forNullOrBlankKid() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
 
         service.getKey(td, null).test().assertNoErrors().assertComplete().assertNoValues();
         service.getKey(td, "  ").test().assertNoErrors().assertComplete().assertNoValues();
@@ -267,7 +267,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKey_returnsMatchingKey() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet bundle = jwks("kid-1", "kid-2");
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
 
@@ -279,7 +279,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void getKey_refreshesOnMiss_andReturnsNewKid() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet first = jwks("kid-1");
         JWKSet second = jwks("kid-1", "kid-2");
 
@@ -302,7 +302,7 @@ class TrustDomainKeyServiceImplTest {
     void shouldBoundResponseSizeWithConfiguredMaximum() {
         settings.setMaxResponseSizeKb(8);
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet bundle = jwks("kid-1");
         when(jwkSetFetcher.getKeys(JWKS_URL, 8 * 1024L)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
 
@@ -314,7 +314,7 @@ class TrustDomainKeyServiceImplTest {
     @Test
     void evict_clearsCachedBundle() {
         TrustDomainKeyServiceImpl service = new TrustDomainKeyServiceImpl(jwkSetFetcher, domain);
-        TrustDomain td = trustDomain();
+        TrustedDomain td = trustDomain();
         JWKSet bundle = jwks("kid-1");
         when(jwkSetFetcher.getKeys(JWKS_URL, DEFAULT_MAX_RESPONSE_SIZE_BYTES)).thenReturn(Maybe.just(new JWKSetFetchResponse(bundle, null)));
 
@@ -334,15 +334,15 @@ class TrustDomainKeyServiceImplTest {
 
     // --- helpers -----------------------------------------------------------
 
-    private static TrustDomain trustDomain() {
-        TrustDomain td = TrustDomain.builder()
+    private static TrustedDomain trustDomain() {
+        TrustedDomain td = TrustedDomain.builder()
                 .id("td-1")
                 .name("example.org")
                 .keyMaterial(TrustDomainKeyMaterial.builder()
                         .source(KeyMaterialSource.JWKS_URL)
                         .jwksUrl(JWKS_URL)
+                        .refreshIntervalSeconds(300)
                         .build())
-                .refreshIntervalSeconds(300)
                 .build();
         return td;
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -21,8 +21,9 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.KeyResolutionMethod;
 import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.TrustedIssuer;
-import io.gravitee.am.model.oidc.TrustDomain;
-import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.ReferenceType;
 import io.reactivex.rxjava3.core.Completable;
@@ -145,8 +146,8 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
         when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
         when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
-        when(trustDomainService.create(eq(existing), any(NewTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.create(eq(existing), any(NewTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
 
         AutomationDomain in = definition("customer-auth");
         TokenExchangeSettings tokenExchange = new TokenExchangeSettings();
@@ -159,9 +160,10 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(200, put(domainsTarget(), in).getStatus());
 
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
         verify(trustDomainService).create(eq(existing), captor.capture(), any());
-        assertEquals("https://issuer.example.com", captor.getValue().getIssuer());
+        assertEquals("https://issuer.example.com", captor.getValue().getDomainIdentifier());
+        assertEquals("https://issuer.example.com/keys", captor.getValue().getKeyMaterial().getJwksUrl());
     }
 
     @Test
@@ -172,10 +174,11 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
         when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
         when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
         when(trustDomainService.findByReference(ReferenceType.DOMAIN, domainId)).thenReturn(Flowable.just(
-                TrustDomain.builder()
+                TrustedDomain.builder()
                         .id("td-1")
                         .name("https-issuer.example.com")
-                        .issuer("https://issuer.example.com")
+                        .domainIdentifier("https://issuer.example.com")
+                        .tokenExchange(new TokenExchangeTrustSettings())
                         .build()));
         when(trustDomainService.delete(eq(existing), anyString(), any())).thenReturn(Completable.complete());
 

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/mapper/ObjectMapperResolver.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/mapper/ObjectMapperResolver.java
@@ -57,7 +57,15 @@ public class ObjectMapperResolver implements ContextResolver<ObjectMapper> {
     private final ObjectMapper mapper;
 
     public ObjectMapperResolver() {
-        mapper = new ObjectMapper();
+        this(newManagementObjectMapper());
+    }
+
+    public ObjectMapperResolver(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public static ObjectMapper newManagementObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
 
         SimpleModule module = new SimpleModule();
         module.setDeserializerModifier(new BeanDeserializerModifier() {
@@ -112,6 +120,7 @@ public class ObjectMapperResolver implements ContextResolver<ObjectMapper> {
         mapper.registerModule(module);
         mapper.registerModule(new Jdk8Module());
         mapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
+        return mapper;
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/DomainResource.java
@@ -353,6 +353,12 @@ public class DomainResource extends AbstractDomainResource {
         return resourceContext.getResource(ThemesResource.class);
     }
 
+    @Path("trusted-domains")
+    public TrustedDomainsResource getTrustedDomainsResource() {
+        return resourceContext.getResource(TrustedDomainsResource.class);
+    }
+
+    @Deprecated
     @Path("trust-domains")
     public TrustDomainsResource getTrustDomainsResource() {
         return resourceContext.getResource(TrustDomainsResource.class);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainResource.java
@@ -18,12 +18,12 @@ package io.gravitee.am.management.handlers.management.api.resources.organization
 import io.gravitee.am.management.handlers.management.api.resources.AbstractResource;
 import io.gravitee.am.management.service.DomainService;
 import io.gravitee.am.model.Acl;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.TrustDomainNotFoundException;
-import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Maybe;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,9 +46,8 @@ import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@Deprecated
-@Tag(name = "trust-domain")
-public class TrustDomainResource extends AbstractResource {
+@Tag(name = "trusted-domain")
+public class TrustedDomainResource extends AbstractResource {
 
     @Autowired
     private DomainService domainService;
@@ -59,30 +58,28 @@ public class TrustDomainResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "getTrustDomain",
-            deprecated = true,
-            summary = "Get a trust domain",
+            operationId = "getTrustedDomain",
+            summary = "Get a trusted domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[READ] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[READ] permission on the specified environment " +
                     "or DOMAIN_TRUST_DOMAIN[READ] permission on the specified organization")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Trust domain",
+            @ApiResponse(responseCode = "200", description = "Trusted domain",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = TrustDomain.class))),
-            @ApiResponse(responseCode = "404", description = "Trust domain not found")})
+                            schema = @Schema(implementation = TrustedDomain.class))),
+            @ApiResponse(responseCode = "404", description = "Trusted domain not found")})
     public void read(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
             @PathParam("domain") String domainId,
-            @PathParam("trustDomainId") String trustDomainId,
+            @PathParam("trustedDomainId") String trustedDomainId,
             @Suspended final AsyncResponse response) {
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_TRUST_DOMAIN, Acl.READ)
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId))))
-                .flatMap(domain -> trustDomainService.findById(trustDomainId)
+                .flatMap(domain -> trustDomainService.findById(trustedDomainId)
                         .filter(td -> domainId.equals(td.getReferenceId())))
-                .switchIfEmpty(Maybe.error(new TrustDomainNotFoundException(trustDomainId)))
-                .map(TrustDomain::from)
+                .switchIfEmpty(Maybe.error(new TrustDomainNotFoundException(trustedDomainId)))
                 .subscribe(response::resume, response::resume);
     }
 
@@ -90,60 +87,56 @@ public class TrustDomainResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "updateTrustDomain",
-            deprecated = true,
-            summary = "Update a trust domain",
+            operationId = "updateTrustedDomain",
+            summary = "Update a trusted domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified environment " +
-                    "or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified organization. " +
-                    "Deprecated: use PUT /trusted-domains/{trustedDomainId} instead.")
+                    "or DOMAIN_TRUST_DOMAIN[UPDATE] permission on the specified organization")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Trust domain successfully updated",
+            @ApiResponse(responseCode = "200", description = "Trusted domain successfully updated",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = TrustDomain.class))),
-            @ApiResponse(responseCode = "404", description = "Trust domain not found"),
+                            schema = @Schema(implementation = TrustedDomain.class))),
+            @ApiResponse(responseCode = "404", description = "Trusted domain not found"),
             @ApiResponse(responseCode = "500", description = "Internal server error")})
     public void update(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
             @PathParam("domain") String domainId,
-            @PathParam("trustDomainId") String trustDomainId,
-            @Parameter(name = "trustDomain", required = true) @Valid @NotNull final UpdateTrustDomain updateTrustDomain,
+            @PathParam("trustedDomainId") String trustedDomainId,
+            @Parameter(name = "trustedDomain", required = true) @Valid @NotNull final UpdateTrustedDomain updateTrustedDomain,
             @Suspended final AsyncResponse response) {
         final var authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_TRUST_DOMAIN, Acl.UPDATE)
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId))))
-                .flatMapSingle(domain -> trustDomainService.update(domain, trustDomainId, updateTrustDomain, authenticatedUser))
-                .map(TrustDomain::from)
+                .flatMapSingle(domain -> trustDomainService.update(domain, trustedDomainId, updateTrustedDomain, authenticatedUser))
                 .subscribe(response::resume, response::resume);
     }
 
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "deleteTrustDomain",
-            deprecated = true,
-            summary = "Delete a trust domain",
+            operationId = "deleteTrustedDomain",
+            summary = "Delete a trusted domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified environment " +
                     "or DOMAIN_TRUST_DOMAIN[DELETE] permission on the specified organization")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Trust domain successfully deleted"),
+            @ApiResponse(responseCode = "204", description = "Trusted domain successfully deleted"),
             @ApiResponse(responseCode = "500", description = "Internal server error")})
     public void delete(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
             @PathParam("domain") String domainId,
-            @PathParam("trustDomainId") String trustDomainId,
+            @PathParam("trustedDomainId") String trustedDomainId,
             @Suspended final AsyncResponse response) {
         final var authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_TRUST_DOMAIN, Acl.DELETE)
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId))))
-                .flatMapCompletable(domain -> trustDomainService.delete(domain, trustDomainId, authenticatedUser))
+                .flatMapCompletable(domain -> trustDomainService.delete(domain, trustedDomainId, authenticatedUser))
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainsResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainsResource.java
@@ -19,11 +19,11 @@ import io.gravitee.am.management.handlers.management.api.resources.AbstractResou
 import io.gravitee.am.management.service.DomainService;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.ReferenceType;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.service.exception.DomainNotFoundException;
-import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.common.http.MediaType;
 import io.reactivex.rxjava3.core.Maybe;
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,9 +51,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.net.URI;
 
-@Deprecated
-@Tag(name = "trust-domain")
-public class TrustDomainsResource extends AbstractResource {
+@Tag(name = "trusted-domain")
+public class TrustedDomainsResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
@@ -67,17 +66,15 @@ public class TrustDomainsResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "listTrustDomains",
-            deprecated = true,
-            summary = "List trust domains registered against the security domain",
-            hidden = false,
+            operationId = "listTrustedDomains",
+            summary = "List trusted domains registered against the security domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[LIST] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified environment " +
                     "or DOMAIN_TRUST_DOMAIN[LIST] permission on the specified organization")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "List of trust domains",
+            @ApiResponse(responseCode = "200", description = "List of trusted domains",
                     content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = TrustDomain.class)))),
+                            array = @ArraySchema(schema = @Schema(implementation = TrustedDomain.class)))),
             @ApiResponse(responseCode = "500", description = "Internal server error")})
     public void list(
             @PathParam("organizationId") String organizationId,
@@ -88,7 +85,6 @@ public class TrustDomainsResource extends AbstractResource {
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId))))
                 .flatMapPublisher(domain -> trustDomainService.findByReference(ReferenceType.DOMAIN, domainId))
-                .map(TrustDomain::from)
                 .toList()
                 .subscribe(response::resume, response::resume);
     }
@@ -97,43 +93,41 @@ public class TrustDomainsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(
-            operationId = "createTrustDomain",
-            deprecated = true,
-            summary = "Register a trust domain on the security domain",
+            operationId = "createTrustedDomain",
+            summary = "Register a trusted domain on the security domain",
             description = "User must have the DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified domain " +
                     "or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified environment " +
-                    "or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization. " +
-                    "Deprecated: use POST /trusted-domains instead.")
+                    "or DOMAIN_TRUST_DOMAIN[CREATE] permission on the specified organization")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Trust domain successfully created",
+            @ApiResponse(responseCode = "201", description = "Trusted domain successfully created",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = TrustDomain.class))),
-            @ApiResponse(responseCode = "400", description = "Invalid trust domain configuration"),
+                            schema = @Schema(implementation = TrustedDomain.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid trusted domain configuration"),
             @ApiResponse(responseCode = "500", description = "Internal server error")})
     public void create(
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
             @PathParam("domain") String domainId,
-            @Parameter(name = "trustDomain", required = true) @Valid @NotNull final NewTrustDomain newTrustDomain,
+            @Parameter(name = "trustedDomain", required = true) @Valid @NotNull final NewTrustedDomain newTrustedDomain,
             @Suspended final AsyncResponse response) {
         final var authenticatedUser = getAuthenticatedUser();
 
         checkAnyPermission(organizationId, environmentId, domainId, Permission.DOMAIN_TRUST_DOMAIN, Acl.CREATE)
                 .andThen(domainService.findById(domainId)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domainId))))
-                .flatMapSingle(domain -> trustDomainService.create(domain, newTrustDomain, authenticatedUser))
+                .flatMapSingle(domain -> trustDomainService.create(domain, newTrustedDomain, authenticatedUser))
                 .map(td -> Response
                         .created(URI.create("/organizations/" + organizationId
                                 + "/environments/" + environmentId
                                 + "/domains/" + domainId
-                                + "/trust-domains/" + td.getId()))
-                        .entity(TrustDomain.from(td))
+                                + "/trusted-domains/" + td.getId()))
+                        .entity(td)
                         .build())
                 .subscribe(response::resume, response::resume);
     }
 
-    @Path("{trustDomainId}")
-    public TrustDomainResource getTrustDomainResource() {
-        return resourceContext.getResource(TrustDomainResource.class);
+    @Path("{trustedDomainId}")
+    public TrustedDomainResource getTrustedDomainResource() {
+        return resourceContext.getResource(TrustedDomainResource.class);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/DomainResourceTest.java
@@ -32,7 +32,9 @@ import io.gravitee.am.model.account.AccountSettings;
 import io.gravitee.am.model.login.LoginSettings;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.OIDCSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.model.scim.SCIMSettings;
@@ -166,20 +168,22 @@ public class DomainResourceTest extends JerseySpringTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
     }
 
-    private static TrustDomain tokenExchangeTrustDomain(String id, String name, String issuer) {
-        return TrustDomain.builder()
+    private static TrustedDomain tokenExchangeTrustDomain(String id, String name, String issuer) {
+        return TrustedDomain.builder()
                 .id(id)
                 .name(name)
                 .keyMaterial(TrustDomainKeyMaterial.builder()
                         .source(KeyMaterialSource.JWKS_URL)
                         .jwksUrl(issuer + "/keys")
                         .build())
-                .issuer(issuer)
+                .domainIdentifier(issuer)
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 
-    private static TrustDomain spiffeTrustDomain(String id, String name) {
-        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
+    private static TrustedDomain spiffeTrustDomain(String id, String name) {
+        return TrustedDomain.builder().id(id).name(name)
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain(name).build()).build();
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainResourceTest.java
@@ -22,7 +22,9 @@ import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
 import io.gravitee.am.service.model.UpdateTrustDomain;
@@ -69,11 +71,11 @@ public class TrustDomainResourceTest extends JerseySpringTest {
         return domain;
     }
 
-    private static TrustDomain tokenExchangeTrustDomain() {
+    private static TrustedDomain tokenExchangeTrustDomain() {
         UserBindingCriterion criterion = new UserBindingCriterion();
         criterion.setAttribute("emails.value");
         criterion.setExpression("{#token['email']}");
-        return TrustDomain.builder()
+        return TrustedDomain.builder()
                 .id(TRUST_DOMAIN_ID)
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(DOMAIN_ID)
@@ -82,11 +84,12 @@ public class TrustDomainResourceTest extends JerseySpringTest {
                         .source(KeyMaterialSource.JWKS_URL)
                         .jwksUrl("https://issuer.example.org/keys")
                         .build())
-                .refreshIntervalSeconds(300)
-                .issuer("https://issuer.example.org")
-                .scopeMappings(Map.of("read", "domain:read"))
-                .userBindingEnabled(true)
-                .userBindingCriteria(List.of(criterion))
+                .domainIdentifier("https://issuer.example.org")
+                .tokenExchange(TokenExchangeTrustSettings.builder()
+                        .scopeMappings(Map.of("read", "domain:read"))
+                        .userBindingEnabled(true)
+                        .userBindingCriteria(List.of(criterion))
+                        .build())
                 .build();
     }
 
@@ -114,7 +117,7 @@ public class TrustDomainResourceTest extends JerseySpringTest {
     @Test
     public void shouldReturnNotFound_whenTrustDomainBelongsToAnotherDomain() {
         stubDomain();
-        TrustDomain other = tokenExchangeTrustDomain();
+        TrustedDomain other = tokenExchangeTrustDomain();
         other.setReferenceId("another-domain");
         doReturn(Maybe.just(other)).when(trustDomainService).findById(TRUST_DOMAIN_ID);
 
@@ -131,44 +134,6 @@ public class TrustDomainResourceTest extends JerseySpringTest {
         final Response response = trustDomainTarget().request().get();
 
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
-    }
-
-    @Test
-    public void shouldUpdateTokenExchangeSettings() {
-        Domain domain = stubDomain();
-        doReturn(Single.just(tokenExchangeTrustDomain()))
-                .when(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), any(UpdateTrustDomain.class), any());
-
-        final Response response = trustDomainTarget().request()
-                .put(Entity.json(Map.of(
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/v2/keys"),
-                        "issuer", "https://issuer.example.org/v2",
-                        "scopeMappings", Map.of("write", "domain:write"),
-                        "userBindingEnabled", true,
-                        "userBindingCriteria", List.of(Map.of(
-                                "attribute", "username",
-                                "expression", "{#token['sub']}")))));
-
-        assertEquals(HttpStatusCode.OK_200, response.getStatus());
-        ArgumentCaptor<UpdateTrustDomain> captor = ArgumentCaptor.forClass(UpdateTrustDomain.class);
-        verify(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), captor.capture(), any());
-        UpdateTrustDomain received = captor.getValue();
-        assertEquals("https://issuer.example.org/v2", received.getIssuer());
-        assertEquals(Map.of("write", "domain:write"), received.getScopeMappings());
-        assertTrue(received.getUserBindingEnabled());
-        assertEquals("username", received.getUserBindingCriteria().get(0).getAttribute());
-    }
-
-    @Test
-    public void shouldRejectUpdateIntroducingDuplicateIssuer() {
-        Domain domain = stubDomain();
-        doReturn(Single.error(new TrustDomainIssuerAlreadyExistsException("https://issuer.example.org")))
-                .when(trustDomainService).update(eq(domain), eq(TRUST_DOMAIN_ID), any(UpdateTrustDomain.class), any());
-
-        final Response response = trustDomainTarget().request()
-                .put(Entity.json(Map.of("issuer", "https://issuer.example.org")));
-
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test
@@ -198,10 +163,10 @@ public class TrustDomainResourceTest extends JerseySpringTest {
         doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
 
         final Response response = trustDomainTarget().request()
-                .put(Entity.json(Map.of("issuer", "https://issuer.example.org")));
+                .put(Entity.json(Map.of("description", "amended")));
 
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
-        verify(trustDomainService, never()).update(any(), any(), any(), any());
+        verify(trustDomainService, never()).update(any(), any(), any(UpdateTrustDomain.class), any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustDomainsResourceTest.java
@@ -24,7 +24,9 @@ import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.exception.InvalidTrustDomainException;
 import io.gravitee.am.service.model.NewTrustDomain;
@@ -75,15 +77,14 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         return domain;
     }
 
-    private static TrustDomain spiffeTrustDomain(TrustDomainKeyMaterial keyMaterial) {
-        return TrustDomain.builder()
+    private static TrustedDomain spiffeTrustDomain(TrustDomainKeyMaterial keyMaterial) {
+        return TrustedDomain.builder()
                 .id("td-1")
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(DOMAIN_ID)
                 .name("example.org")
-                .spiffeTrustDomain("example.org")
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("example.org").build())
                 .keyMaterial(keyMaterial)
-                .refreshIntervalSeconds(300)
                 .build();
     }
 
@@ -125,129 +126,17 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
     }
 
     @Test
-    public void shouldCreateWithPemKeyMaterial() {
-        Domain domain = stubDomain();
-        TrustDomainKeyMaterial pem = TrustDomainKeyMaterial.builder()
-                .source(KeyMaterialSource.PEM)
-                .certificate(PEM_CERTIFICATE)
-                .build();
-        doReturn(Single.just(spiffeTrustDomain(pem)))
-                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "example.org",
-                        "keyMaterial", Map.of("source", "PEM", "certificate", PEM_CERTIFICATE))));
-
-        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
-        verify(trustDomainService).create(eq(domain), captor.capture(), any());
-        assertEquals(KeyMaterialSource.PEM, captor.getValue().getKeyMaterial().getSource());
-        assertEquals(PEM_CERTIFICATE, captor.getValue().getKeyMaterial().getCertificate());
-    }
-
-    @Test
-    public void shouldCreateWithInlineJwkSet() {
-        Domain domain = stubDomain();
-        RSAKey key = new RSAKey();
-        key.setKid("key-1");
-        key.setE("AQAB");
-        key.setN("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z");
-        JWKSet jwkSet = new JWKSet();
-        jwkSet.setKeys(List.of(key));
-        doReturn(Single.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
-                .source(KeyMaterialSource.JWK_SET)
-                .jwkSet(jwkSet)
-                .build())))
-                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "example.org",
-                        "keyMaterial", Map.of("source", "JWK_SET", "jwkSet", Map.of("keys", List.of(Map.of(
-                                "kty", "RSA",
-                                "kid", "key-1",
-                                "e", "AQAB",
-                                "n", "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z")))))));
-
-        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
-        verify(trustDomainService).create(eq(domain), captor.capture(), any());
-        JWKSet received = captor.getValue().getKeyMaterial().getJwkSet();
-        assertNotNull(received);
-        assertEquals(1, received.getKeys().size());
-        assertEquals("key-1", received.getKeys().get(0).getKid());
-        assertEquals("RSA", received.getKeys().get(0).getKty());
-    }
-
-    @Test
-    public void shouldCreateWithAnIssuerMatcher() {
-        Domain domain = stubDomain();
-        doReturn(Single.just(tokenExchangeTrustDomain()))
-                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "example.org",
-                        "issuer", "https://issuer.example.org",
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"))));
-
-        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
-        Map<String, Object> body = response.readEntity(Map.class);
-        assertEquals("https://issuer.example.org", body.get("issuer"));
-        assertEquals("jwks_url", body.get("bundleSource"));
-    }
-
-    @Test
-    public void shouldRejectInvalidKeyMaterial() {
-        Domain domain = stubDomain();
-        doReturn(Single.error(new InvalidTrustDomainException("keyMaterial.source is required")))
-                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of("name", "example.org")));
-
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
-    }
-
-    @Test
-    public void shouldRejectANameLongerThanTheAdvertisedMaxLength() {
-        stubDomain();
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "a".repeat(TrustDomain.NAME_MAX_LENGTH + 1),
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"))));
-
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
-        verify(trustDomainService, never()).create(any(), any(), any());
-    }
-
-    @Test
-    public void shouldRejectASpiffeTrustDomainLongerThanTheAdvertisedMaxLength() {
-        stubDomain();
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "acme-corp",
-                        "spiffeTrustDomain", "a".repeat(TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + 1),
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"))));
-
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
-        verify(trustDomainService, never()).create(any(), any(), any());
-    }
-
-    @Test
     public void shouldReturnNotFound_whenDomainIsUnknown() {
         doReturn(Maybe.empty()).when(domainService).findById(DOMAIN_ID);
 
         final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
                 .post(Entity.json(Map.of(
                         "name", "example.org",
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://spire.example.org/keys"))));
+                        "bundleSource", "JWKS_URL",
+                        "jwksUrl", "https://spire.example.org/keys")));
 
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
-        verify(trustDomainService, never()).create(any(), any(), any());
+        verify(trustDomainService, never()).create(any(), any(NewTrustDomain.class), any());
     }
 
     @Test
@@ -268,54 +157,26 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
         ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
         verify(trustDomainService).create(eq(domain), captor.capture(), any());
-        assertNull(captor.getValue().getKeyMaterial());
         assertEquals(SpiffeBundleSource.JWKS_URL, captor.getValue().getBundleSource());
         assertEquals("https://spire.example.org/keys", captor.getValue().getJwksUrl());
     }
 
-    private static TrustDomain tokenExchangeTrustDomain() {
+    private static TrustedDomain tokenExchangeTrustDomain() {
         UserBindingCriterion criterion = new UserBindingCriterion();
         criterion.setAttribute("emails.value");
         criterion.setExpression("{#token['email']}");
-        TrustDomain td = spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+        TrustedDomain td = spiffeTrustDomain(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://issuer.example.org/keys")
                 .build());
-        td.setSpiffeTrustDomain(null);
-        td.setIssuer("https://issuer.example.org");
-        td.setScopeMappings(Map.of("read", "domain:read"));
-        td.setUserBindingEnabled(true);
-        td.setUserBindingCriteria(List.of(criterion));
+        td.setSpiffe(null);
+        td.setDomainIdentifier("https://issuer.example.org");
+        td.setTokenExchange(TokenExchangeTrustSettings.builder()
+                .scopeMappings(Map.of("read", "domain:read"))
+                .userBindingEnabled(true)
+                .userBindingCriteria(List.of(criterion))
+                .build());
         return td;
-    }
-
-    @Test
-    public void shouldCreateTokenExchangeTrustedDomainWithScopeMappingsAndUserBinding() {
-        Domain domain = stubDomain();
-        doReturn(Single.just(tokenExchangeTrustDomain()))
-                .when(trustDomainService).create(eq(domain), any(NewTrustDomain.class), any());
-
-        final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
-                .post(Entity.json(Map.of(
-                        "name", "issuer.example.org",
-                        "issuer", "https://issuer.example.org",
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
-                        "scopeMappings", Map.of("read", "domain:read"),
-                        "userBindingEnabled", true,
-                        "userBindingCriteria", List.of(Map.of(
-                                "attribute", "emails.value",
-                                "expression", "{#token['email']}")))));
-
-        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
-        verify(trustDomainService).create(eq(domain), captor.capture(), any());
-        NewTrustDomain received = captor.getValue();
-        assertEquals("https://issuer.example.org", received.getIssuer());
-        assertEquals(Map.of("read", "domain:read"), received.getScopeMappings());
-        assertTrue(received.isUserBindingEnabled());
-        assertEquals(1, received.getUserBindingCriteria().size());
-        assertEquals("emails.value", received.getUserBindingCriteria().get(0).getAttribute());
-        assertEquals("{#token['email']}", received.getUserBindingCriteria().get(0).getExpression());
     }
 
     @Test
@@ -350,11 +211,11 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
                 .post(Entity.json(Map.of(
                         "name", "issuer.example.org",
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
-                        "issuer", "https://issuer.example.org")));
+                        "bundleSource", "JWKS_URL",
+                        "jwksUrl", "https://issuer.example.org/keys")));
 
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
-        verify(trustDomainService, never()).create(any(), any(), any());
+        verify(trustDomainService, never()).create(any(), any(NewTrustDomain.class), any());
     }
 
     @Test
@@ -374,10 +235,10 @@ public class TrustDomainsResourceTest extends JerseySpringTest {
         final Response response = target("domains").path(DOMAIN_ID).path("trust-domains").request()
                 .post(Entity.json(Map.of(
                         "name", "issuer.example.org",
-                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
-                        "issuer", "https://issuer.example.org")));
+                        "bundleSource", "JWKS_URL",
+                        "jwksUrl", "https://issuer.example.org/keys")));
 
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
-        verify(trustDomainService, never()).create(any(), any(), any());
+        verify(trustDomainService, never()).create(any(), any(NewTrustDomain.class), any());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainResourceTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class TrustedDomainResourceTest extends JerseySpringTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+    private static final String TRUSTED_DOMAIN_ID = "td-1";
+
+    @BeforeEach
+    public void resetTrustDomainService() {
+        reset(trustDomainService);
+    }
+
+    private Domain stubDomain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        doReturn(Maybe.just(domain)).when(domainService).findById(DOMAIN_ID);
+        return domain;
+    }
+
+    private jakarta.ws.rs.client.WebTarget trustedDomainTarget() {
+        return target("domains").path(DOMAIN_ID).path("trusted-domains").path(TRUSTED_DOMAIN_ID);
+    }
+
+    private static TrustedDomain tokenExchangeTrustDomain() {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("emails.value");
+        criterion.setExpression("{#token['email']}");
+        return TrustedDomain.builder()
+                .id(TRUSTED_DOMAIN_ID)
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name("issuer.example.org")
+                .keyMaterial(TrustDomainKeyMaterial.builder()
+                        .source(KeyMaterialSource.JWKS_URL)
+                        .jwksUrl("https://issuer.example.org/keys")
+                        .build())
+                .domainIdentifier("https://issuer.example.org")
+                .tokenExchange(TokenExchangeTrustSettings.builder()
+                        .scopeMappings(Map.of("read", "domain:read"))
+                        .userBindingEnabled(true)
+                        .userBindingCriteria(List.of(criterion))
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void shouldReadTheNestedBlocksAndNoneOfTheDeprecatedAccessors() {
+        stubDomain();
+        doReturn(Maybe.just(tokenExchangeTrustDomain())).when(trustDomainService).findById(TRUSTED_DOMAIN_ID);
+
+        final Response response = trustedDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        Map<String, Object> body = response.readEntity(Map.class);
+        assertEquals("https://issuer.example.org", body.get("domainIdentifier"));
+        Map<String, Object> tokenExchange = (Map<String, Object>) body.get("tokenExchange");
+        assertEquals(Map.of("read", "domain:read"), tokenExchange.get("scopeMappings"));
+        assertEquals(Boolean.TRUE, tokenExchange.get("userBindingEnabled"));
+        assertFalse(body.containsKey("issuer"));
+        assertFalse(body.containsKey("scopeMappings"));
+        assertFalse(body.containsKey("userBindingEnabled"));
+        assertFalse(body.containsKey("refreshIntervalSeconds"));
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenTrustedDomainBelongsToAnotherDomain() {
+        stubDomain();
+        TrustedDomain other = tokenExchangeTrustDomain();
+        other.setReferenceId("another-domain");
+        doReturn(Maybe.just(other)).when(trustDomainService).findById(TRUSTED_DOMAIN_ID);
+
+        final Response response = trustedDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenTrustedDomainIsUnknown() {
+        stubDomain();
+        doReturn(Maybe.empty()).when(trustDomainService).findById(TRUSTED_DOMAIN_ID);
+
+        final Response response = trustedDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldUpdateTokenExchangeSettings() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).update(eq(domain), eq(TRUSTED_DOMAIN_ID), any(UpdateTrustedDomain.class), any());
+
+        final Response response = trustedDomainTarget().request()
+                .put(Entity.json(Map.of(
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/v2/keys"),
+                        "domainIdentifier", "https://issuer.example.org/v2",
+                        "tokenExchange", Map.of(
+                                "scopeMappings", Map.of("write", "domain:write"),
+                                "userBindingEnabled", true,
+                                "userBindingCriteria", List.of(Map.of(
+                                        "attribute", "username",
+                                        "expression", "{#token['sub']}"))))));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        ArgumentCaptor<UpdateTrustedDomain> captor = ArgumentCaptor.forClass(UpdateTrustedDomain.class);
+        verify(trustDomainService).update(eq(domain), eq(TRUSTED_DOMAIN_ID), captor.capture(), any());
+        UpdateTrustedDomain received = captor.getValue();
+        assertEquals("https://issuer.example.org/v2", received.getDomainIdentifier());
+        assertEquals(Map.of("write", "domain:write"), received.getTokenExchange().getScopeMappings());
+        assertTrue(received.getTokenExchange().isUserBindingEnabled());
+        assertEquals("username", received.getTokenExchange().getUserBindingCriteria().get(0).getAttribute());
+    }
+
+    @Test
+    public void shouldClearAUsageWhenTheUpdateSendsItBlank() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).update(eq(domain), eq(TRUSTED_DOMAIN_ID), any(UpdateTrustedDomain.class), any());
+
+        trustedDomainTarget().request()
+                .put(Entity.json(Map.of(
+                        "domainIdentifier", "",
+                        "spiffe", Map.of("spiffeTrustDomain", "acme.org"))));
+
+        ArgumentCaptor<UpdateTrustedDomain> captor = ArgumentCaptor.forClass(UpdateTrustedDomain.class);
+        verify(trustDomainService).update(eq(domain), eq(TRUSTED_DOMAIN_ID), captor.capture(), any());
+        assertEquals("", captor.getValue().getDomainIdentifier());
+        assertEquals("acme.org", captor.getValue().getSpiffe().getSpiffeTrustDomain());
+    }
+
+    @Test
+    public void shouldRejectUpdateIntroducingDuplicateIssuer() {
+        Domain domain = stubDomain();
+        doReturn(Single.error(new TrustDomainIssuerAlreadyExistsException("https://issuer.example.org")))
+                .when(trustDomainService).update(eq(domain), eq(TRUSTED_DOMAIN_ID), any(UpdateTrustedDomain.class), any());
+
+        final Response response = trustedDomainTarget().request()
+                .put(Entity.json(Map.of(
+                        "domainIdentifier", "https://issuer.example.org",
+                        "tokenExchange", Map.of())));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldDeleteTrustedDomain() {
+        Domain domain = stubDomain();
+        doReturn(Completable.complete()).when(trustDomainService).delete(eq(domain), eq(TRUSTED_DOMAIN_ID), any());
+
+        final Response response = trustedDomainTarget().request().delete();
+
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+        verify(trustDomainService).delete(eq(domain), eq(TRUSTED_DOMAIN_ID), any());
+    }
+
+    @Test
+    public void shouldRejectReadWithoutTrustDomainPermission() {
+        stubDomain();
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustedDomainTarget().request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldRejectUpdateWithoutTrustDomainPermission() {
+        stubDomain();
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustedDomainTarget().request()
+                .put(Entity.json(Map.of("description", "amended")));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).update(any(), any(), any(UpdateTrustedDomain.class), any());
+    }
+
+    @Test
+    public void shouldRejectDeleteWithoutTrustDomainPermission() {
+        stubDomain();
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = trustedDomainTarget().request().delete();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).delete(any(), any(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/test/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/TrustedDomainsResourceTest.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.management.api.resources.organizations.environments.domains;
+
+import io.gravitee.am.management.handlers.management.api.JerseySpringTest;
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.service.permissions.PermissionAcls;
+import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.gravitee.am.model.jose.RSAKey;
+import io.gravitee.am.model.oidc.JWKSet;
+import io.gravitee.am.model.oidc.KeyMaterialSource;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.exception.InvalidTrustDomainException;
+import io.gravitee.am.service.model.NewTrustedDomain;
+import io.gravitee.common.http.HttpStatusCode;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class TrustedDomainsResourceTest extends JerseySpringTest {
+
+    private static final String DOMAIN_ID = "domain-id";
+
+    private static final String PEM_CERTIFICATE = "-----BEGIN CERTIFICATE-----\nMIIDGzCCAgOgAwIBAgIUTjn3isOFd6UKhH07F2M9E0+1naMwDQYJKoZIhvcNAQEL\nBQAwHDEaMBgGA1UEAwwRdHJ1c3QtZG9tYWluLXRlc3QwIBcNMjYwODE5MDk0NTU3\nWhgPMjEyNjA3MjYwOTQ1NTdaMBwxGjAYBgNVBAMMEXRydXN0LWRvbWFpbi10ZXN0\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1R3nx/2UCXBoJKsq2K3Z\nPOGsH8Djxj2nnSZ081MVRQL3YgvrSmgzmRSwr6sYx9oJ8Kn32IINUi/aLiwzxlFL\nACK3D/vjWmjP+kwIep64LCzHdD7PaP0ePgN/0jme1pOWVQgyHVs+0q0w6vepHpKu\nl9NcAkMPd7Pq0fUTPg9ebW2sGko7EKZvcsE3/nOA7fStycEtmscLr38wZFGIZSIw\n6QJ8Eww9Rn7CFhTXnE88/LGJ104YQ9taDR7uDQdB42dss2YQ/tWF82LL/PS/9zFW\nzdlF11dI1Xyo3LTTt584PQkDXp0B+wrT4YoOskTK2aMO1IIkV/iNMUDs6fzbtJvY\nAQIDAQABo1MwUTAdBgNVHQ4EFgQUmh/tKVGDTOrkfdEJ2J2+ZfA0ufswHwYDVR0j\nBBgwFoAUmh/tKVGDTOrkfdEJ2J2+ZfA0ufswDwYDVR0TAQH/BAUwAwEB/zANBgkq\nhkiG9w0BAQsFAAOCAQEAn84I8ZiCavT+RBk4f0eHd5pnT9Scj0zcEElwgDw+8nNM\neyTSuPdngL9pQCSBbZbo7ZNCe0WFOf2W/SLIzRx6E3+z1ffAmLr9/LTC1+UNuh1n\nfeEljw97Q0sJKd/EyyUg+ZwUwQ5yiTT8hAQdai1kWhRLbalI2cYYJ+1HlXD73eKM\n9WrINYHmLrXclebEtB3SPTTeGtMZ/ajKlcBV1fu/+OoN5e09hvvEEJZ48aNYZrTt\n2An+LQABjo4LNsjP1prK4PtQl1/PI/jHUiRkHfWZx3y2Rakw5bu+bWMMn3vL4Dsk\nrXiZ9rmdTvbQ38TVI3+G5aBLVP9DS+9cXdHfSlyVPg==\n-----END CERTIFICATE-----";
+
+    @BeforeEach
+    public void resetTrustDomainService() {
+        reset(trustDomainService);
+    }
+
+    private Domain stubDomain() {
+        Domain domain = new Domain();
+        domain.setId(DOMAIN_ID);
+        doReturn(Maybe.just(domain)).when(domainService).findById(DOMAIN_ID);
+        return domain;
+    }
+
+    private static TrustedDomain spiffeTrustDomain(TrustDomainKeyMaterial keyMaterial) {
+        return TrustedDomain.builder()
+                .id("td-1")
+                .referenceType(ReferenceType.DOMAIN)
+                .referenceId(DOMAIN_ID)
+                .name("example.org")
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("example.org").build())
+                .keyMaterial(keyMaterial)
+                .build();
+    }
+
+    private static TrustedDomain tokenExchangeTrustDomain() {
+        UserBindingCriterion criterion = new UserBindingCriterion();
+        criterion.setAttribute("emails.value");
+        criterion.setExpression("{#token['email']}");
+        TrustedDomain td = spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl("https://issuer.example.org/keys")
+                .build());
+        td.setSpiffe(null);
+        td.setDomainIdentifier("https://issuer.example.org");
+        td.setTokenExchange(TokenExchangeTrustSettings.builder()
+                .scopeMappings(Map.of("read", "domain:read"))
+                .userBindingEnabled(true)
+                .userBindingCriteria(List.of(criterion))
+                .build());
+        return td;
+    }
+
+    @Test
+    public void shouldExposeTheNestedBlocksAndNoneOfTheDeprecatedAccessors() {
+        stubDomain();
+        doReturn(Flowable.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWKS_URL)
+                .jwksUrl("https://spire.example.org/keys")
+                .build())))
+                .when(trustDomainService).findByReference(ReferenceType.DOMAIN, DOMAIN_ID);
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        List<Map<String, Object>> body = response.readEntity(List.class);
+        assertEquals(1, body.size());
+        Map<String, Object> trustedDomain = body.get(0);
+        assertEquals("example.org", ((Map<String, Object>) trustedDomain.get("spiffe")).get("spiffeTrustDomain"));
+        Map<String, Object> keyMaterial = (Map<String, Object>) trustedDomain.get("keyMaterial");
+        assertEquals("jwks_url", keyMaterial.get("source"));
+        assertEquals("https://spire.example.org/keys", keyMaterial.get("jwksUrl"));
+        assertFalse(trustedDomain.containsKey("spiffeTrustDomain"));
+        assertFalse(trustedDomain.containsKey("issuer"));
+        assertFalse(trustedDomain.containsKey("bundleSource"));
+        assertFalse(trustedDomain.containsKey("jwksUrl"));
+    }
+
+    @Test
+    public void shouldCreateWithPemKeyMaterial() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.PEM)
+                .certificate(PEM_CERTIFICATE)
+                .build())))
+                .when(trustDomainService).create(eq(domain), any(NewTrustedDomain.class), any());
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "example.org",
+                        "spiffe", Map.of("spiffeTrustDomain", "example.org"),
+                        "keyMaterial", Map.of("source", "PEM", "certificate", PEM_CERTIFICATE))));
+
+        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), any());
+        assertEquals(KeyMaterialSource.PEM, captor.getValue().getKeyMaterial().getSource());
+        assertEquals(PEM_CERTIFICATE, captor.getValue().getKeyMaterial().getCertificate());
+        assertEquals("example.org", captor.getValue().getSpiffe().getSpiffeTrustDomain());
+    }
+
+    @Test
+    public void shouldCreateWithInlineJwkSet() {
+        Domain domain = stubDomain();
+        RSAKey key = new RSAKey();
+        key.setKid("key-1");
+        key.setE("AQAB");
+        key.setN("0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z");
+        JWKSet jwkSet = new JWKSet();
+        jwkSet.setKeys(List.of(key));
+        doReturn(Single.just(spiffeTrustDomain(TrustDomainKeyMaterial.builder()
+                .source(KeyMaterialSource.JWK_SET)
+                .jwkSet(jwkSet)
+                .build())))
+                .when(trustDomainService).create(eq(domain), any(NewTrustedDomain.class), any());
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "example.org",
+                        "keyMaterial", Map.of("source", "JWK_SET", "jwkSet", Map.of("keys", List.of(Map.of(
+                                "kty", "RSA",
+                                "kid", "key-1",
+                                "e", "AQAB",
+                                "n", "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z")))))));
+
+        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), any());
+        JWKSet received = captor.getValue().getKeyMaterial().getJwkSet();
+        assertNotNull(received);
+        assertEquals(1, received.getKeys().size());
+        assertEquals("key-1", received.getKeys().get(0).getKid());
+        assertEquals("RSA", received.getKeys().get(0).getKty());
+    }
+
+    @Test
+    public void shouldCreateTokenExchangeTrustedDomainWithScopeMappingsAndUserBinding() {
+        Domain domain = stubDomain();
+        doReturn(Single.just(tokenExchangeTrustDomain()))
+                .when(trustDomainService).create(eq(domain), any(NewTrustedDomain.class), any());
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "issuer.example.org",
+                        "domainIdentifier", "https://issuer.example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://issuer.example.org/keys"),
+                        "tokenExchange", Map.of(
+                                "scopeMappings", Map.of("read", "domain:read"),
+                                "userBindingEnabled", true,
+                                "userBindingCriteria", List.of(Map.of(
+                                        "attribute", "emails.value",
+                                        "expression", "{#token['email']}"))))));
+
+        assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
+        verify(trustDomainService).create(eq(domain), captor.capture(), any());
+        NewTrustedDomain received = captor.getValue();
+        assertEquals("https://issuer.example.org", received.getDomainIdentifier());
+        assertEquals(Map.of("read", "domain:read"), received.getTokenExchange().getScopeMappings());
+        assertTrue(received.getTokenExchange().isUserBindingEnabled());
+        assertEquals(1, received.getTokenExchange().getUserBindingCriteria().size());
+
+        Map<String, Object> body = response.readEntity(Map.class);
+        assertEquals("https://issuer.example.org", body.get("domainIdentifier"));
+        assertFalse(body.containsKey("issuer"));
+    }
+
+    @Test
+    public void shouldRejectInvalidKeyMaterial() {
+        Domain domain = stubDomain();
+        doReturn(Single.error(new InvalidTrustDomainException("keyMaterial.source is required")))
+                .when(trustDomainService).create(eq(domain), any(NewTrustedDomain.class), any());
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of("name", "example.org")));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnNotFound_whenDomainIsUnknown() {
+        doReturn(Maybe.empty()).when(domainService).findById(DOMAIN_ID);
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://spire.example.org/keys"))));
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        verify(trustDomainService, never()).create(any(), any(NewTrustedDomain.class), any());
+    }
+
+    @Test
+    public void shouldRejectListWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request().get();
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldRejectCreateWithoutTrustDomainPermission() {
+        doReturn(Single.just(false)).when(permissionService).hasPermission(any(User.class), any(PermissionAcls.class));
+
+        final Response response = target("domains").path(DOMAIN_ID).path("trusted-domains").request()
+                .post(Entity.json(Map.of(
+                        "name", "example.org",
+                        "keyMaterial", Map.of("source", "JWKS_URL", "jwksUrl", "https://spire.example.org/keys"))));
+
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+        verify(trustDomainService, never()).create(any(), any(NewTrustedDomain.class), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgrader.java
@@ -26,10 +26,11 @@ import io.gravitee.am.model.SystemTaskStatus;
 import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.repository.management.api.SystemTaskRepository;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -78,11 +79,11 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
             "Trusted issuers can't be migrated to trusted domains, other instance may process them or an upgrader has failed previously";
 
     private final DomainService domainService;
-    private final TrustDomainRepository trustDomainRepository;
+    private final TrustedDomainRepository trustDomainRepository;
 
     public DomainTrustedIssuerUpgrader(@Lazy SystemTaskRepository systemTaskRepository,
                                        DomainService domainService,
-                                       @Lazy TrustDomainRepository trustDomainRepository) {
+                                       @Lazy TrustedDomainRepository trustDomainRepository) {
         super(systemTaskRepository);
         this.domainService = domainService;
         this.trustDomainRepository = trustDomainRepository;
@@ -121,14 +122,14 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
                 .flatMapCompletable(existing -> migrateIssuers(domain, issuers, existing));
     }
 
-    private Completable migrateIssuers(Domain domain, List<TrustedIssuer> issuers, List<TrustDomain> existing) {
+    private Completable migrateIssuers(Domain domain, List<TrustedIssuer> issuers, List<TrustedDomain> existing) {
         Set<String> alreadyVouchedFor = existing.stream()
-                .map(TrustDomain::getIssuer)
+                .map(TrustedDomain::getDomainIdentifier)
                 .filter(Objects::nonNull)
                 .collect(toSet());
         // names are unique across every trusted domain, so a derived name may not collide with a
         // trusted domain that only serves SPIFFE either
-        Set<String> takenNames = existing.stream().map(TrustDomain::getName).collect(toSet());
+        Set<String> takenNames = existing.stream().map(TrustedDomain::getName).collect(toSet());
         Map<String, String> derivedNames = TrustedIssuerNaming.deriveNames(
                 issuers.stream().map(TrustedIssuer::getIssuer).filter(issuer -> !alreadyVouchedFor.contains(issuer)).toList(),
                 takenNames);
@@ -142,9 +143,9 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
     }
 
     private Single<Boolean> migrateIssuer(Domain domain, TrustedIssuer issuer, String name, Set<String> takenNames) {
-        if (issuer.getIssuer().length() > TrustDomain.ISSUER_MAX_LENGTH) {
+        if (issuer.getIssuer().length() > TrustedDomain.ISSUER_MAX_LENGTH) {
             log.warn("Trusted issuer {} of domain {} is left inline: a trusted domain bounds its issuer at {} characters",
-                    issuer.getIssuer(), domain.getId(), TrustDomain.ISSUER_MAX_LENGTH);
+                    issuer.getIssuer(), domain.getId(), TrustedDomain.ISSUER_MAX_LENGTH);
             return Single.just(false);
         }
         if (takenNames.contains(name)) {
@@ -164,18 +165,19 @@ public class DomainTrustedIssuerUpgrader extends SystemTaskUpgrader {
         return domainService.update(domain.getId(), domain).ignoreElement();
     }
 
-    private static TrustDomain asTrustDomain(Domain domain, TrustedIssuer issuer, String name) {
+    private static TrustedDomain asTrustDomain(Domain domain, TrustedIssuer issuer, String name) {
         Date now = Date.from(Instant.now());
-        return TrustDomain.builder()
+        return TrustedDomain.builder()
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(domain.getId())
                 .name(name)
-                .issuer(issuer.getIssuer())
+                .domainIdentifier(issuer.getIssuer())
                 .keyMaterial(keyMaterialOf(issuer))
-                .refreshIntervalSeconds(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS)
-                .scopeMappings(issuer.getScopeMappings())
-                .userBindingEnabled(issuer.isUserBindingEnabled())
-                .userBindingCriteria(issuer.getUserBindingCriteria())
+                .tokenExchange(TokenExchangeTrustSettings.builder()
+                        .scopeMappings(issuer.getScopeMappings())
+                        .userBindingEnabled(issuer.isUserBindingEnabled())
+                        .userBindingCriteria(issuer.getUserBindingCriteria())
+                        .build())
                 .createdAt(now)
                 .updatedAt(now)
                 .build();

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjection.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjection.java
@@ -22,11 +22,12 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.TrustDomainService;
-import io.gravitee.am.service.model.NewTrustDomain;
-import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.service.model.NewTrustedDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -86,9 +87,9 @@ public class TrustedIssuerProjection {
                 .flatMapCompletable(existing -> replace(domain, existing, written, principal));
     }
 
-    private Completable replace(Domain domain, List<TrustDomain> existing, List<TrustedIssuer> written, User principal) {
-        Map<String, TrustDomain> byIssuer = new LinkedHashMap<>();
-        existing.forEach(trustDomain -> byIssuer.put(trustDomain.getIssuer(), trustDomain));
+    private Completable replace(Domain domain, List<TrustedDomain> existing, List<TrustedIssuer> written, User principal) {
+        Map<String, TrustedDomain> byIssuer = new LinkedHashMap<>();
+        existing.forEach(trustDomain -> byIssuer.put(trustDomain.getDomainIdentifier(), trustDomain));
 
         List<TrustedIssuer> declared = written.stream()
                 .filter(issuer -> issuer != null && issuer.getIssuer() != null && !issuer.getIssuer().isBlank())
@@ -96,31 +97,31 @@ public class TrustedIssuerProjection {
         Set<String> declaredIssuers = declared.stream().map(TrustedIssuer::getIssuer).collect(toSet());
         Map<String, String> derivedNames = TrustedIssuerNaming.deriveNames(
                 declared.stream().map(TrustedIssuer::getIssuer).filter(issuer -> !byIssuer.containsKey(issuer)).toList(),
-                existing.stream().map(TrustDomain::getName).collect(toSet()));
+                existing.stream().map(TrustedDomain::getName).collect(toSet()));
 
         Completable upserts = Flowable.fromIterable(declared)
                 .concatMapCompletable(issuer -> {
-                    TrustDomain match = byIssuer.get(issuer.getIssuer());
+                    TrustedDomain match = byIssuer.get(issuer.getIssuer());
                     return match != null
                             ? trustDomainService.update(domain, match.getId(), asUpdate(issuer, match), principal).ignoreElement()
                             : trustDomainService.create(domain, asNew(issuer, derivedNames.get(issuer.getIssuer())), principal).ignoreElement();
                 });
         Completable deletions = Flowable.fromIterable(existing)
-                .filter(trustDomain -> !declaredIssuers.contains(trustDomain.getIssuer()))
+                .filter(trustDomain -> !declaredIssuers.contains(trustDomain.getDomainIdentifier()))
                 .concatMapCompletable(trustDomain -> trustDomainService.delete(domain, trustDomain.getId(), principal));
 
         return upserts.andThen(deletions);
     }
 
-    private Single<List<TrustDomain>> tokenExchangeTrustDomains(String domainId) {
+    private Single<List<TrustedDomain>> tokenExchangeTrustDomains(String domainId) {
         return trustDomainService.findByReference(ReferenceType.DOMAIN, domainId)
-                .filter(TrustDomain::trustsTokenExchange)
+                .filter(TrustedDomain::trustsTokenExchange)
                 .toList();
     }
 
-    private static TrustedIssuer asTrustedIssuer(TrustDomain trustDomain) {
+    private static TrustedIssuer asTrustedIssuer(TrustedDomain trustDomain) {
         TrustedIssuer trustedIssuer = new TrustedIssuer();
-        trustedIssuer.setIssuer(trustDomain.getIssuer());
+        trustedIssuer.setIssuer(trustDomain.getDomainIdentifier());
         trustedIssuer.setScopeMappings(trustDomain.getScopeMappings());
         trustedIssuer.setUserBindingEnabled(trustDomain.isUserBindingEnabled());
         trustedIssuer.setUserBindingCriteria(trustDomain.getUserBindingCriteria());
@@ -135,27 +136,31 @@ public class TrustedIssuerProjection {
         return trustedIssuer;
     }
 
-    private static NewTrustDomain asNew(TrustedIssuer issuer, String name) {
-        NewTrustDomain newTrustDomain = new NewTrustDomain();
+    private static NewTrustedDomain asNew(TrustedIssuer issuer, String name) {
+        NewTrustedDomain newTrustDomain = new NewTrustedDomain();
         newTrustDomain.setName(name);
-        newTrustDomain.setIssuer(issuer.getIssuer());
+        newTrustDomain.setDomainIdentifier(issuer.getIssuer());
         newTrustDomain.setKeyMaterial(keyMaterialOf(issuer));
-        newTrustDomain.setScopeMappings(issuer.getScopeMappings());
-        newTrustDomain.setUserBindingEnabled(issuer.isUserBindingEnabled());
-        newTrustDomain.setUserBindingCriteria(issuer.getUserBindingCriteria());
+        newTrustDomain.setTokenExchange(tokenExchangeOf(issuer));
         return newTrustDomain;
     }
 
-    private static UpdateTrustDomain asUpdate(TrustedIssuer issuer, TrustDomain existing) {
-        UpdateTrustDomain updateTrustDomain = new UpdateTrustDomain();
+    private static UpdateTrustedDomain asUpdate(TrustedIssuer issuer, TrustedDomain existing) {
+        UpdateTrustedDomain updateTrustDomain = new UpdateTrustedDomain();
         updateTrustDomain.setDescription(existing.getDescription());
-        updateTrustDomain.setIssuer(issuer.getIssuer());
-        updateTrustDomain.setSpiffeTrustDomain(existing.getSpiffeTrustDomain());
+        updateTrustDomain.setDomainIdentifier(issuer.getIssuer());
+        updateTrustDomain.setSpiffe(existing.getSpiffe());
         updateTrustDomain.setKeyMaterial(keyMaterialOf(issuer));
-        updateTrustDomain.setScopeMappings(issuer.getScopeMappings());
-        updateTrustDomain.setUserBindingEnabled(issuer.isUserBindingEnabled());
-        updateTrustDomain.setUserBindingCriteria(issuer.getUserBindingCriteria());
+        updateTrustDomain.setTokenExchange(tokenExchangeOf(issuer));
         return updateTrustDomain;
+    }
+
+    private static TokenExchangeTrustSettings tokenExchangeOf(TrustedIssuer issuer) {
+        return TokenExchangeTrustSettings.builder()
+                .scopeMappings(issuer.getScopeMappings())
+                .userBindingEnabled(issuer.isUserBindingEnabled())
+                .userBindingCriteria(issuer.getUserBindingCriteria())
+                .build();
     }
 
     private static TrustDomainKeyMaterial keyMaterialOf(TrustedIssuer issuer) {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/upgrades/DomainTrustedIssuerUpgraderTest.java
@@ -25,10 +25,12 @@ import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.repository.management.api.SystemTaskRepository;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -66,7 +68,7 @@ class DomainTrustedIssuerUpgraderTest {
     private DomainService domainService;
 
     @Mock
-    private TrustDomainRepository trustDomainRepository;
+    private TrustedDomainRepository trustDomainRepository;
 
     @InjectMocks
     private DomainTrustedIssuerUpgrader upgrader;
@@ -75,14 +77,14 @@ class DomainTrustedIssuerUpgraderTest {
     void shouldMigrateTrustedIssuerToTokenExchangeTrustedDomain() {
         TrustedIssuer issuer = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
 
-        TrustDomain migrated = migrateOne(domainWith(issuer));
+        TrustedDomain migrated = migrateOne(domainWith(issuer));
 
         assertEquals(ReferenceType.DOMAIN, migrated.getReferenceType());
         assertEquals(DOMAIN_ID, migrated.getReferenceId());
-        assertEquals("https://issuer.example.com", migrated.getIssuer());
+        assertEquals("https://issuer.example.com", migrated.getDomainIdentifier());
         assertEquals(KeyMaterialSource.JWKS_URL, migrated.getKeyMaterial().getSource());
         assertEquals("https://issuer.example.com/jwks", migrated.getKeyMaterial().getJwksUrl());
-        assertEquals(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS, migrated.getRefreshIntervalSeconds());
+        assertEquals(TrustedDomain.DEFAULT_REFRESH_INTERVAL_SECONDS, migrated.getRefreshIntervalSeconds());
         assertNull(migrated.getAllowedAlgorithms());
     }
 
@@ -93,7 +95,7 @@ class DomainTrustedIssuerUpgraderTest {
         issuer.setUserBindingEnabled(true);
         issuer.setUserBindingCriteria(List.of(criterion("email", "{#token.email}")));
 
-        TrustDomain migrated = migrateOne(domainWith(issuer));
+        TrustedDomain migrated = migrateOne(domainWith(issuer));
 
         assertEquals(Map.of("ext:read", "read"), migrated.getScopeMappings());
         assertTrue(migrated.isUserBindingEnabled());
@@ -125,7 +127,7 @@ class DomainTrustedIssuerUpgraderTest {
 
     @Test
     void shouldDeriveDistinctNamesForIssuersSharingHostButDifferentPath() {
-        List<TrustDomain> migrated = migrate(domainWith(
+        List<TrustedDomain> migrated = migrate(domainWith(
                 jwksIssuer("https://issuer.example.com/realms/one", "https://issuer.example.com/one/jwks"),
                 jwksIssuer("https://issuer.example.com/realms/two", "https://issuer.example.com/two/jwks")));
 
@@ -141,14 +143,14 @@ class DomainTrustedIssuerUpgraderTest {
         Domain backward = domainWith(two, one);
         backward.setId("other-domain-id");
 
-        List<TrustDomain> migrated = migrateAll(forward, backward);
+        List<TrustedDomain> migrated = migrateAll(forward, backward);
 
         assertEquals(namesOf(migrated, DOMAIN_ID), namesOf(migrated, "other-domain-id"));
     }
 
     @Test
     void shouldDisambiguateIssuersSlugifyingToTheSameName() {
-        List<TrustDomain> migrated = migrate(domainWith(
+        List<TrustedDomain> migrated = migrate(domainWith(
                 jwksIssuer("https://issuer.example.com/a-b", "https://issuer.example.com/jwks"),
                 jwksIssuer("https://issuer.example.com/a/b", "https://issuer.example.com/jwks")));
 
@@ -169,45 +171,45 @@ class DomainTrustedIssuerUpgraderTest {
         TrustedIssuer blank = jwksIssuer(" ", "https://issuer.example.com/jwks");
         TrustedIssuer valid = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
 
-        List<TrustDomain> migrated = migrate(domainWith(blank, valid));
+        List<TrustedDomain> migrated = migrate(domainWith(blank, valid));
 
         assertEquals(1, migrated.size());
-        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+        assertEquals("https://issuer.example.com", migrated.get(0).getDomainIdentifier());
     }
 
     @Test
     void shouldLeaveIssuerInlineWhenItIsTooLongToStore() {
-        TrustedIssuer tooLong = jwksIssuer("https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH), "https://issuer.example.com/jwks");
+        TrustedIssuer tooLong = jwksIssuer("https://issuer.example.com/" + "a".repeat(TrustedDomain.ISSUER_MAX_LENGTH), "https://issuer.example.com/jwks");
         TrustedIssuer valid = jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks");
 
-        List<TrustDomain> migrated = migrate(domainWith(tooLong, valid));
+        List<TrustedDomain> migrated = migrate(domainWith(tooLong, valid));
 
         assertEquals(1, migrated.size());
-        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+        assertEquals("https://issuer.example.com", migrated.get(0).getDomainIdentifier());
     }
 
     @Test
     void shouldMigrateIssuerSittingExactlyOnTheStorageLimit() {
-        String issuer = "https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH - "https://issuer.example.com/".length());
+        String issuer = "https://issuer.example.com/" + "a".repeat(TrustedDomain.ISSUER_MAX_LENGTH - "https://issuer.example.com/".length());
 
-        assertEquals(issuer, migrateOne(domainWith(jwksIssuer(issuer, "https://issuer.example.com/jwks"))).getIssuer());
+        assertEquals(issuer, migrateOne(domainWith(jwksIssuer(issuer, "https://issuer.example.com/jwks"))).getDomainIdentifier());
     }
 
     @Test
     void shouldLeaveSpiffeTrustDomainsUntouched() {
         Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
-        TrustDomain spiffe = TrustDomain.builder()
+        TrustedDomain spiffe = TrustedDomain.builder()
                 .id("spiffe-id")
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(DOMAIN_ID)
                 .name("spiffe-label")
-                .spiffeTrustDomain("issuer.example.com")
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("issuer.example.com").build())
                 .build();
 
-        List<TrustDomain> migrated = migrate(domain, spiffe);
+        List<TrustedDomain> migrated = migrate(domain, spiffe);
 
         assertEquals(1, migrated.size());
-        assertEquals("https://issuer.example.com", migrated.get(0).getIssuer());
+        assertEquals("https://issuer.example.com", migrated.get(0).getDomainIdentifier());
         verify(trustDomainRepository, never()).update(any());
         verify(trustDomainRepository, never()).delete(any());
     }
@@ -234,17 +236,17 @@ class DomainTrustedIssuerUpgraderTest {
                 jwksIssuer("https://one.example.com", "https://one.example.com/jwks"),
                 jwksIssuer("https://two.example.com", "https://two.example.com/jwks"));
 
-        List<TrustDomain> migrated = migrate(domain, alreadyMigrated("https://one.example.com"));
+        List<TrustedDomain> migrated = migrate(domain, alreadyMigrated("https://one.example.com"));
 
         assertEquals(1, migrated.size());
-        assertEquals("https://two.example.com", migrated.get(0).getIssuer());
+        assertEquals("https://two.example.com", migrated.get(0).getDomainIdentifier());
     }
 
     @Test
     void shouldDisambiguateWhenTheDerivedNameIsAlreadyHeld() {
         Domain domain = domainWith(jwksIssuer("https://issuer.example.com", "https://issuer.example.com/jwks"));
 
-        TrustDomain migrated = migrateOne(domain, squatter("https-issuer.example.com"));
+        TrustedDomain migrated = migrateOne(domain, squatter("https-issuer.example.com"));
 
         assertEquals("https-issuer.example.com-605ec2f1", migrated.getName());
     }
@@ -283,9 +285,9 @@ class DomainTrustedIssuerUpgraderTest {
         TrustedIssuer issuer = new TrustedIssuer();
         issuer.setIssuer("https://issuer.example.com");
 
-        TrustDomain migrated = migrateOne(domainWith(issuer));
+        TrustedDomain migrated = migrateOne(domainWith(issuer));
 
-        assertEquals("https://issuer.example.com", migrated.getIssuer());
+        assertEquals("https://issuer.example.com", migrated.getDomainIdentifier());
         assertNull(migrated.getKeyMaterial());
     }
 
@@ -327,13 +329,13 @@ class DomainTrustedIssuerUpgraderTest {
         verify(trustDomainRepository, never()).create(any());
     }
 
-    private TrustDomain migrateOne(Domain domain, TrustDomain... existing) {
-        List<TrustDomain> migrated = migrate(domain, existing);
+    private TrustedDomain migrateOne(Domain domain, TrustedDomain... existing) {
+        List<TrustedDomain> migrated = migrate(domain, existing);
         assertEquals(1, migrated.size());
         return migrated.get(0);
     }
 
-    private List<TrustDomain> migrateAll(Domain... domains) {
+    private List<TrustedDomain> migrateAll(Domain... domains) {
         initializeSystemTask();
         stubDomainUpdate();
         when(domainService.listAll()).thenReturn(Flowable.fromArray(domains));
@@ -341,7 +343,7 @@ class DomainTrustedIssuerUpgraderTest {
         return captureCreated();
     }
 
-    private List<TrustDomain> migrate(Domain domain, TrustDomain... existing) {
+    private List<TrustedDomain> migrate(Domain domain, TrustedDomain... existing) {
         initializeSystemTask();
         stubDomainUpdate();
         when(domainService.listAll()).thenReturn(Flowable.just(domain));
@@ -350,8 +352,8 @@ class DomainTrustedIssuerUpgraderTest {
         return captureCreated();
     }
 
-    private List<TrustDomain> captureCreated() {
-        ArgumentCaptor<TrustDomain> captor = ArgumentCaptor.forClass(TrustDomain.class);
+    private List<TrustedDomain> captureCreated() {
+        ArgumentCaptor<TrustedDomain> captor = ArgumentCaptor.forClass(TrustedDomain.class);
         when(trustDomainRepository.create(captor.capture())).thenAnswer(i -> Single.just(i.getArgument(0)));
 
         assertTrue(upgrader.upgrade());
@@ -375,31 +377,33 @@ class DomainTrustedIssuerUpgraderTest {
         });
     }
 
-    private static List<String> namesOf(List<TrustDomain> migrated, String referenceId) {
+    private static List<String> namesOf(List<TrustedDomain> migrated, String referenceId) {
         return migrated.stream()
                 .filter(trustDomain -> referenceId.equals(trustDomain.getReferenceId()))
-                .map(TrustDomain::getName)
+                .map(TrustedDomain::getName)
                 .sorted()
                 .toList();
     }
 
-    private static TrustDomain squatter(String name) {
-        return TrustDomain.builder()
+    private static TrustedDomain squatter(String name) {
+        return TrustedDomain.builder()
                 .id("squatter-" + name)
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(DOMAIN_ID)
                 .name(name)
-                .issuer("https://other.example.com")
+                .domainIdentifier("https://other.example.com")
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 
-    private static TrustDomain alreadyMigrated(String issuer) {
-        return TrustDomain.builder()
+    private static TrustedDomain alreadyMigrated(String issuer) {
+        return TrustedDomain.builder()
                 .id("existing-" + issuer)
                 .referenceType(ReferenceType.DOMAIN)
                 .referenceId(DOMAIN_ID)
                 .name("already-migrated")
-                .issuer(issuer)
+                .domainIdentifier(issuer)
+                .tokenExchange(new TokenExchangeTrustSettings())
                 .build();
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjectionTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/trustdomain/TrustedIssuerProjectionTest.java
@@ -23,11 +23,15 @@ import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.TrustedIssuer;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.service.TrustDomainService;
 import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -103,15 +107,15 @@ class TrustedIssuerProjectionTest {
     void shouldCreateATrustedDomainForAWrittenIssuer() {
         Domain domain = domain();
         stubExisting();
-        when(trustDomainService.create(eq(domain), any(NewTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.create(eq(domain), any(NewTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
 
         projection.apply(domain, List.of(jwksIssuer(ISSUER)), principal).blockingAwait();
 
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
         verify(trustDomainService).create(eq(domain), captor.capture(), eq(principal));
         assertEquals("https-issuer.example.com", captor.getValue().getName());
-        assertEquals(ISSUER, captor.getValue().getIssuer());
+        assertEquals(ISSUER, captor.getValue().getDomainIdentifier());
         assertEquals(KeyMaterialSource.JWKS_URL, captor.getValue().getKeyMaterial().getSource());
         assertEquals(ISSUER + "/keys", captor.getValue().getKeyMaterial().getJwksUrl());
     }
@@ -120,17 +124,17 @@ class TrustedIssuerProjectionTest {
     void shouldAmendTheTrustedDomainAlreadyVouchingForAWrittenIssuer() {
         Domain domain = domain();
         stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER));
-        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
 
         TrustedIssuer written = jwksIssuer(ISSUER);
         written.setScopeMappings(Map.of("ext:write", "write"));
         projection.apply(domain, List.of(written), principal).blockingAwait();
 
-        ArgumentCaptor<UpdateTrustDomain> captor = ArgumentCaptor.forClass(UpdateTrustDomain.class);
+        ArgumentCaptor<UpdateTrustedDomain> captor = ArgumentCaptor.forClass(UpdateTrustedDomain.class);
         verify(trustDomainService).update(eq(domain), eq("td-1"), captor.capture(), eq(principal));
-        assertEquals(Map.of("ext:write", "write"), captor.getValue().getScopeMappings());
-        verify(trustDomainService, never()).create(any(), any(), any());
+        assertEquals(Map.of("ext:write", "write"), captor.getValue().getTokenExchange().getScopeMappings());
+        verify(trustDomainService, never()).create(any(), any(NewTrustedDomain.class), any());
     }
 
     @Test
@@ -138,8 +142,8 @@ class TrustedIssuerProjectionTest {
         Domain domain = domain();
         stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER),
                 tokenExchange("td-2", "https-other.example.com", "https://other.example.com"));
-        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
         when(trustDomainService.delete(eq(domain), anyString(), any())).thenReturn(Completable.complete());
 
         projection.apply(domain, List.of(jwksIssuer(ISSUER)), principal).blockingAwait();
@@ -152,14 +156,14 @@ class TrustedIssuerProjectionTest {
     void shouldDisambiguateAWrittenIssuerWhoseDerivedNameIsAlreadyHeld() {
         Domain domain = domain();
         stubExisting(tokenExchange("td-1", "https-issuer.example.com", ISSUER));
-        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
-        when(trustDomainService.create(eq(domain), any(NewTrustDomain.class), any()))
-                .thenReturn(Single.just(new TrustDomain()));
+        when(trustDomainService.update(eq(domain), anyString(), any(UpdateTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
+        when(trustDomainService.create(eq(domain), any(NewTrustedDomain.class), any()))
+                .thenReturn(Single.just(new TrustedDomain()));
 
         projection.apply(domain, List.of(jwksIssuer(ISSUER), jwksIssuer(ISSUER + "/")), principal).blockingAwait();
 
-        ArgumentCaptor<NewTrustDomain> captor = ArgumentCaptor.forClass(NewTrustDomain.class);
+        ArgumentCaptor<NewTrustedDomain> captor = ArgumentCaptor.forClass(NewTrustedDomain.class);
         verify(trustDomainService).create(eq(domain), captor.capture(), eq(principal));
         assertNotEquals("https-issuer.example.com", captor.getValue().getName());
         assertTrue(captor.getValue().getName().startsWith("https-issuer.example.com-"));
@@ -183,11 +187,11 @@ class TrustedIssuerProjectionTest {
         projection.apply(domain, null, principal).blockingAwait();
 
         verify(trustDomainService, never()).findByReference(any(), any());
-        verify(trustDomainService, never()).create(any(), any(), any());
+        verify(trustDomainService, never()).create(any(), any(NewTrustedDomain.class), any());
         verify(trustDomainService, never()).delete(any(), any(), any());
     }
 
-    private void stubExisting(TrustDomain... trustDomains) {
+    private void stubExisting(TrustedDomain... trustDomains) {
         when(trustDomainService.findByReference(ReferenceType.DOMAIN, DOMAIN_ID))
                 .thenReturn(Flowable.fromArray(trustDomains));
     }
@@ -207,25 +211,28 @@ class TrustedIssuerProjectionTest {
         return trustedIssuer;
     }
 
-    private static TrustDomain tokenExchange(String id, String name, String issuer) {
+    private static TrustedDomain tokenExchange(String id, String name, String issuer) {
         UserBindingCriterion criterion = new UserBindingCriterion();
         criterion.setAttribute("email");
         criterion.setExpression("{#token.email}");
-        return TrustDomain.builder()
+        return TrustedDomain.builder()
                 .id(id)
                 .name(name)
                 .keyMaterial(TrustDomainKeyMaterial.builder()
                         .source(KeyMaterialSource.JWKS_URL)
                         .jwksUrl(issuer + "/keys")
                         .build())
-                .issuer(issuer)
-                .scopeMappings(Map.of("ext:read", "read"))
-                .userBindingEnabled(true)
-                .userBindingCriteria(List.of(criterion))
+                .domainIdentifier(issuer)
+                .tokenExchange(TokenExchangeTrustSettings.builder()
+                        .scopeMappings(Map.of("ext:read", "read"))
+                        .userBindingEnabled(true)
+                        .userBindingCriteria(List.of(criterion))
+                        .build())
                 .build();
     }
 
-    private static TrustDomain spiffe(String id, String name) {
-        return TrustDomain.builder().id(id).name(name).spiffeTrustDomain(name).build();
+    private static TrustedDomain spiffe(String id, String name) {
+        return TrustedDomain.builder().id(id).name(name)
+                .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain(name).build()).build();
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/application/SpiffeApplicationSettings.java
@@ -29,7 +29,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class SpiffeApplicationSettings {
 
-    /** Name of the {@code TrustDomain} this application authenticates against. */
+    /** Name of the {@code TrustedDomain} this application authenticates against. */
     private String trustDomain;
 
     /** SPIFFE ID expected in the SVID's {@code sub} claim. Interpreted per {@link #subjectMatchMode}. */

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/KeyMaterialSource.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/KeyMaterialSource.java
@@ -16,8 +16,8 @@
 package io.gravitee.am.model.oidc;
 
 /**
- * Where the signing keys of a {@link TrustDomain} come from. All sources are legal for every
- * {@link TrustDomain}.
+ * Where the signing keys of a {@link TrustedDomain} come from. All sources are legal for every
+ * {@link TrustedDomain}.
  *
  * @author GraviteeSource Team
  */

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeBundleSource.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeBundleSource.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.model.oidc;
 
 /**
- * How AM obtains the JWT-SVID signing keys for a {@link TrustDomain}.
+ * How AM obtains the JWT-SVID signing keys for a {@link TrustedDomain}.
  *
  * @author GraviteeSource Team
  */

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeTrustSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/SpiffeTrustSettings.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.oidc;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "SPIFFE trust settings",
+        description = "Accepts JWT-SVIDs from this authority as client assertions.")
+public class SpiffeTrustSettings {
+
+    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID, without the "
+            + "\"spiffe://\" scheme. Lowercased on write. Unique within the security domain.",
+            example = "acme.org")
+    private String spiffeTrustDomain;
+
+    @Schema(description = "Signature algorithms accepted for JWT-SVID validation. Defaults to "
+            + "workloadIdentitySettings.defaultAllowedAlgorithms when absent.")
+    private List<String> allowedAlgorithms;
+
+    public SpiffeTrustSettings(SpiffeTrustSettings other) {
+        this.spiffeTrustDomain = other.spiffeTrustDomain;
+        this.allowedAlgorithms = other.allowedAlgorithms == null ? null : new ArrayList<>(other.allowedAlgorithms);
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TokenExchangeTrustSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TokenExchangeTrustSettings.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.oidc;
+
+import io.gravitee.am.model.UserBindingCriterion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "Token exchange trust settings",
+        description = "Accepts this authority's JWTs as subject or actor tokens during an RFC 8693 "
+                + "exchange, matched by domainIdentifier.")
+public class TokenExchangeTrustSettings {
+
+    @Schema(description = "One-to-one mapping from external scope to domain scope. Unmapped issuer "
+            + "scopes are dropped (fail-closed).")
+    private Map<String, String> scopeMappings;
+
+    @Schema(description = "Whether the external JWT subject is resolved to a single domain user using "
+            + "the user binding criteria. When false, a virtual user is built from the token claims only.",
+            defaultValue = "false")
+    private boolean userBindingEnabled;
+
+    @Schema(description = "Criteria used to locate a domain user when user binding is enabled. All "
+            + "criteria are combined with AND.")
+    private List<UserBindingCriterion> userBindingCriteria;
+
+    public TokenExchangeTrustSettings(TokenExchangeTrustSettings other) {
+        this.scopeMappings = other.scopeMappings == null ? null : new LinkedHashMap<>(other.scopeMappings);
+        this.userBindingEnabled = other.userBindingEnabled;
+        this.userBindingCriteria = other.userBindingCriteria == null ? null : new ArrayList<>(other.userBindingCriteria);
+    }
+}

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomain.java
@@ -15,100 +15,32 @@
  */
 package io.gravitee.am.model.oidc;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * External authority an AM domain trusts, and the key material used to verify what it vouches for.
- *
- * <p>A trusted domain declares how tokens are recognised as coming from it: {@code spiffeTrustDomain}
- * matches the trust domain of a JWT-SVID presented as a client assertion, {@code issuer} matches the
- * {@code iss} claim of an external token presented during an RFC 8693 exchange. At least one is
- * required, and setting both lets one authority serve both usages on shared key material.
- *
- * @author GraviteeSource Team
- */
+@Deprecated
 @Getter
 @Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder(toBuilder = true)
+@Schema(deprecated = true, title = "Trust domain",
+        description = "Deprecated: use the /trusted-domains endpoint instead.")
 public class TrustDomain {
-
-    public static final int DEFAULT_REFRESH_INTERVAL_SECONDS = 300;
-
-    public static final int NAME_MAX_LENGTH = 255;
-
-    public static final int SPIFFE_TRUST_DOMAIN_MAX_LENGTH = 255;
-
-    public static final int ISSUER_MAX_LENGTH = 512;
 
     private String id;
     private String referenceId;
     private ReferenceType referenceType;
-
-    /**
-     * Label this trusted domain is known by in the Console and in audit entries. Unique within an AM
-     * domain, and carries no matching semantics.
-     */
-    @Schema(description = "Label the trusted domain is known by. Unique within the security domain.",
-            example = "acme-corp")
     private String name;
-
     private String description;
-
-    /**
-     * Trust domain as it appears in the SPIFFE IDs this authority issues, matched against the
-     * {@code sub} of a JWT-SVID. Null when this authority is not trusted for SPIFFE.
-     */
-    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID, without the "
-            + "\"spiffe://\" scheme. Required to accept SPIFFE client assertions.",
-            example = "acme.org")
-    private String spiffeTrustDomain;
-
-    /**
-     * Value of the {@code iss} claim this authority vouches for, matched against external subject and
-     * actor tokens. Null when this authority is not trusted for token exchange.
-     */
-    @Schema(description = "Expected value of the \"iss\" claim in an external JWT. Required to accept "
-            + "tokens during an RFC 8693 exchange.",
-            example = "https://sso.acme.com")
-    private String issuer;
-
+    private String domainIdentifier;
     private TrustDomainKeyMaterial keyMaterial;
-
-    private int refreshIntervalSeconds = DEFAULT_REFRESH_INTERVAL_SECONDS;
-
-    /**
-     * Optional override of {@link SpiffeDomainSettings#getDefaultAllowedAlgorithms()}.
-     */
-    private List<String> allowedAlgorithms;
-
-    @Schema(description = "One-to-one mapping from external scope to domain scope. Unmapped issuer scopes "
-            + "are dropped (fail-closed). Applies to tokens matched by \"issuer\".")
-    private Map<String, String> scopeMappings;
-
-    @Schema(description = "Whether the external JWT subject is resolved to a single domain user using the "
-            + "user binding criteria. When false, a virtual user is built from the token claims only.",
-            defaultValue = "false")
-    private boolean userBindingEnabled;
-
-    @Schema(description = "Criteria used to locate a domain user when user binding is enabled. All criteria "
-            + "are combined with AND.")
-    private List<UserBindingCriterion> userBindingCriteria;
+    private SpiffeTrustSettings spiffe;
+    private TokenExchangeTrustSettings tokenExchange;
 
     @Schema(type = "java.lang.Long")
     private Date createdAt;
@@ -116,71 +48,73 @@ public class TrustDomain {
     @Schema(type = "java.lang.Long")
     private Date updatedAt;
 
-    public TrustDomain(TrustDomain other) {
-        this.id = other.id;
-        this.referenceId = other.referenceId;
-        this.referenceType = other.referenceType;
-        this.name = other.name;
-        this.description = other.description;
-        this.spiffeTrustDomain = other.spiffeTrustDomain;
-        this.issuer = other.issuer;
-        this.keyMaterial = other.keyMaterial != null ? new TrustDomainKeyMaterial(other.keyMaterial) : null;
-        this.refreshIntervalSeconds = other.refreshIntervalSeconds;
-        this.allowedAlgorithms = other.allowedAlgorithms;
-        this.scopeMappings = other.scopeMappings != null ? new LinkedHashMap<>(other.scopeMappings) : null;
-        this.userBindingEnabled = other.userBindingEnabled;
-        this.userBindingCriteria = other.userBindingCriteria != null ? new ArrayList<>(other.userBindingCriteria) : null;
-        this.createdAt = other.createdAt;
-        this.updatedAt = other.updatedAt;
-    }
+    @Schema(deprecated = true, description = "Use spiffe.spiffeTrustDomain instead.")
+    private String spiffeTrustDomain;
 
-    /**
-     * Whether this authority is trusted for SPIFFE client assertions.
-     */
-    public boolean trustsSpiffe() {
-        return spiffeTrustDomain != null;
-    }
+    @Schema(deprecated = true, description = "Use domainIdentifier instead.")
+    private String issuer;
 
-    /**
-     * Whether this authority is trusted for RFC 8693 token exchange.
-     */
-    public boolean trustsTokenExchange() {
-        return issuer != null;
-    }
+    @Schema(deprecated = true, description = "Use keyMaterial.refreshIntervalSeconds instead.")
+    private int refreshIntervalSeconds;
 
-    /**
-     * @deprecated superseded by {@link #getKeyMaterial()}; PEM key material has no representation here.
-     */
-    @Deprecated
-    @JsonProperty
+    @Schema(deprecated = true, description = "Use spiffe.allowedAlgorithms instead.")
+    private List<String> allowedAlgorithms;
+
+    @Schema(deprecated = true, description = "Use tokenExchange.scopeMappings instead.")
+    private Map<String, String> scopeMappings;
+
+    @Schema(deprecated = true, description = "Use tokenExchange.userBindingEnabled instead.")
+    private boolean userBindingEnabled;
+
+    @Schema(deprecated = true, description = "Use tokenExchange.userBindingCriteria instead.")
+    private List<UserBindingCriterion> userBindingCriteria;
+
     @Schema(deprecated = true, description = "Use keyMaterial.source instead. Null when the key material is a PEM certificate.")
-    public SpiffeBundleSource getBundleSource() {
-        if (keyMaterial == null || keyMaterial.getSource() == null) {
+    private SpiffeBundleSource bundleSource;
+
+    @Schema(deprecated = true, description = "Use keyMaterial.jwksUrl instead.")
+    private String jwksUrl;
+
+    @Schema(deprecated = true, description = "Use keyMaterial.jwkSet instead.")
+    private JWKSet staticJwks;
+
+    public static TrustDomain from(TrustedDomain trustedDomain) {
+        if (trustedDomain == null) {
             return null;
         }
-        return switch (keyMaterial.getSource()) {
-            case JWKS_URL -> SpiffeBundleSource.JWKS_URL;
-            case JWK_SET -> SpiffeBundleSource.STATIC_JWKS;
-            case PEM -> null;
-        };
-    }
+        TrustDomain td = new TrustDomain();
+        td.setId(trustedDomain.getId());
+        td.setReferenceId(trustedDomain.getReferenceId());
+        td.setReferenceType(trustedDomain.getReferenceType());
+        td.setName(trustedDomain.getName());
+        td.setDescription(trustedDomain.getDescription());
+        td.setDomainIdentifier(trustedDomain.getDomainIdentifier());
+        td.setKeyMaterial(trustedDomain.getKeyMaterial());
+        td.setSpiffe(trustedDomain.getSpiffe());
+        td.setTokenExchange(trustedDomain.getTokenExchange());
+        td.setCreatedAt(trustedDomain.getCreatedAt());
+        td.setUpdatedAt(trustedDomain.getUpdatedAt());
 
-    /**
-     * @deprecated superseded by {@link #getKeyMaterial()}.
-     */
-    @Deprecated
-    @JsonProperty
-    @Schema(deprecated = true, description = "Use keyMaterial.jwksUrl instead.")
-    public String getJwksUrl() {
-        return keyMaterial != null ? keyMaterial.getJwksUrl() : null;
-    }
+        td.setSpiffeTrustDomain(trustedDomain.getSpiffeTrustDomain());
+        td.setIssuer(trustedDomain.getDomainIdentifier());
+        td.setRefreshIntervalSeconds(trustedDomain.getRefreshIntervalSeconds());
+        td.setAllowedAlgorithms(trustedDomain.getAllowedAlgorithms());
+        td.setScopeMappings(trustedDomain.getScopeMappings());
+        td.setUserBindingEnabled(trustedDomain.isUserBindingEnabled());
+        td.setUserBindingCriteria(trustedDomain.getUserBindingCriteria());
 
-    /**
-     * @deprecated superseded by {@link #getKeyMaterial()}.
-     */
-    @Deprecated
-    @JsonProperty
-    public JWKSet getStaticJwks() {
-        return keyMaterial != null ? keyMaterial.getJwkSet() : null;
+        TrustDomainKeyMaterial keyMaterial = trustedDomain.getKeyMaterial();
+        if (keyMaterial != null) {
+            td.setJwksUrl(keyMaterial.getJwksUrl());
+            td.setStaticJwks(keyMaterial.getJwkSet());
+            if (keyMaterial.getSource() != null) {
+                td.setBundleSource(switch (keyMaterial.getSource()) {
+                    case JWKS_URL -> SpiffeBundleSource.JWKS_URL;
+                    case JWK_SET -> SpiffeBundleSource.STATIC_JWKS;
+                    case PEM -> null;
+                });
+            }
+        }
+        return td;
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomainKeyMaterial.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustDomainKeyMaterial.java
@@ -43,6 +43,10 @@ public class TrustDomainKeyMaterial {
             example = "https://issuer.example.com/.well-known/jwks.json")
     private String jwksUrl;
 
+    @Schema(description = "How often the JWKS endpoint is re-polled, clamped by "
+            + "keyRetrievalSettings.cacheTtlSeconds. Applies only when source is JWKS_URL.")
+    private Integer refreshIntervalSeconds;
+
     @Schema(description = "Inline JWK set. Required when source is JWK_SET.")
     private JWKSet jwkSet;
 
@@ -66,6 +70,7 @@ public class TrustDomainKeyMaterial {
     public TrustDomainKeyMaterial(TrustDomainKeyMaterial other) {
         this.source = other.source;
         this.jwksUrl = other.jwksUrl;
+        this.refreshIntervalSeconds = other.refreshIntervalSeconds;
         this.jwkSet = cloneJwkSet(other.jwkSet);
         this.certificate = other.certificate;
     }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustedDomain.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/TrustedDomain.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.model.oidc;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.gravitee.am.model.ReferenceType;
+import io.gravitee.am.model.UserBindingCriterion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TrustedDomain {
+
+    public static final int NAME_MAX_LENGTH = 255;
+
+    public static final int SPIFFE_TRUST_DOMAIN_MAX_LENGTH = 255;
+
+    public static final int ISSUER_MAX_LENGTH = 512;
+
+    public static final int DEFAULT_REFRESH_INTERVAL_SECONDS = 300;
+
+    private String id;
+    private String referenceId;
+    private ReferenceType referenceType;
+
+    @Schema(description = "Label the trusted domain is known by. Unique within the security domain.",
+            example = "acme-corp")
+    private String name;
+
+    private String description;
+
+    @Schema(description = "Issuer identifier of this authority's authorization server. Matched against "
+            + "the \"iss\" of an external JWT during an RFC 8693 exchange.",
+            example = "https://sso.acme.com")
+    private String domainIdentifier;
+
+    private TrustDomainKeyMaterial keyMaterial;
+
+    @Schema(description = "Accepts JWT-SVIDs from this authority as client assertions. Absent when this "
+            + "authority is not trusted for SPIFFE.")
+    private SpiffeTrustSettings spiffe;
+
+    @Schema(description = "Accepts this authority's JWTs as subject or actor tokens during an RFC 8693 "
+            + "exchange. Absent when this authority is not trusted for token exchange.")
+    private TokenExchangeTrustSettings tokenExchange;
+
+    @Schema(type = "java.lang.Long")
+    private Date createdAt;
+
+    @Schema(type = "java.lang.Long")
+    private Date updatedAt;
+
+    @Builder
+    public TrustedDomain(String id,
+                         String referenceId,
+                         ReferenceType referenceType,
+                         String name,
+                         String description,
+                         String domainIdentifier,
+                         TrustDomainKeyMaterial keyMaterial,
+                         SpiffeTrustSettings spiffe,
+                         TokenExchangeTrustSettings tokenExchange,
+                         Date createdAt,
+                         Date updatedAt) {
+        this.id = id;
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+        this.name = name;
+        this.description = description;
+        this.domainIdentifier = domainIdentifier;
+        this.keyMaterial = keyMaterial;
+        this.spiffe = spiffe;
+        this.tokenExchange = tokenExchange;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public TrustedDomain(TrustedDomain other) {
+        this.id = other.id;
+        this.referenceId = other.referenceId;
+        this.referenceType = other.referenceType;
+        this.name = other.name;
+        this.description = other.description;
+        this.domainIdentifier = other.domainIdentifier;
+        this.keyMaterial = other.keyMaterial != null ? new TrustDomainKeyMaterial(other.keyMaterial) : null;
+        this.spiffe = other.spiffe != null ? new SpiffeTrustSettings(other.spiffe) : null;
+        this.tokenExchange = other.tokenExchange != null ? new TokenExchangeTrustSettings(other.tokenExchange) : null;
+        this.createdAt = other.createdAt;
+        this.updatedAt = other.updatedAt;
+    }
+
+    public boolean trustsSpiffe() {
+        return spiffe != null && spiffe.getSpiffeTrustDomain() != null;
+    }
+
+    public boolean trustsTokenExchange() {
+        return tokenExchange != null && domainIdentifier != null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public String getSpiffeTrustDomain() {
+        return spiffe != null ? spiffe.getSpiffeTrustDomain() : null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public List<String> getAllowedAlgorithms() {
+        return spiffe != null ? spiffe.getAllowedAlgorithms() : null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public Map<String, String> getScopeMappings() {
+        return tokenExchange != null ? tokenExchange.getScopeMappings() : null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public boolean isUserBindingEnabled() {
+        return tokenExchange != null && tokenExchange.isUserBindingEnabled();
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public List<UserBindingCriterion> getUserBindingCriteria() {
+        return tokenExchange != null ? tokenExchange.getUserBindingCriteria() : null;
+    }
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    public int getRefreshIntervalSeconds() {
+        if (keyMaterial == null || keyMaterial.getRefreshIntervalSeconds() == null) {
+            return DEFAULT_REFRESH_INTERVAL_SECONDS;
+        }
+        return keyMaterial.getRefreshIntervalSeconds();
+    }
+}

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/TrustedDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/TrustedDomainRepository.java
@@ -16,7 +16,7 @@
 package io.gravitee.am.repository.management.api;
 
 import io.gravitee.am.model.ReferenceType;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.repository.common.CrudRepository;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -24,24 +24,24 @@ import io.reactivex.rxjava3.core.Maybe;
 /**
  * @author GraviteeSource Team
  */
-public interface TrustDomainRepository extends CrudRepository<TrustDomain, String> {
+public interface TrustedDomainRepository extends CrudRepository<TrustedDomain, String> {
 
-    Flowable<TrustDomain> findByReference(ReferenceType referenceType, String referenceId);
+    Flowable<TrustedDomain> findByReference(ReferenceType referenceType, String referenceId);
 
     /**
      * Finds a trusted domain by the label it is known by. Labels are unique per reference.
      */
-    Maybe<TrustDomain> findByName(ReferenceType referenceType, String referenceId, String name);
+    Maybe<TrustedDomain> findByName(ReferenceType referenceType, String referenceId, String name);
 
     /**
      * Finds the trusted domain that vouches for a SPIFFE trust domain. Unique per reference, and
      * absent on trusted domains that are not trusted for SPIFFE.
      */
-    Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain);
+    Maybe<TrustedDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain);
 
     /**
      * Finds the trusted domain vouching for an issuer. Unique per reference, and absent on trusted
      * domains that are not trusted for token exchange.
      */
-    Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer);
+    Maybe<TrustedDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer);
 }

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustedDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustedDomainRepository.java
@@ -23,12 +23,14 @@ import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.JWKModule;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcTrustDomain;
-import io.gravitee.am.repository.jdbc.management.api.spring.SpringTrustDomainRepository;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.jdbc.management.api.spring.SpringTrustedDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -43,7 +45,7 @@ import java.util.Map;
 import static reactor.adapter.rxjava.RxJava3Adapter.monoToSingle;
 
 @Repository
-public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements TrustDomainRepository {
+public class JdbcTrustedDomainRepository extends AbstractJdbcRepository implements TrustedDomainRepository {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JWKModule());
     private static final TypeReference<List<String>> STRING_LIST = new TypeReference<>() {};
@@ -52,10 +54,10 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     private static final TypeReference<TrustDomainKeyMaterial> KEY_MATERIAL = new TypeReference<>() {};
 
     @Autowired
-    private SpringTrustDomainRepository repository;
+    private SpringTrustedDomainRepository repository;
 
     @Override
-    public Maybe<TrustDomain> findById(String id) {
+    public Maybe<TrustedDomain> findById(String id) {
         LOGGER.debug("findById({})", id);
         return repository.findById(id)
                 .map(this::toEntity)
@@ -63,7 +65,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Single<TrustDomain> create(TrustDomain item) {
+    public Single<TrustedDomain> create(TrustedDomain item) {
         item.setId(item.getId() == null ? RandomString.generate() : item.getId());
         LOGGER.debug("Create trust domain with id {}", item.getId());
         return monoToSingle(getTemplate().insert(toJdbcEntity(item)))
@@ -72,7 +74,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Single<TrustDomain> update(TrustDomain item) {
+    public Single<TrustedDomain> update(TrustedDomain item) {
         LOGGER.debug("Update trust domain with id {}", item.getId());
         return repository.save(toJdbcEntity(item))
                 .map(this::toEntity)
@@ -87,7 +89,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Flowable<TrustDomain> findByReference(ReferenceType referenceType, String referenceId) {
+    public Flowable<TrustedDomain> findByReference(ReferenceType referenceType, String referenceId) {
         LOGGER.debug("findByReference({}, {})", referenceType, referenceId);
         return repository.findByReference(referenceType.name(), referenceId)
                 .map(this::toEntity)
@@ -95,7 +97,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Maybe<TrustDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
+    public Maybe<TrustedDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
         LOGGER.debug("findByName({}, {}, {})", referenceType, referenceId, name);
         return repository.findByName(referenceType.name(), referenceId, name)
                 .map(this::toEntity)
@@ -103,7 +105,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
+    public Maybe<TrustedDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
         LOGGER.debug("findBySpiffeTrustDomain({}, {}, {})", referenceType, referenceId, spiffeTrustDomain);
         return repository.findBySpiffeTrustDomain(referenceType.name(), referenceId, spiffeTrustDomain)
                 .map(this::toEntity)
@@ -111,37 +113,33 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
     }
 
     @Override
-    public Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
+    public Maybe<TrustedDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
         LOGGER.debug("findByIssuer({}, {}, {})", referenceType, referenceId, issuer);
         return repository.findByIssuer(referenceType.name(), referenceId, issuer)
                 .map(this::toEntity)
                 .observeOn(Schedulers.computation());
     }
 
-    private TrustDomain toEntity(JdbcTrustDomain entity) {
+    private TrustedDomain toEntity(JdbcTrustDomain entity) {
         if (entity == null) {
             return null;
         }
-        TrustDomain td = new TrustDomain();
+        TrustedDomain td = new TrustedDomain();
         td.setId(entity.getId());
         td.setReferenceId(entity.getReferenceId());
         td.setReferenceType(entity.getReferenceType() != null ? ReferenceType.valueOf(entity.getReferenceType()) : null);
         td.setName(entity.getName());
         td.setDescription(entity.getDescription());
-        td.setSpiffeTrustDomain(readSpiffeTrustDomain(entity));
-        td.setIssuer(entity.getIssuer());
+        td.setDomainIdentifier(entity.getIssuer());
         td.setKeyMaterial(readKeyMaterial(entity));
-        td.setRefreshIntervalSeconds(entity.getRefreshIntervalSeconds());
-        td.setAllowedAlgorithms(parseJson(entity.getAllowedAlgorithms(), STRING_LIST, "allowed algorithms"));
-        td.setScopeMappings(parseJson(entity.getScopeMappings(), STRING_MAP, "scope mappings"));
-        td.setUserBindingEnabled(Boolean.TRUE.equals(entity.getUserBindingEnabled()));
-        td.setUserBindingCriteria(parseJson(entity.getUserBindingCriteria(), CRITERION_LIST, "user binding criteria"));
+        td.setSpiffe(readSpiffe(entity));
+        td.setTokenExchange(readTokenExchange(entity));
         td.setCreatedAt(toDate(entity.getCreatedAt()));
         td.setUpdatedAt(toDate(entity.getUpdatedAt()));
         return td;
     }
 
-    private JdbcTrustDomain toJdbcEntity(TrustDomain td) {
+    private JdbcTrustDomain toJdbcEntity(TrustedDomain td) {
         if (td == null) {
             return null;
         }
@@ -152,7 +150,7 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
         entity.setName(td.getName());
         entity.setDescription(td.getDescription());
         entity.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
-        entity.setIssuer(td.getIssuer());
+        entity.setIssuer(td.getDomainIdentifier());
         entity.setKeyMaterial(serializeJson(td.getKeyMaterial(), "key material"));
         entity.setRefreshIntervalSeconds(td.getRefreshIntervalSeconds());
         entity.setAllowedAlgorithms(serializeJson(td.getAllowedAlgorithms(), "allowed algorithms"));
@@ -169,12 +167,38 @@ public class JdbcTrustDomainRepository extends AbstractJdbcRepository implements
      * trust domains stored before it existed.
      */
     static TrustDomainKeyMaterial readKeyMaterial(JdbcTrustDomain entity) {
-        if (entity.getKeyMaterial() != null && !entity.getKeyMaterial().isBlank()) {
-            return parseJson(entity.getKeyMaterial(), KEY_MATERIAL, "key material");
+        TrustDomainKeyMaterial model = entity.getKeyMaterial() != null && !entity.getKeyMaterial().isBlank()
+                ? parseJson(entity.getKeyMaterial(), KEY_MATERIAL, "key material")
+                : TrustDomainKeyMaterial.fromBundleSource(
+                        entity.getBundleSource() != null ? SpiffeBundleSource.valueOf(entity.getBundleSource()) : null,
+                        entity.getJwksUrl());
+        if (model != null) {
+            model.setRefreshIntervalSeconds(entity.getRefreshIntervalSeconds());
         }
-        return TrustDomainKeyMaterial.fromBundleSource(
-                entity.getBundleSource() != null ? SpiffeBundleSource.valueOf(entity.getBundleSource()) : null,
-                entity.getJwksUrl());
+        return model;
+    }
+
+    static SpiffeTrustSettings readSpiffe(JdbcTrustDomain entity) {
+        String spiffeTrustDomain = readSpiffeTrustDomain(entity);
+        List<String> allowedAlgorithms = parseJson(entity.getAllowedAlgorithms(), STRING_LIST, "allowed algorithms");
+        if (spiffeTrustDomain == null && allowedAlgorithms == null) {
+            return null;
+        }
+        return SpiffeTrustSettings.builder()
+                .spiffeTrustDomain(spiffeTrustDomain)
+                .allowedAlgorithms(allowedAlgorithms)
+                .build();
+    }
+
+    static TokenExchangeTrustSettings readTokenExchange(JdbcTrustDomain entity) {
+        if (entity.getIssuer() == null) {
+            return null;
+        }
+        return TokenExchangeTrustSettings.builder()
+                .scopeMappings(parseJson(entity.getScopeMappings(), STRING_MAP, "scope mappings"))
+                .userBindingEnabled(Boolean.TRUE.equals(entity.getUserBindingEnabled()))
+                .userBindingCriteria(parseJson(entity.getUserBindingCriteria(), CRITERION_LIST, "user binding criteria"))
+                .build();
     }
 
     /**

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringTrustedDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/spring/SpringTrustedDomainRepository.java
@@ -22,7 +22,7 @@ import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.repository.reactive.RxJava3CrudRepository;
 
-public interface SpringTrustDomainRepository extends RxJava3CrudRepository<JdbcTrustDomain, String> {
+public interface SpringTrustedDomainRepository extends RxJava3CrudRepository<JdbcTrustDomain, String> {
 
     @Query("select * from trust_domains where reference_type = :refType and reference_id = :refId")
     Flowable<JdbcTrustDomain> findByReference(@Param("refType") String refType, @Param("refId") String refId);

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainLegacyMappingTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/test/java/io/gravitee/am/repository/jdbc/management/api/JdbcTrustDomainLegacyMappingTest.java
@@ -33,7 +33,7 @@ public class JdbcTrustDomainLegacyMappingTest {
         JdbcTrustDomain legacy = new JdbcTrustDomain();
         legacy.setName("example.org");
 
-        assertEquals("example.org", JdbcTrustDomainRepository.readSpiffeTrustDomain(legacy));
+        assertEquals("example.org", JdbcTrustedDomainRepository.readSpiffeTrustDomain(legacy));
     }
 
     @Test
@@ -42,7 +42,7 @@ public class JdbcTrustDomainLegacyMappingTest {
         migrated.setName("issuer.example");
         migrated.setIssuer("https://issuer.example/realm");
 
-        assertNull(JdbcTrustDomainRepository.readSpiffeTrustDomain(migrated));
+        assertNull(JdbcTrustedDomainRepository.readSpiffeTrustDomain(migrated));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class JdbcTrustDomainLegacyMappingTest {
         row.setName("acme-corp");
         row.setSpiffeTrustDomain("acme.org");
 
-        assertEquals("acme.org", JdbcTrustDomainRepository.readSpiffeTrustDomain(row));
+        assertEquals("acme.org", JdbcTrustedDomainRepository.readSpiffeTrustDomain(row));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class JdbcTrustDomainLegacyMappingTest {
         legacy.setBundleSource("JWKS_URL");
         legacy.setJwksUrl("https://spire.example.org/keys");
 
-        var keyMaterial = JdbcTrustDomainRepository.readKeyMaterial(legacy);
+        var keyMaterial = JdbcTrustedDomainRepository.readKeyMaterial(legacy);
 
         assertEquals(KeyMaterialSource.JWKS_URL, keyMaterial.getSource());
         assertEquals("https://spire.example.org/keys", keyMaterial.getJwksUrl());
@@ -73,7 +73,7 @@ public class JdbcTrustDomainLegacyMappingTest {
         row.setJwksUrl("https://legacy.example.org/keys");
         row.setKeyMaterial("{\"source\":\"PEM\",\"certificate\":\"cert\"}");
 
-        var keyMaterial = JdbcTrustDomainRepository.readKeyMaterial(row);
+        var keyMaterial = JdbcTrustedDomainRepository.readKeyMaterial(row);
 
         assertEquals(KeyMaterialSource.PEM, keyMaterial.getSource());
         assertEquals("cert", keyMaterial.getCertificate());
@@ -82,6 +82,6 @@ public class JdbcTrustDomainLegacyMappingTest {
 
     @Test
     public void shouldReadNoKeyMaterial_whenRowHasNeither() {
-        assertNull(JdbcTrustDomainRepository.readKeyMaterial(new JdbcTrustDomain()));
+        assertNull(JdbcTrustedDomainRepository.readKeyMaterial(new JdbcTrustDomain()));
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTrustedDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoTrustedDomainRepository.java
@@ -25,9 +25,11 @@ import io.gravitee.am.model.jose.JWKModule;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.TrustDomainKeyMaterialMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.TrustDomainMongo;
 import io.gravitee.am.repository.mongodb.management.internal.model.UserBindingCriterionMongo;
@@ -57,7 +59,7 @@ import static io.gravitee.am.repository.mongodb.common.MongoUtils.FIELD_REFERENC
  */
 @Component
 @CustomLog
-public class MongoTrustDomainRepository extends AbstractManagementMongoRepository implements TrustDomainRepository {
+public class MongoTrustedDomainRepository extends AbstractManagementMongoRepository implements TrustedDomainRepository {
 
     private static final String COLLECTION_NAME = "trust_domains";
     private static final String FIELD_NAME = "name";
@@ -100,7 +102,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     }
 
     @Override
-    public Maybe<TrustDomain> findById(String id) {
+    public Maybe<TrustedDomain> findById(String id) {
         return Observable.fromPublisher(collection.find(eq(FIELD_ID, id)).first())
                 .firstElement()
                 .map(this::toEntity)
@@ -108,7 +110,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     }
 
     @Override
-    public Single<TrustDomain> create(TrustDomain item) {
+    public Single<TrustedDomain> create(TrustedDomain item) {
         TrustDomainMongo doc = toMongo(item);
         doc.setId(doc.getId() == null ? RandomString.generate() : doc.getId());
         return Single.fromPublisher(collection.insertOne(doc))
@@ -120,7 +122,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     }
 
     @Override
-    public Single<TrustDomain> update(TrustDomain item) {
+    public Single<TrustedDomain> update(TrustedDomain item) {
         TrustDomainMongo doc = toMongo(item);
         return Single.fromPublisher(collection.replaceOne(eq(FIELD_ID, doc.getId()), doc))
                 .map(updateResult -> item)
@@ -134,7 +136,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     }
 
     @Override
-    public Flowable<TrustDomain> findByReference(ReferenceType referenceType, String referenceId) {
+    public Flowable<TrustedDomain> findByReference(ReferenceType referenceType, String referenceId) {
         return Flowable.fromPublisher(collection.find(and(
                         eq(FIELD_REFERENCE_TYPE, referenceType.name()),
                         eq(FIELD_REFERENCE_ID, referenceId))))
@@ -143,21 +145,21 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
     }
 
     @Override
-    public Maybe<TrustDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
+    public Maybe<TrustedDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
         return findByField(referenceType, referenceId, FIELD_NAME, name);
     }
 
     @Override
-    public Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
+    public Maybe<TrustedDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
         return findByField(referenceType, referenceId, FIELD_SPIFFE_TRUST_DOMAIN, spiffeTrustDomain);
     }
 
     @Override
-    public Maybe<TrustDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
+    public Maybe<TrustedDomain> findByIssuer(ReferenceType referenceType, String referenceId, String issuer) {
         return findByField(referenceType, referenceId, FIELD_ISSUER, issuer);
     }
 
-    private Maybe<TrustDomain> findByField(ReferenceType referenceType, String referenceId, String field, String value) {
+    private Maybe<TrustedDomain> findByField(ReferenceType referenceType, String referenceId, String field, String value) {
         return Observable.fromPublisher(collection.find(and(
                         eq(FIELD_REFERENCE_TYPE, referenceType.name()),
                         eq(FIELD_REFERENCE_ID, referenceId),
@@ -167,30 +169,26 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
                 .observeOn(Schedulers.computation());
     }
 
-    private TrustDomain toEntity(TrustDomainMongo doc) {
+    private TrustedDomain toEntity(TrustDomainMongo doc) {
         if (doc == null) {
             return null;
         }
-        TrustDomain td = new TrustDomain();
+        TrustedDomain td = new TrustedDomain();
         td.setId(doc.getId());
         td.setReferenceId(doc.getReferenceId());
         td.setReferenceType(doc.getReferenceType() != null ? ReferenceType.valueOf(doc.getReferenceType()) : null);
         td.setName(doc.getName());
         td.setDescription(doc.getDescription());
-        td.setSpiffeTrustDomain(readSpiffeTrustDomain(doc));
-        td.setIssuer(doc.getIssuer());
+        td.setDomainIdentifier(doc.getIssuer());
         td.setKeyMaterial(readKeyMaterial(doc));
-        td.setRefreshIntervalSeconds(doc.getRefreshIntervalSeconds());
-        td.setAllowedAlgorithms(doc.getAllowedAlgorithms());
-        td.setScopeMappings(doc.getScopeMappings());
-        td.setUserBindingEnabled(Boolean.TRUE.equals(doc.getUserBindingEnabled()));
-        td.setUserBindingCriteria(UserBindingCriterionMongo.toModelList(doc.getUserBindingCriteria()));
+        td.setSpiffe(readSpiffe(doc));
+        td.setTokenExchange(readTokenExchange(doc));
         td.setCreatedAt(doc.getCreatedAt());
         td.setUpdatedAt(doc.getUpdatedAt());
         return td;
     }
 
-    private TrustDomainMongo toMongo(TrustDomain td) {
+    private TrustDomainMongo toMongo(TrustedDomain td) {
         if (td == null) {
             return null;
         }
@@ -201,7 +199,7 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
         doc.setName(td.getName());
         doc.setDescription(td.getDescription());
         doc.setSpiffeTrustDomain(td.getSpiffeTrustDomain());
-        doc.setIssuer(td.getIssuer());
+        doc.setIssuer(td.getDomainIdentifier());
         doc.setKeyMaterial(toMongo(td.getKeyMaterial()));
         doc.setRefreshIntervalSeconds(td.getRefreshIntervalSeconds());
         doc.setAllowedAlgorithms(td.getAllowedAlgorithms());
@@ -230,17 +228,42 @@ public class MongoTrustDomainRepository extends AbstractManagementMongoRepositor
      */
     static TrustDomainKeyMaterial readKeyMaterial(TrustDomainMongo doc) {
         TrustDomainKeyMaterialMongo keyMaterial = doc.getKeyMaterial();
-        if (keyMaterial != null) {
-            return TrustDomainKeyMaterial.builder()
-                    .source(keyMaterial.getSource() != null ? KeyMaterialSource.valueOf(keyMaterial.getSource()) : null)
-                    .jwksUrl(keyMaterial.getJwksUrl())
-                    .jwkSet(parseJwkSet(keyMaterial.getJwkSet()))
-                    .certificate(keyMaterial.getCertificate())
-                    .build();
+        TrustDomainKeyMaterial model = keyMaterial != null
+                ? TrustDomainKeyMaterial.builder()
+                        .source(keyMaterial.getSource() != null ? KeyMaterialSource.valueOf(keyMaterial.getSource()) : null)
+                        .jwksUrl(keyMaterial.getJwksUrl())
+                        .jwkSet(parseJwkSet(keyMaterial.getJwkSet()))
+                        .certificate(keyMaterial.getCertificate())
+                        .build()
+                : TrustDomainKeyMaterial.fromBundleSource(
+                        doc.getBundleSource() != null ? SpiffeBundleSource.valueOf(doc.getBundleSource()) : null,
+                        doc.getJwksUrl());
+        if (model != null) {
+            model.setRefreshIntervalSeconds(doc.getRefreshIntervalSeconds());
         }
-        return TrustDomainKeyMaterial.fromBundleSource(
-                doc.getBundleSource() != null ? SpiffeBundleSource.valueOf(doc.getBundleSource()) : null,
-                doc.getJwksUrl());
+        return model;
+    }
+
+    static SpiffeTrustSettings readSpiffe(TrustDomainMongo doc) {
+        String spiffeTrustDomain = readSpiffeTrustDomain(doc);
+        if (spiffeTrustDomain == null && doc.getAllowedAlgorithms() == null) {
+            return null;
+        }
+        return SpiffeTrustSettings.builder()
+                .spiffeTrustDomain(spiffeTrustDomain)
+                .allowedAlgorithms(doc.getAllowedAlgorithms())
+                .build();
+    }
+
+    static TokenExchangeTrustSettings readTokenExchange(TrustDomainMongo doc) {
+        if (doc.getIssuer() == null) {
+            return null;
+        }
+        return TokenExchangeTrustSettings.builder()
+                .scopeMappings(doc.getScopeMappings())
+                .userBindingEnabled(Boolean.TRUE.equals(doc.getUserBindingEnabled()))
+                .userBindingCriteria(UserBindingCriterionMongo.toModelList(doc.getUserBindingCriteria()))
+                .build();
     }
 
     private static TrustDomainKeyMaterialMongo toMongo(TrustDomainKeyMaterial keyMaterial) {

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainLegacyMappingTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/test/java/io/gravitee/am/repository/mongodb/management/MongoTrustDomainLegacyMappingTest.java
@@ -34,7 +34,7 @@ public class MongoTrustDomainLegacyMappingTest {
         TrustDomainMongo legacy = new TrustDomainMongo();
         legacy.setName("example.org");
 
-        assertEquals("example.org", MongoTrustDomainRepository.readSpiffeTrustDomain(legacy));
+        assertEquals("example.org", MongoTrustedDomainRepository.readSpiffeTrustDomain(legacy));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class MongoTrustDomainLegacyMappingTest {
         migrated.setName("issuer.example");
         migrated.setIssuer("https://issuer.example/realm");
 
-        assertNull(MongoTrustDomainRepository.readSpiffeTrustDomain(migrated));
+        assertNull(MongoTrustedDomainRepository.readSpiffeTrustDomain(migrated));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class MongoTrustDomainLegacyMappingTest {
         doc.setName("acme-corp");
         doc.setSpiffeTrustDomain("acme.org");
 
-        assertEquals("acme.org", MongoTrustDomainRepository.readSpiffeTrustDomain(doc));
+        assertEquals("acme.org", MongoTrustedDomainRepository.readSpiffeTrustDomain(doc));
     }
 
     @Test
@@ -61,7 +61,7 @@ public class MongoTrustDomainLegacyMappingTest {
         legacy.setBundleSource("JWKS_URL");
         legacy.setJwksUrl("https://spire.example.org/keys");
 
-        var keyMaterial = MongoTrustDomainRepository.readKeyMaterial(legacy);
+        var keyMaterial = MongoTrustedDomainRepository.readKeyMaterial(legacy);
 
         assertEquals(KeyMaterialSource.JWKS_URL, keyMaterial.getSource());
         assertEquals("https://spire.example.org/keys", keyMaterial.getJwksUrl());
@@ -77,7 +77,7 @@ public class MongoTrustDomainLegacyMappingTest {
         keyMaterialMongo.setCertificate("cert");
         doc.setKeyMaterial(keyMaterialMongo);
 
-        var keyMaterial = MongoTrustDomainRepository.readKeyMaterial(doc);
+        var keyMaterial = MongoTrustedDomainRepository.readKeyMaterial(doc);
 
         assertEquals(KeyMaterialSource.PEM, keyMaterial.getSource());
         assertEquals("cert", keyMaterial.getCertificate());
@@ -86,6 +86,6 @@ public class MongoTrustDomainLegacyMappingTest {
 
     @Test
     public void shouldReadNoKeyMaterial_whenDocumentHasNeither() {
-        assertNull(MongoTrustDomainRepository.readKeyMaterial(new TrustDomainMongo()));
+        assertNull(MongoTrustedDomainRepository.readKeyMaterial(new TrustDomainMongo()));
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/TrustedDomainRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/TrustedDomainRepositoryTest.java
@@ -19,7 +19,9 @@ import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.jose.RSAKey;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.KeyMaterialSource;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.gravitee.am.repository.management.AbstractManagementTest;
 import org.junit.Test;
@@ -33,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import static io.gravitee.am.model.ReferenceType.DOMAIN;
 import static java.util.UUID.randomUUID;
 
-public class TrustDomainRepositoryTest extends AbstractManagementTest {
+public class TrustedDomainRepositoryTest extends AbstractManagementTest {
 
     private static final String PEM_CERTIFICATE = """
             -----BEGIN CERTIFICATE-----
@@ -41,21 +43,23 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
             -----END CERTIFICATE-----""";
 
     @Autowired
-    protected TrustDomainRepository repository;
+    protected TrustedDomainRepository repository;
 
-    private TrustDomain buildTrustDomain(String referenceId, String name) {
-        TrustDomain td = new TrustDomain();
+    private TrustedDomain buildTrustDomain(String referenceId, String name) {
+        TrustedDomain td = new TrustedDomain();
         td.setReferenceId(referenceId);
         td.setReferenceType(DOMAIN);
         td.setName(name);
-        td.setSpiffeTrustDomain(name);
         td.setDescription("desc-" + name);
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://example.com/" + name + "/keys")
+                .refreshIntervalSeconds(120)
                 .build());
-        td.setRefreshIntervalSeconds(120);
-        td.setAllowedAlgorithms(List.of("RS256", "ES256"));
+        td.setSpiffe(SpiffeTrustSettings.builder()
+                .spiffeTrustDomain(name)
+                .allowedAlgorithms(List.of("RS256", "ES256"))
+                .build());
         Date now = new Date();
         td.setCreatedAt(now);
         td.setUpdatedAt(now);
@@ -177,9 +181,9 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
     @Test
     public void shouldServeBothUsagesFromOneTrustedDomain() {
         String referenceId = randomUUID().toString();
-        TrustDomain both = buildTrustDomain(referenceId, "acme-corp");
-        both.setSpiffeTrustDomain("acme.org");
-        both.setIssuer("https://sso.acme.com");
+        TrustedDomain both = buildTrustDomain(referenceId, "acme-corp");
+        both.setSpiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("acme.org").build());
+        both.setDomainIdentifier("https://sso.acme.com");
         var created = repository.create(both).blockingGet();
 
         var bySpiffe = repository.findBySpiffeTrustDomain(DOMAIN, referenceId, "acme.org").test();
@@ -196,8 +200,8 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         String referenceId = randomUUID().toString();
         repository.create(buildTrustDomain(referenceId, "example.org")).blockingGet();
 
-        TrustDomain duplicate = buildTrustDomain(referenceId, "other-label");
-        duplicate.setSpiffeTrustDomain("example.org");
+        TrustedDomain duplicate = buildTrustDomain(referenceId, "other-label");
+        duplicate.setSpiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("example.org").build());
 
         var observer = repository.create(duplicate).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
@@ -225,7 +229,7 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
     @Test
     public void shouldRoundTripPemKeyMaterial() {
         String referenceId = randomUUID().toString();
-        TrustDomain td = buildTrustDomain(referenceId, "pem.example");
+        TrustedDomain td = buildTrustDomain(referenceId, "pem.example");
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate(PEM_CERTIFICATE)
@@ -243,7 +247,7 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
     @Test
     public void shouldRoundTripInlineJwkSet() {
         String referenceId = randomUUID().toString();
-        TrustDomain td = buildTrustDomain(referenceId, "jwks.example");
+        TrustedDomain td = buildTrustDomain(referenceId, "jwks.example");
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWK_SET)
                 .jwkSet(inlineJwkSet())
@@ -266,11 +270,11 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         String referenceId = randomUUID().toString();
         var created = repository.create(buildTrustDomain(referenceId, "example.org")).blockingGet();
 
-        TrustDomain toUpdate = new TrustDomain(created);
+        TrustedDomain toUpdate = new TrustedDomain(created);
         toUpdate.setDescription("updated-description");
         toUpdate.getKeyMaterial().setJwksUrl("https://example.com/v2/keys");
-        toUpdate.setRefreshIntervalSeconds(600);
-        toUpdate.setAllowedAlgorithms(List.of("RS512"));
+        toUpdate.getKeyMaterial().setRefreshIntervalSeconds(600);
+        toUpdate.getSpiffe().setAllowedAlgorithms(List.of("RS512"));
         toUpdate.setUpdatedAt(new Date());
 
         var observer = repository.update(toUpdate).test();
@@ -298,17 +302,18 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         findObserver.assertNoErrors();
     }
 
-    private TrustDomain buildTokenExchangeTrustDomain(String referenceId, String issuer) {
-        TrustDomain td = buildTrustDomain(referenceId, "issuer.example");
-        td.setSpiffeTrustDomain(null);
-        td.setAllowedAlgorithms(null);
+    private TrustedDomain buildTokenExchangeTrustDomain(String referenceId, String issuer) {
+        TrustedDomain td = buildTrustDomain(referenceId, "issuer.example");
+        td.setSpiffe(null);
         UserBindingCriterion criterion = new UserBindingCriterion();
         criterion.setAttribute("emails.value");
         criterion.setExpression("{#token['email']}");
-        td.setIssuer(issuer);
-        td.setScopeMappings(Map.of("read", "domain:read"));
-        td.setUserBindingEnabled(true);
-        td.setUserBindingCriteria(List.of(criterion));
+        td.setDomainIdentifier(issuer);
+        td.setTokenExchange(TokenExchangeTrustSettings.builder()
+                .scopeMappings(Map.of("read", "domain:read"))
+                .userBindingEnabled(true)
+                .userBindingCriteria(List.of(criterion))
+                .build());
         return td;
     }
 
@@ -321,7 +326,7 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         observer.awaitDone(10, TimeUnit.SECONDS);
         observer.assertNoErrors();
         observer.assertValue(found -> found.getSpiffeTrustDomain() == null);
-        observer.assertValue(found -> "https://issuer.example/realm".equals(found.getIssuer()));
+        observer.assertValue(found -> "https://issuer.example/realm".equals(found.getDomainIdentifier()));
         observer.assertValue(found -> Map.of("read", "domain:read").equals(found.getScopeMappings()));
         observer.assertValue(found -> found.isUserBindingEnabled());
         observer.assertValue(found -> found.getUserBindingCriteria().size() == 1);
@@ -358,7 +363,7 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         String referenceId = randomUUID().toString();
         repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
 
-        TrustDomain duplicate = buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm");
+        TrustedDomain duplicate = buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm");
         duplicate.setName("other.example");
         var observer = repository.create(duplicate).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
@@ -386,8 +391,8 @@ public class TrustDomainRepositoryTest extends AbstractManagementTest {
         String referenceId = randomUUID().toString();
         var created = repository.create(buildTokenExchangeTrustDomain(referenceId, "https://issuer.example/realm")).blockingGet();
 
-        TrustDomain toUpdate = new TrustDomain(created);
-        toUpdate.setIssuer("https://issuer.example/realm-v2");
+        TrustedDomain toUpdate = new TrustedDomain(created);
+        toUpdate.setDomainIdentifier("https://issuer.example/realm-v2");
         toUpdate.setUpdatedAt(new Date());
         repository.update(toUpdate).blockingGet();
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/TrustDomainService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/TrustDomainService.java
@@ -18,9 +18,11 @@ package io.gravitee.am.service;
 import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.Domain;
 import io.gravitee.am.model.ReferenceType;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -28,23 +30,29 @@ import io.reactivex.rxjava3.core.Single;
 
 public interface TrustDomainService {
 
-    Maybe<TrustDomain> findById(String id);
+    Maybe<TrustedDomain> findById(String id);
 
     /**
      * Looks up a trusted domain by the label it is known by, unique within a reference.
      */
-    Maybe<TrustDomain> findByName(ReferenceType referenceType, String referenceId, String name);
+    Maybe<TrustedDomain> findByName(ReferenceType referenceType, String referenceId, String name);
 
     /**
      * Looks up the trusted domain that vouches for a SPIFFE trust domain, unique within a reference.
      */
-    Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain);
+    Maybe<TrustedDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain);
 
-    Flowable<TrustDomain> findByReference(ReferenceType referenceType, String referenceId);
+    Flowable<TrustedDomain> findByReference(ReferenceType referenceType, String referenceId);
 
-    Single<TrustDomain> create(Domain domain, NewTrustDomain newTrustDomain, User principal);
+    Single<TrustedDomain> create(Domain domain, NewTrustedDomain newTrustedDomain, User principal);
 
-    Single<TrustDomain> update(Domain domain, String id, UpdateTrustDomain updateTrustDomain, User principal);
+    Single<TrustedDomain> update(Domain domain, String id, UpdateTrustedDomain updateTrustedDomain, User principal);
+
+    @Deprecated
+    Single<TrustedDomain> create(Domain domain, NewTrustDomain newTrustDomain, User principal);
+
+    @Deprecated
+    Single<TrustedDomain> update(Domain domain, String id, UpdateTrustDomain updateTrustDomain, User principal);
 
     Completable delete(Domain domain, String id, User principal);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/ApplicationServiceImpl.java
@@ -206,7 +206,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
     @Lazy
     @Autowired
-    private io.gravitee.am.repository.management.api.TrustDomainRepository trustDomainRepository;
+    private io.gravitee.am.repository.management.api.TrustedDomainRepository trustDomainRepository;
 
     private ClientRedirectUrisValidator clientRedirectUrisValidator = new ClientRedirectUrisValidator();
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TrustDomainServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/TrustDomainServiceImpl.java
@@ -29,9 +29,10 @@ import io.gravitee.am.model.common.event.Payload;
 import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.TrustDomainService;
@@ -42,7 +43,9 @@ import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
 import io.gravitee.am.service.exception.TrustDomainNotFoundException;
 import io.gravitee.am.service.exception.TrustDomainSpiffeAlreadyExistsException;
 import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.management.TrustDomainAuditBuilder;
 import io.gravitee.am.service.utils.PrivateAddressGuard;
@@ -78,7 +81,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
 
     @Lazy
     @Autowired
-    private TrustDomainRepository repository;
+    private TrustedDomainRepository repository;
 
     @Autowired
     private EventService eventService;
@@ -87,51 +90,47 @@ public class TrustDomainServiceImpl implements TrustDomainService {
     private AuditService auditService;
 
     @Override
-    public Maybe<TrustDomain> findById(String id) {
+    public Maybe<TrustedDomain> findById(String id) {
         return repository.findById(id)
                 .onErrorResumeNext(ex -> Maybe.error(new TechnicalManagementException("Failed to find trust domain " + id, ex)));
     }
 
     @Override
-    public Maybe<TrustDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
+    public Maybe<TrustedDomain> findByName(ReferenceType referenceType, String referenceId, String name) {
         return repository.findByName(referenceType, referenceId, name);
     }
 
     @Override
-    public Maybe<TrustDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
+    public Maybe<TrustedDomain> findBySpiffeTrustDomain(ReferenceType referenceType, String referenceId, String spiffeTrustDomain) {
         return repository.findBySpiffeTrustDomain(referenceType, referenceId, spiffeTrustDomain);
     }
 
     @Override
-    public Flowable<TrustDomain> findByReference(ReferenceType referenceType, String referenceId) {
+    public Flowable<TrustedDomain> findByReference(ReferenceType referenceType, String referenceId) {
         return repository.findByReference(referenceType, referenceId);
     }
 
     @Override
-    public Single<TrustDomain> create(Domain domain, NewTrustDomain input, User principal) {
+    public Single<TrustedDomain> create(Domain domain, NewTrustedDomain input, User principal) {
         Objects.requireNonNull(domain, "domain is required");
-        Objects.requireNonNull(input, "newTrustDomain is required");
+        Objects.requireNonNull(input, "newTrustedDomain is required");
 
-        TrustDomain td = new TrustDomain();
+        TrustedDomain td = new TrustedDomain();
         td.setReferenceType(ReferenceType.DOMAIN);
         td.setReferenceId(domain.getId());
         td.setName(trimToNull(input.getName()));
         td.setDescription(input.getDescription());
-        applyMatchers(td, input.getSpiffeTrustDomain(), input.getIssuer());
-        td.setKeyMaterial(resolveKeyMaterial(input.getKeyMaterial(), input.getBundleSource(), input.getJwksUrl()));
-        td.setRefreshIntervalSeconds(Optional.ofNullable(input.getRefreshIntervalSeconds())
-                .orElse(TrustDomain.DEFAULT_REFRESH_INTERVAL_SECONDS));
-        td.setAllowedAlgorithms(input.getAllowedAlgorithms());
-        td.setScopeMappings(input.getScopeMappings());
-        td.setUserBindingEnabled(input.isUserBindingEnabled());
-        td.setUserBindingCriteria(input.getUserBindingCriteria());
+        td.setDomainIdentifier(trimToNull(input.getDomainIdentifier()));
+        td.setKeyMaterial(input.getKeyMaterial());
+        td.setSpiffe(normalizeSpiffe(input.getSpiffe()));
+        td.setTokenExchange(input.getTokenExchange());
         Date now = new Date();
         td.setCreatedAt(now);
         td.setUpdatedAt(now);
 
         return validate(domain, td)
                 .andThen(rejectDuplicates(domain, td, null))
-                .andThen(Single.defer(() -> repository.create(td)))
+                .andThen(Single.defer(() -> repository.create(collapseUnusedSections(td))))
                 .flatMap(created -> publish(domain, created, Action.CREATE).andThen(Single.just(created)))
                 .doOnSuccess(created -> auditService.report(AuditBuilder.builder(TrustDomainAuditBuilder.class)
                         .principal(principal)
@@ -145,13 +144,13 @@ public class TrustDomainServiceImpl implements TrustDomainService {
     }
 
     @Override
-    public Single<TrustDomain> update(Domain domain, String id, UpdateTrustDomain input, User principal) {
+    public Single<TrustedDomain> update(Domain domain, String id, UpdateTrustedDomain input, User principal) {
         Objects.requireNonNull(domain, "domain is required");
-        Objects.requireNonNull(input, "updateTrustDomain is required");
+        Objects.requireNonNull(input, "updateTrustedDomain is required");
         Objects.requireNonNull(id, "id is required");
 
-        AtomicReference<TrustDomain> existingRef = new AtomicReference<>();
-        AtomicReference<TrustDomain> updatedRef = new AtomicReference<>();
+        AtomicReference<TrustedDomain> existingRef = new AtomicReference<>();
+        AtomicReference<TrustedDomain> updatedRef = new AtomicReference<>();
 
         return repository.findById(id)
                 .switchIfEmpty(Single.error(new TrustDomainNotFoundException(id)))
@@ -161,40 +160,29 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                             || !domain.getId().equals(existing.getReferenceId())) {
                         return Single.error(new InvalidTrustDomainException("Trust domain is not linked to domain " + domain.getId()));
                     }
-                    TrustDomain updated = new TrustDomain(existing);
+                    TrustedDomain updated = new TrustedDomain(existing);
                     if (input.getName() != null) {
                         updated.setName(trimToNull(input.getName()));
                     }
                     updated.setDescription(input.getDescription());
-                    if (input.getSpiffeTrustDomain() != null || input.getIssuer() != null) {
-                        applyMatchers(updated, input.getSpiffeTrustDomain(), input.getIssuer());
+                    if (input.getDomainIdentifier() != null) {
+                        updated.setDomainIdentifier(trimToNull(input.getDomainIdentifier()));
                     }
-                    TrustDomainKeyMaterial keyMaterial =
-                            resolveKeyMaterial(input.getKeyMaterial(), input.getBundleSource(), input.getJwksUrl());
-                    if (keyMaterial != null) {
-                        updated.setKeyMaterial(keyMaterial);
+                    if (input.getKeyMaterial() != null) {
+                        updated.setKeyMaterial(input.getKeyMaterial());
                     }
-                    if (input.getRefreshIntervalSeconds() != null) {
-                        updated.setRefreshIntervalSeconds(input.getRefreshIntervalSeconds());
+                    if (input.getSpiffe() != null) {
+                        updated.setSpiffe(normalizeSpiffe(input.getSpiffe()));
                     }
-                    if (input.getAllowedAlgorithms() != null) {
-                        updated.setAllowedAlgorithms(input.getAllowedAlgorithms());
-                    }
-                    if (input.getScopeMappings() != null) {
-                        updated.setScopeMappings(input.getScopeMappings());
-                    }
-                    if (input.getUserBindingEnabled() != null) {
-                        updated.setUserBindingEnabled(input.getUserBindingEnabled());
-                    }
-                    if (input.getUserBindingCriteria() != null) {
-                        updated.setUserBindingCriteria(input.getUserBindingCriteria());
+                    if (input.getTokenExchange() != null) {
+                        updated.setTokenExchange(input.getTokenExchange());
                     }
                     updated.setUpdatedAt(new Date());
                     updatedRef.set(updated);
 
                     return validate(domain, updated)
                             .andThen(rejectDuplicates(domain, updated, existing))
-                            .andThen(Single.defer(() -> repository.update(updated)))
+                            .andThen(Single.defer(() -> repository.update(collapseUnusedSections(updated))))
                             .flatMap(saved -> publish(domain, saved, Action.UPDATE).andThen(Single.just(saved)));
                 })
                 .doOnSuccess(saved -> auditService.report(AuditBuilder.builder(TrustDomainAuditBuilder.class)
@@ -207,7 +195,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                             .principal(principal)
                             .type(EventType.TRUST_DOMAIN_UPDATED)
                             .throwable(ex);
-                    TrustDomain updated = updatedRef.get();
+                    TrustedDomain updated = updatedRef.get();
                     if (updated != null) {
                         builder.trustDomain(updated).oldValue(existingRef.get());
                     } else {
@@ -221,7 +209,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
 
     @Override
     public Completable delete(Domain domain, String id, User principal) {
-        AtomicReference<TrustDomain> tdRef = new AtomicReference<>();
+        AtomicReference<TrustedDomain> tdRef = new AtomicReference<>();
         return repository.findById(id)
                 .switchIfEmpty(Maybe.error(new TrustDomainNotFoundException(id)))
                 .flatMapCompletable(td -> {
@@ -234,7 +222,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                             .andThen(publish(domain, td, Action.DELETE));
                 })
                 .doOnComplete(() -> {
-                    TrustDomain td = tdRef.get();
+                    TrustedDomain td = tdRef.get();
                     auditService.report(AuditBuilder.builder(TrustDomainAuditBuilder.class)
                             .principal(principal)
                             .type(EventType.TRUST_DOMAIN_DELETED)
@@ -247,7 +235,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                             .principal(principal)
                             .type(EventType.TRUST_DOMAIN_DELETED)
                             .throwable(ex);
-                    TrustDomain td = tdRef.get();
+                    TrustedDomain td = tdRef.get();
                     if (td != null) {
                         builder.trustDomain(td).oldValue(td);
                     } else {
@@ -257,31 +245,107 @@ public class TrustDomainServiceImpl implements TrustDomainService {
                 });
     }
 
-    /**
-     * Sets the matchers a trusted domain is recognised by. A payload that declares neither is written
-     * against the SPIFFE-only API that preceded the issuer matcher, and means the name.
-     */
-    private static void applyMatchers(TrustDomain td, String spiffeTrustDomain, String issuer) {
-        String spiffe = spiffeTrustDomain == null && issuer == null
-                ? td.getName()
-                : trimToNull(spiffeTrustDomain);
-        td.setSpiffeTrustDomain(spiffe != null ? spiffe.toLowerCase(Locale.ROOT) : null);
-        td.setIssuer(trimToNull(issuer));
+    @Override
+    @Deprecated
+    public Single<TrustedDomain> create(Domain domain, NewTrustDomain newTrustDomain, User principal) {
+        Objects.requireNonNull(newTrustDomain, "newTrustDomain is required");
+        return create(domain, upgrade(newTrustDomain), principal);
     }
 
-    private Completable rejectDuplicates(Domain domain, TrustDomain td, TrustDomain beforeUpdate) {
-        return rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getName,
+    @Override
+    @Deprecated
+    public Single<TrustedDomain> update(Domain domain, String id, UpdateTrustDomain updateTrustDomain, User principal) {
+        Objects.requireNonNull(domain, "domain is required");
+        Objects.requireNonNull(updateTrustDomain, "updateTrustDomain is required");
+        Objects.requireNonNull(id, "id is required");
+        return repository.findById(id)
+                .map(existing -> upgrade(updateTrustDomain, existing))
+                .onErrorComplete()
+                .defaultIfEmpty(upgrade(updateTrustDomain, new TrustedDomain()))
+                .flatMap(input -> update(domain, id, input, principal));
+    }
+
+    private static NewTrustedDomain upgrade(NewTrustDomain v1) {
+        NewTrustedDomain upgraded = new NewTrustedDomain();
+        upgraded.setName(v1.getName());
+        upgraded.setDescription(v1.getDescription());
+        upgraded.setKeyMaterial(upgradeKeyMaterial(
+                v1.getBundleSource(), v1.getJwksUrl(), v1.getRefreshIntervalSeconds(), null));
+        upgraded.setSpiffe(SpiffeTrustSettings.builder()
+                .spiffeTrustDomain(trimToNull(v1.getName()))
+                .allowedAlgorithms(v1.getAllowedAlgorithms())
+                .build());
+        return upgraded;
+    }
+
+    private static UpdateTrustedDomain upgrade(UpdateTrustDomain v1, TrustedDomain existing) {
+        UpdateTrustedDomain upgraded = new UpdateTrustedDomain();
+        upgraded.setDescription(v1.getDescription());
+        upgraded.setKeyMaterial(upgradeKeyMaterial(
+                v1.getBundleSource(), v1.getJwksUrl(), v1.getRefreshIntervalSeconds(), existing.getKeyMaterial()));
+        if (v1.getAllowedAlgorithms() != null) {
+            SpiffeTrustSettings spiffe = existing.getSpiffe() != null
+                    ? new SpiffeTrustSettings(existing.getSpiffe())
+                    : new SpiffeTrustSettings();
+            spiffe.setAllowedAlgorithms(v1.getAllowedAlgorithms());
+            upgraded.setSpiffe(spiffe);
+        }
+        return upgraded;
+    }
+
+    private static TrustDomainKeyMaterial upgradeKeyMaterial(SpiffeBundleSource bundleSource,
+                                                             String jwksUrl,
+                                                             Integer refreshIntervalSeconds,
+                                                             TrustDomainKeyMaterial existing) {
+        if (bundleSource == null && jwksUrl == null && refreshIntervalSeconds == null) {
+            return null;
+        }
+        TrustDomainKeyMaterial keyMaterial;
+        if (bundleSource != null || jwksUrl != null) {
+            keyMaterial = TrustDomainKeyMaterial.fromBundleSource(
+                    bundleSource != null ? bundleSource : SpiffeBundleSource.JWKS_URL, jwksUrl);
+        } else {
+            keyMaterial = existing != null ? new TrustDomainKeyMaterial(existing) : null;
+        }
+        if (keyMaterial != null && refreshIntervalSeconds != null) {
+            keyMaterial.setRefreshIntervalSeconds(refreshIntervalSeconds);
+        }
+        return keyMaterial;
+    }
+
+    private static TrustedDomain collapseUnusedSections(TrustedDomain td) {
+        if (td.getSpiffe() != null && td.getSpiffe().getSpiffeTrustDomain() == null) {
+            td.setSpiffe(null);
+        }
+        if (td.getDomainIdentifier() == null) {
+            td.setTokenExchange(null);
+        }
+        return td;
+    }
+
+    private static SpiffeTrustSettings normalizeSpiffe(SpiffeTrustSettings spiffe) {
+        if (spiffe == null) {
+            return null;
+        }
+        SpiffeTrustSettings normalized = new SpiffeTrustSettings(spiffe);
+        String spiffeTrustDomain = trimToNull(normalized.getSpiffeTrustDomain());
+        normalized.setSpiffeTrustDomain(spiffeTrustDomain != null ? spiffeTrustDomain.toLowerCase(Locale.ROOT) : null);
+        return normalized;
+    }
+
+    private Completable rejectDuplicates(Domain domain, TrustedDomain td, TrustedDomain beforeUpdate) {
+        return rejectDuplicate(domain, td, beforeUpdate, TrustedDomain::getName,
                 repository::findByName, TrustDomainAlreadyExistsException::new)
-                .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getSpiffeTrustDomain,
+                .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustedDomain::getSpiffeTrustDomain,
                         repository::findBySpiffeTrustDomain, TrustDomainSpiffeAlreadyExistsException::new))
-                .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustDomain::getIssuer,
+                .andThen(rejectDuplicate(domain, td, beforeUpdate, TrustedDomain::getDomainIdentifier,
                         repository::findByIssuer, TrustDomainIssuerAlreadyExistsException::new));
     }
 
     private Completable rejectDuplicate(Domain domain,
-                                        TrustDomain td,
-                                        TrustDomain beforeUpdate,
-                                        Function<TrustDomain, String> field,
+                                        TrustedDomain td,
+                                        TrustedDomain beforeUpdate,
+                                        Function<TrustedDomain, String> field,
                                         TrustDomainLookup lookup,
                                         Function<String, Throwable> conflict) {
         String value = field.apply(td);
@@ -297,10 +361,10 @@ public class TrustDomainServiceImpl implements TrustDomainService {
 
     @FunctionalInterface
     private interface TrustDomainLookup {
-        Maybe<TrustDomain> find(ReferenceType referenceType, String referenceId, String value);
+        Maybe<TrustedDomain> find(ReferenceType referenceType, String referenceId, String value);
     }
 
-    private Completable publish(Domain domain, TrustDomain trustDomain, Action action) {
+    private Completable publish(Domain domain, TrustedDomain trustDomain, Action action) {
         Event event = new Event(TRUST_DOMAIN, new Payload(trustDomain.getId(), trustDomain.getReferenceType(), trustDomain.getReferenceId(), action));
         return eventService.create(event, domain).ignoreElement();
     }
@@ -310,18 +374,6 @@ public class TrustDomainServiceImpl implements TrustDomainService {
      * fields are ignored whenever key material is supplied directly; a bare {@code jwksUrl} means
      * the JWKS-URL source, as it did before the bundle source became explicit.
      */
-    private static TrustDomainKeyMaterial resolveKeyMaterial(TrustDomainKeyMaterial keyMaterial,
-                                                             SpiffeBundleSource bundleSource,
-                                                             String jwksUrl) {
-        if (keyMaterial != null) {
-            return keyMaterial;
-        }
-        if (bundleSource == null && jwksUrl == null) {
-            return null;
-        }
-        return TrustDomainKeyMaterial.fromBundleSource(
-                bundleSource != null ? bundleSource : SpiffeBundleSource.JWKS_URL, jwksUrl);
-    }
 
     private static String trimToNull(String value) {
         if (value == null) {
@@ -331,7 +383,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         return trimmed.isEmpty() ? null : trimmed;
     }
 
-    private Completable validate(Domain domain, TrustDomain td) {
+    private Completable validate(Domain domain, TrustedDomain td) {
         SpiffeDomainSettings spiffeSettings = Optional.ofNullable(domain.getOidc())
                 .map(o -> o.getWorkloadIdentitySettings())
                 .orElseGet(SpiffeDomainSettings::defaultSettings);
@@ -341,8 +393,8 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         if (td.getName() == null) {
             return Completable.error(new InvalidTrustDomainException("name is required"));
         }
-        if (td.getName().length() > TrustDomain.NAME_MAX_LENGTH) {
-            return Completable.error(new InvalidTrustDomainException("name must be at most " + TrustDomain.NAME_MAX_LENGTH + " characters"));
+        if (td.getName().length() > TrustedDomain.NAME_MAX_LENGTH) {
+            return Completable.error(new InvalidTrustDomainException("name must be at most " + TrustedDomain.NAME_MAX_LENGTH + " characters"));
         }
         Optional<String> matcherError = validateMatchers(td, spiffeSettings);
         if (matcherError.isPresent()) {
@@ -371,7 +423,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         return Completable.complete();
     }
 
-    private Optional<String> validateMatchers(TrustDomain td, SpiffeDomainSettings spiffeSettings) {
+    private Optional<String> validateMatchers(TrustedDomain td, SpiffeDomainSettings spiffeSettings) {
         if (!td.trustsSpiffe() && !td.trustsTokenExchange()) {
             return Optional.of("a trusted domain must declare spiffeTrustDomain, issuer, or both");
         }
@@ -382,12 +434,12 @@ public class TrustDomainServiceImpl implements TrustDomainService {
             if (!SPIFFE_TRUST_DOMAIN_PATTERN.matcher(td.getSpiffeTrustDomain()).matches()) {
                 return Optional.of("spiffeTrustDomain must be a DNS-style label (lowercase letters, digits, '.' or '-')");
             }
-            if (td.getSpiffeTrustDomain().length() > TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH) {
-                return Optional.of("spiffeTrustDomain must be at most " + TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + " characters");
+            if (td.getSpiffeTrustDomain().length() > TrustedDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH) {
+                return Optional.of("spiffeTrustDomain must be at most " + TrustedDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + " characters");
             }
         }
-        if (td.trustsTokenExchange() && td.getIssuer().length() > TrustDomain.ISSUER_MAX_LENGTH) {
-            return Optional.of("issuer must be at most " + TrustDomain.ISSUER_MAX_LENGTH + " characters");
+        if (td.trustsTokenExchange() && td.getDomainIdentifier().length() > TrustedDomain.ISSUER_MAX_LENGTH) {
+            return Optional.of("issuer must be at most " + TrustedDomain.ISSUER_MAX_LENGTH + " characters");
         }
         if (!td.trustsTokenExchange()) {
             if (td.getScopeMappings() != null && !td.getScopeMappings().isEmpty()) {
@@ -400,7 +452,7 @@ public class TrustDomainServiceImpl implements TrustDomainService {
         return Optional.empty();
     }
 
-    private Optional<String> validateUserBinding(TrustDomain td) {
+    private Optional<String> validateUserBinding(TrustedDomain td) {
         if (!td.isUserBindingEnabled()) {
             return Optional.empty();
         }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTrustedDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewTrustedDomain.java
@@ -15,39 +15,41 @@
  */
 package io.gravitee.am.service.model;
 
-import io.gravitee.am.model.oidc.SpiffeBundleSource;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
 import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-
-@Deprecated
 @Getter
 @Setter
-public class NewTrustDomain {
+public class NewTrustedDomain {
 
 
+    @Schema(description = "Label the trusted domain is known by. Unique within the security domain.",
+            example = "acme-corp")
     @Size(max = TrustedDomain.NAME_MAX_LENGTH, message = "Name must be at most {max} characters")
     private String name;
 
     private String description;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.source instead.")
-    private SpiffeBundleSource bundleSource;
+    @Schema(description = "Issuer identifier of this authority's authorization server. Matched against "
+            + "the \"iss\" of an external JWT inbound, and carried as the \"aud\" of an ID-JAG outbound. "
+            + "Required when tokenExchange is present.",
+            example = "https://sso.acme.com")
+    @Size(max = TrustedDomain.ISSUER_MAX_LENGTH, message = "Domain identifier must be at most {max} characters")
+    private String domainIdentifier;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.jwksUrl instead.")
-    private String jwksUrl;
+    @Valid
+    private TrustDomainKeyMaterial keyMaterial;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.refreshIntervalSeconds instead.")
-    private Integer refreshIntervalSeconds;
+    @Valid
+    private SpiffeTrustSettings spiffe;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use spiffe.allowedAlgorithms instead.")
-    private List<String> allowedAlgorithms;
+    @Valid
+    private TokenExchangeTrustSettings tokenExchange;
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustDomain.java
@@ -15,83 +15,36 @@
  */
 package io.gravitee.am.service.model;
 
-import io.gravitee.am.model.UserBindingCriterion;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
-import io.gravitee.am.model.oidc.TrustDomain;
-import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
+import io.gravitee.am.model.oidc.TrustedDomain;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
-import java.util.Map;
 
+@Deprecated
+@Getter
+@Setter
 public class UpdateTrustDomain {
-    private String name;
+
+
     private String description;
-    private String spiffeTrustDomain;
-    private String issuer;
-    private TrustDomainKeyMaterial keyMaterial;
-    private SpiffeBundleSource bundleSource;
-    private String jwksUrl;
-    private Integer refreshIntervalSeconds;
-    private List<String> allowedAlgorithms;
-    private Map<String, String> scopeMappings;
-    private Boolean userBindingEnabled;
-    private List<UserBindingCriterion> userBindingCriteria;
 
-    @Schema(description = "New label for the trusted domain. Left unchanged when absent.")
-    @Size(max = TrustDomain.NAME_MAX_LENGTH, message = "Name must be at most {max} characters")
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
-
-    /**
-     * SPIFFE trust domain this authority issues IDs for. Declaring either matcher replaces both, so
-     * omitting one clears it; omitting both leaves the trusted domain's usages untouched.
-     */
-    @Schema(description = "SPIFFE trust domain matched against the \"sub\" of a JWT-SVID. Supplying either "
-            + "matcher replaces both; supplying neither leaves them unchanged.")
-    @Size(max = TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH, message = "SPIFFE trust domain must be at most {max} characters")
-    public String getSpiffeTrustDomain() { return spiffeTrustDomain; }
-    public void setSpiffeTrustDomain(String spiffeTrustDomain) { this.spiffeTrustDomain = spiffeTrustDomain; }
-
-    @Size(max = TrustDomain.ISSUER_MAX_LENGTH, message = "Issuer must be at most {max} characters")
-    public String getIssuer() { return issuer; }
-    public void setIssuer(String issuer) { this.issuer = issuer; }
-
-    public TrustDomainKeyMaterial getKeyMaterial() { return keyMaterial; }
-    public void setKeyMaterial(TrustDomainKeyMaterial keyMaterial) { this.keyMaterial = keyMaterial; }
-
-    /**
-     * @deprecated supply {@code keyMaterial} instead; ignored when {@code keyMaterial} is present.
-     */
     @Deprecated
     @Schema(deprecated = true, description = "Use keyMaterial.source instead.")
-    public SpiffeBundleSource getBundleSource() { return bundleSource; }
-    public void setBundleSource(SpiffeBundleSource bundleSource) { this.bundleSource = bundleSource; }
+    private SpiffeBundleSource bundleSource;
 
-    /**
-     * @deprecated supply {@code keyMaterial} instead; ignored when {@code keyMaterial} is present.
-     */
     @Deprecated
     @Schema(deprecated = true, description = "Use keyMaterial.jwksUrl instead.")
-    public String getJwksUrl() { return jwksUrl; }
-    public void setJwksUrl(String jwksUrl) { this.jwksUrl = jwksUrl; }
+    private String jwksUrl;
 
-    public Integer getRefreshIntervalSeconds() { return refreshIntervalSeconds; }
-    public void setRefreshIntervalSeconds(Integer refreshIntervalSeconds) { this.refreshIntervalSeconds = refreshIntervalSeconds; }
+    @Deprecated
+    @Schema(deprecated = true, description = "Use keyMaterial.refreshIntervalSeconds instead.")
+    private Integer refreshIntervalSeconds;
 
-    public List<String> getAllowedAlgorithms() { return allowedAlgorithms; }
-    public void setAllowedAlgorithms(List<String> allowedAlgorithms) { this.allowedAlgorithms = allowedAlgorithms; }
-
-    public Map<String, String> getScopeMappings() { return scopeMappings; }
-    public void setScopeMappings(Map<String, String> scopeMappings) { this.scopeMappings = scopeMappings; }
-
-    public Boolean getUserBindingEnabled() { return userBindingEnabled; }
-    public void setUserBindingEnabled(Boolean userBindingEnabled) { this.userBindingEnabled = userBindingEnabled; }
-
-    public List<UserBindingCriterion> getUserBindingCriteria() { return userBindingCriteria; }
-    public void setUserBindingCriteria(List<UserBindingCriterion> userBindingCriteria) { this.userBindingCriteria = userBindingCriteria; }
+    @Deprecated
+    @Schema(deprecated = true, description = "Use spiffe.allowedAlgorithms instead.")
+    private List<String> allowedAlgorithms;
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustedDomain.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateTrustedDomain.java
@@ -15,39 +15,40 @@
  */
 package io.gravitee.am.service.model;
 
-import io.gravitee.am.model.oidc.SpiffeBundleSource;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
 import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-
-@Deprecated
 @Getter
 @Setter
-public class NewTrustDomain {
+public class UpdateTrustedDomain {
 
 
+    @Schema(description = "New label for the trusted domain. Kept unchanged when absent.")
     @Size(max = TrustedDomain.NAME_MAX_LENGTH, message = "Name must be at most {max} characters")
     private String name;
 
     private String description;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.source instead.")
-    private SpiffeBundleSource bundleSource;
+    @Schema(description = "Issuer identifier of this authority's authorization server. Matched against "
+            + "the \"iss\" of an external JWT inbound, and carried as the \"aud\" of an ID-JAG outbound. "
+            + "Required when tokenExchange is present.",
+            example = "https://sso.acme.com")
+    @Size(max = TrustedDomain.ISSUER_MAX_LENGTH, message = "Domain identifier must be at most {max} characters")
+    private String domainIdentifier;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.jwksUrl instead.")
-    private String jwksUrl;
+    @Valid
+    private TrustDomainKeyMaterial keyMaterial;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use keyMaterial.refreshIntervalSeconds instead.")
-    private Integer refreshIntervalSeconds;
+    @Valid
+    private SpiffeTrustSettings spiffe;
 
-    @Deprecated
-    @Schema(deprecated = true, description = "Use spiffe.allowedAlgorithms instead.")
-    private List<String> allowedAlgorithms;
+    @Valid
+    private TokenExchangeTrustSettings tokenExchange;
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/TrustDomainAuditBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/reporter/builder/management/TrustDomainAuditBuilder.java
@@ -18,11 +18,11 @@ package io.gravitee.am.service.reporter.builder.management;
 import io.gravitee.am.common.audit.EntityType;
 import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.model.Reference;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
 
 public class TrustDomainAuditBuilder extends ManagementAuditBuilder<TrustDomainAuditBuilder> {
 
-    public TrustDomainAuditBuilder trustDomain(TrustDomain trustDomain) {
+    public TrustDomainAuditBuilder trustDomain(TrustedDomain trustDomain) {
         if (trustDomain != null) {
             if (EventType.TRUST_DOMAIN_DELETED.equals(getType())
                     || EventType.TRUST_DOMAIN_CREATED.equals(getType())

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/ApplicationServiceImplSpiffeValidationTest.java
@@ -23,8 +23,9 @@ import io.gravitee.am.model.application.ApplicationOAuthSettings;
 import io.gravitee.am.model.application.ApplicationSettings;
 import io.gravitee.am.model.application.ApplicationType;
 import io.gravitee.am.model.application.SpiffeApplicationSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.am.service.exception.InvalidClientMetadataException;
 import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,7 @@ class ApplicationServiceImplSpiffeValidationTest {
     private static final String TRUST_DOMAIN = "acme";
 
     @Mock
-    private TrustDomainRepository trustDomainRepository;
+    private TrustedDomainRepository trustDomainRepository;
 
     private ApplicationServiceImpl service;
 
@@ -53,7 +54,8 @@ class ApplicationServiceImplSpiffeValidationTest {
         service = new ApplicationServiceImpl();
         ReflectionTestUtils.setField(service, "trustDomainRepository", trustDomainRepository);
         lenient().when(trustDomainRepository.findBySpiffeTrustDomain(eq(ReferenceType.DOMAIN), eq(DOMAIN_ID), eq(TRUST_DOMAIN)))
-                .thenReturn(Maybe.just(TrustDomain.builder().name(TRUST_DOMAIN).spiffeTrustDomain(TRUST_DOMAIN).build()));
+                .thenReturn(Maybe.just(TrustedDomain.builder().name(TRUST_DOMAIN)
+                        .spiffe(SpiffeTrustSettings.builder().spiffeTrustDomain(TRUST_DOMAIN).build()).build()));
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/TrustDomainServiceImplTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/impl/TrustDomainServiceImplTest.java
@@ -31,9 +31,11 @@ import io.gravitee.am.model.oidc.OIDCSettings;
 import io.gravitee.am.model.oidc.SpiffeBundleSource;
 import io.gravitee.am.model.KeyRetrievalSettings;
 import io.gravitee.am.model.oidc.SpiffeDomainSettings;
-import io.gravitee.am.model.oidc.TrustDomain;
+import io.gravitee.am.model.oidc.TrustedDomain;
+import io.gravitee.am.model.oidc.SpiffeTrustSettings;
+import io.gravitee.am.model.oidc.TokenExchangeTrustSettings;
 import io.gravitee.am.model.oidc.TrustDomainKeyMaterial;
-import io.gravitee.am.repository.management.api.TrustDomainRepository;
+import io.gravitee.am.repository.management.api.TrustedDomainRepository;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.exception.InvalidTrustDomainException;
@@ -42,7 +44,9 @@ import io.gravitee.am.service.exception.TrustDomainIssuerAlreadyExistsException;
 import io.gravitee.am.service.exception.TrustDomainNotFoundException;
 import io.gravitee.am.service.exception.TrustDomainSpiffeAlreadyExistsException;
 import io.gravitee.am.service.model.NewTrustDomain;
+import io.gravitee.am.service.model.NewTrustedDomain;
 import io.gravitee.am.service.model.UpdateTrustDomain;
+import io.gravitee.am.service.model.UpdateTrustedDomain;
 import io.gravitee.am.service.reporter.builder.management.TrustDomainAuditBuilder;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -97,7 +101,7 @@ public class TrustDomainServiceImplTest {
     private TrustDomainServiceImpl service = new TrustDomainServiceImpl();
 
     @Mock
-    private TrustDomainRepository repository;
+    private TrustedDomainRepository repository;
 
     @Mock
     private EventService eventService;
@@ -144,8 +148,9 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenNameInvalid() {
-        NewTrustDomain input = validInput();
+        NewTrustDomain input = new NewTrustDomain();
         input.setName("INVALID NAME");
+        input.setJwksUrl("https://example.com/keys");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -154,7 +159,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenNameMissing() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setName(null);
 
         service.create(domain, input, null).test()
@@ -163,7 +168,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenKeyMaterialMissing() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(null);
 
         service.create(domain, input, null).test()
@@ -173,7 +178,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenKeyMaterialSourceMissing() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder().jwksUrl("https://example.com/keys").build());
 
         service.create(domain, input, null).test()
@@ -183,7 +188,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenJwksUrlMissing() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder().source(KeyMaterialSource.JWKS_URL).build());
 
         service.create(domain, input, null).test()
@@ -193,7 +198,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenJwksUrlBlank() {
-        NewTrustDomain input = jwksUrlInput("   ");
+        NewTrustedDomain input = jwksUrlInput("   ");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class);
@@ -201,7 +206,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenJwksUrlResolvesToPrivateAddress() {
-        NewTrustDomain input = jwksUrlInput("https://10.0.0.1/keys");
+        NewTrustedDomain input = jwksUrlInput("https://10.0.0.1/keys");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -211,7 +216,7 @@ public class TrustDomainServiceImplTest {
     @Test
     public void create_allowsPrivateAddress_whenPolicyPermits() {
         keyRetrievalSettings.setAllowPrivateIpAddress(true);
-        NewTrustDomain input = jwksUrlInput("https://10.0.0.1/keys");
+        NewTrustedDomain input = jwksUrlInput("https://10.0.0.1/keys");
         stubRepoForCreate();
 
         service.create(domain, input, null).test()
@@ -220,7 +225,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejectsHttp_whenPolicyDisallows() {
-        NewTrustDomain input = jwksUrlInput("http://example.org/keys");
+        NewTrustedDomain input = jwksUrlInput("http://example.org/keys");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -229,20 +234,20 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldDefaultSpiffeTrustDomainToName_whenNoMatcherProvided() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         stubRepoForCreate();
 
         service.create(domain, input, null).test()
                 .assertNoErrors()
                 .assertValue(created -> "example.org".equals(created.getSpiffeTrustDomain()))
-                .assertValue(created -> created.getIssuer() == null);
+                .assertValue(created -> created.getDomainIdentifier() == null);
     }
 
     @Test
     public void shouldLowercaseTheSpiffeTrustDomainButKeepTheNameAsTyped() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setName("Acme Corp");
-        input.setSpiffeTrustDomain("ACME.ORG");
+        spiffeOf(input).setSpiffeTrustDomain("ACME.ORG");
         stubRepoForCreate();
 
         service.create(domain, input, null).test()
@@ -259,7 +264,7 @@ public class TrustDomainServiceImplTest {
 
         service.create(domain, tokenExchangeInput(), null).test()
                 .assertNoErrors()
-                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()))
+                .assertValue(created -> "https://issuer.example.com".equals(created.getDomainIdentifier()))
                 .assertValue(created -> created.getSpiffeTrustDomain() == null);
     }
 
@@ -267,14 +272,14 @@ public class TrustDomainServiceImplTest {
     public void shouldServeBothUsagesFromOneTrustedDomain() {
         stubRepoForCreate();
         stubNoIssuerConflict();
-        NewTrustDomain input = tokenExchangeInput();
+        NewTrustedDomain input = tokenExchangeInput();
         input.setName("acme-corp");
-        input.setSpiffeTrustDomain("acme.org");
+        spiffeOf(input).setSpiffeTrustDomain("acme.org");
 
         service.create(domain, input, null).test()
                 .assertNoErrors()
                 .assertValue(created -> "acme.org".equals(created.getSpiffeTrustDomain()))
-                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()));
+                .assertValue(created -> "https://issuer.example.com".equals(created.getDomainIdentifier()));
     }
 
     @Test
@@ -290,7 +295,7 @@ public class TrustDomainServiceImplTest {
     @Test
     public void shouldRejectDuplicateSpiffeTrustDomain() {
         when(repository.findBySpiffeTrustDomain(ReferenceType.DOMAIN, DOMAIN_ID, "example.org"))
-                .thenReturn(Maybe.just(new TrustDomain()));
+                .thenReturn(Maybe.just(new TrustedDomain()));
 
         service.create(domain, validInput(), null).test()
                 .assertError(TrustDomainSpiffeAlreadyExistsException.class);
@@ -299,8 +304,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectASpiffeTrustDomainThatIsNotADnsStyleLabel() {
-        NewTrustDomain input = validInput();
-        input.setSpiffeTrustDomain("-nope-");
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setSpiffeTrustDomain("-nope-");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -309,8 +314,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectANameLongerThanTheColumn() {
-        NewTrustDomain input = validInput();
-        input.setName("a".repeat(TrustDomain.NAME_MAX_LENGTH + 1));
+        NewTrustedDomain input = validInput();
+        input.setName("a".repeat(TrustedDomain.NAME_MAX_LENGTH + 1));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -319,8 +324,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectASpiffeTrustDomainLongerThanTheColumn() {
-        NewTrustDomain input = validInput();
-        input.setSpiffeTrustDomain("a".repeat(TrustDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + 1));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setSpiffeTrustDomain("a".repeat(TrustedDomain.SPIFFE_TRUST_DOMAIN_MAX_LENGTH + 1));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -329,9 +334,9 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldAcceptAFreeFormNameNowThatItIsOnlyALabel() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setName("Acme Corp (prod)");
-        input.setSpiffeTrustDomain("acme.org");
+        spiffeOf(input).setSpiffeTrustDomain("acme.org");
         stubRepoForCreate();
 
         service.create(domain, input, null).test().assertNoErrors();
@@ -339,7 +344,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldAcceptPemKeyMaterial() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate(PEM_CERTIFICATE)
@@ -353,7 +358,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectUnparseablePemKeyMaterial() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.PEM)
                 .certificate("not-a-certificate")
@@ -366,7 +371,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectPemKeyMaterialWithoutCertificate() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder().source(KeyMaterialSource.PEM).build());
 
         service.create(domain, input, null).test()
@@ -376,7 +381,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldAcceptInlineJwkSetKeyMaterial() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWK_SET)
                 .jwkSet(inlineJwkSet())
@@ -390,7 +395,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectEmptyInlineJwkSet() {
-        NewTrustDomain input = validInput();
+        NewTrustedDomain input = validInput();
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWK_SET)
                 .jwkSet(new JWKSet())
@@ -412,18 +417,6 @@ public class TrustDomainServiceImplTest {
         service.create(domain, input, null).test()
                 .assertNoErrors()
                 .assertValue(created -> created.getKeyMaterial().getSource() == KeyMaterialSource.JWKS_URL)
-                .assertValue(created -> "https://example.com/keys".equals(created.getKeyMaterial().getJwksUrl()));
-    }
-
-    @Test
-    public void shouldIgnoreDeprecatedBundleSourceInput_whenKeyMaterialSupplied() {
-        NewTrustDomain input = validInput();
-        input.setBundleSource(SpiffeBundleSource.JWKS_URL);
-        input.setJwksUrl("https://deprecated.example.com/keys");
-        stubRepoForCreate();
-
-        service.create(domain, input, null).test()
-                .assertNoErrors()
                 .assertValue(created -> "https://example.com/keys".equals(created.getKeyMaterial().getJwksUrl()));
     }
 
@@ -464,8 +457,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenRefreshIntervalZero() {
-        NewTrustDomain input = validInput();
-        input.setRefreshIntervalSeconds(0);
+        NewTrustedDomain input = validInput();
+        input.getKeyMaterial().setRefreshIntervalSeconds(0);
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -474,8 +467,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenRefreshIntervalNegative() {
-        NewTrustDomain input = validInput();
-        input.setRefreshIntervalSeconds(-1);
+        NewTrustedDomain input = validInput();
+        input.getKeyMaterial().setRefreshIntervalSeconds(-1);
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class);
@@ -483,8 +476,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_usesDefault_whenRefreshIntervalNotProvided() {
-        NewTrustDomain input = validInput();
-        input.setRefreshIntervalSeconds(null);
+        NewTrustedDomain input = validInput();
+        input.getKeyMaterial().setRefreshIntervalSeconds(null);
         stubRepoForCreate();
 
         service.create(domain, input, null).test()
@@ -493,8 +486,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenAllowedAlgorithmsContainsNone() {
-        NewTrustDomain input = validInput();
-        input.setAllowedAlgorithms(List.of("RS256", "none"));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("RS256", "none"));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -503,8 +496,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenAllowedAlgorithmsContainsHs256() {
-        NewTrustDomain input = validInput();
-        input.setAllowedAlgorithms(List.of("HS256"));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("HS256"));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class);
@@ -512,8 +505,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenAllowedAlgorithmsContainsHs512() {
-        NewTrustDomain input = validInput();
-        input.setAllowedAlgorithms(List.of("hs512"));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("hs512"));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class);
@@ -521,8 +514,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_rejects_whenAllowedAlgorithmsContainsBlank() {
-        NewTrustDomain input = validInput();
-        input.setAllowedAlgorithms(List.of("RS256", "  "));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("RS256", "  "));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class);
@@ -530,26 +523,65 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_acceptsValidAllowedAlgorithms() {
-        NewTrustDomain input = validInput();
-        input.setAllowedAlgorithms(List.of("RS256", "ES256", "EdDSA"));
+        NewTrustedDomain input = validInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("RS256", "ES256", "EdDSA"));
         stubRepoForCreate();
 
         service.create(domain, input, null).test().assertNoErrors();
     }
 
-    private NewTrustDomain validInput() {
+    private NewTrustedDomain validInput() {
         return jwksUrlInput("https://example.com/keys");
     }
 
-    private NewTrustDomain jwksUrlInput(String jwksUrl) {
-        NewTrustDomain input = new NewTrustDomain();
+    private NewTrustedDomain jwksUrlInput(String jwksUrl) {
+        NewTrustedDomain input = new NewTrustedDomain();
         input.setName("example.org");
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl(jwksUrl)
+                .refreshIntervalSeconds(60)
                 .build());
-        input.setRefreshIntervalSeconds(60);
+        input.setSpiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("example.org").build());
         return input;
+    }
+
+    private static SpiffeTrustSettings spiffeOf(NewTrustedDomain input) {
+        if (input.getSpiffe() == null) {
+            input.setSpiffe(new SpiffeTrustSettings());
+        }
+        return input.getSpiffe();
+    }
+
+    private static SpiffeTrustSettings spiffeOf(UpdateTrustedDomain input) {
+        if (input.getSpiffe() == null) {
+            input.setSpiffe(new SpiffeTrustSettings());
+        }
+        return input.getSpiffe();
+    }
+
+    private static TokenExchangeTrustSettings tokenExchangeOf(NewTrustedDomain input) {
+        if (input.getTokenExchange() == null) {
+            input.setTokenExchange(new TokenExchangeTrustSettings());
+        }
+        return input.getTokenExchange();
+    }
+
+    private static TokenExchangeTrustSettings tokenExchangeOf(UpdateTrustedDomain input) {
+        if (input.getTokenExchange() == null) {
+            input.setTokenExchange(new TokenExchangeTrustSettings());
+        }
+        return input.getTokenExchange();
+    }
+
+    private static void tokenExchangeIssuer(NewTrustedDomain input, String issuer) {
+        input.setDomainIdentifier(issuer);
+        tokenExchangeOf(input);
+    }
+
+    private static void tokenExchangeIssuer(UpdateTrustedDomain input, String issuer) {
+        input.setDomainIdentifier(issuer);
+        tokenExchangeOf(input);
     }
 
     private void stubExistingTrustDomainForUpdate() {
@@ -568,17 +600,17 @@ public class TrustDomainServiceImplTest {
         when(eventService.create(any(), any())).thenReturn(Single.just(new io.gravitee.am.model.common.event.Event()));
     }
 
-    private static TrustDomain spiffeEntity() {
-        TrustDomain existing = new TrustDomain();
+    private static TrustedDomain spiffeEntity() {
+        TrustedDomain existing = new TrustedDomain();
         existing.setId("td-1");
         existing.setReferenceType(ReferenceType.DOMAIN);
         existing.setReferenceId(DOMAIN_ID);
         existing.setName("example.org");
-        existing.setSpiffeTrustDomain("example.org");
-        existing.setRefreshIntervalSeconds(60);
+        existing.setSpiffe(SpiffeTrustSettings.builder().spiffeTrustDomain("example.org").build());
         existing.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://example.com/keys")
+                .refreshIntervalSeconds(60)
                 .build());
         return existing;
     }
@@ -616,7 +648,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void create_audits_whenDuplicateName() {
-        TrustDomain existing = new TrustDomain();
+        TrustedDomain existing = new TrustedDomain();
         existing.setId("existing-1");
         existing.setName("example.org");
         when(repository.findByName(any(), any(), any())).thenReturn(Maybe.just(existing));
@@ -638,7 +670,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void update_audits_whenLinkedToWrongDomain() {
-        TrustDomain other = new TrustDomain();
+        TrustedDomain other = new TrustedDomain();
         other.setId("td-1");
         other.setReferenceType(ReferenceType.DOMAIN);
         other.setReferenceId("some-other-domain");
@@ -661,7 +693,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void delete_audits_whenLinkedToWrongDomain() {
-        TrustDomain other = new TrustDomain();
+        TrustedDomain other = new TrustedDomain();
         other.setId("td-1");
         other.setReferenceType(ReferenceType.DOMAIN);
         other.setReferenceId("some-other-domain");
@@ -674,7 +706,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void delete_audits_onSuccess() {
-        TrustDomain td = new TrustDomain();
+        TrustedDomain td = new TrustedDomain();
         td.setId("td-1");
         td.setReferenceType(ReferenceType.DOMAIN);
         td.setReferenceId(DOMAIN_ID);
@@ -694,16 +726,16 @@ public class TrustDomainServiceImplTest {
 
         service.create(domain, tokenExchangeInput(), null).test()
                 .assertNoErrors()
-                .assertValue(created -> "https://issuer.example.com".equals(created.getIssuer()));
+                .assertValue(created -> "https://issuer.example.com".equals(created.getDomainIdentifier()));
     }
 
     @Test
     public void shouldRoundTripScopeMappingsAndUserBinding() {
         stubRepoForCreate();
         stubNoIssuerConflict();
-        NewTrustDomain input = tokenExchangeInput();
-        input.setUserBindingEnabled(true);
-        input.setUserBindingCriteria(List.of(criterion("emails.value", "{#token['email']}")));
+        NewTrustedDomain input = tokenExchangeInput();
+        tokenExchangeOf(input).setUserBindingEnabled(true);
+        tokenExchangeOf(input).setUserBindingCriteria(List.of(criterion("emails.value", "{#token['email']}")));
 
         service.create(domain, input, null).test()
                 .assertNoErrors()
@@ -736,21 +768,22 @@ public class TrustDomainServiceImplTest {
     }
 
     @Test
-    public void shouldAllowAlgorithmsOnATokenExchangeTrustedDomain() {
+    public void shouldDropAlgorithmsOnATokenExchangeOnlyTrustedDomain() {
         stubRepoForCreate();
         stubNoIssuerConflict();
-        NewTrustDomain input = tokenExchangeInput();
-        input.setAllowedAlgorithms(List.of("RS256"));
+        NewTrustedDomain input = tokenExchangeInput();
+        spiffeOf(input).setAllowedAlgorithms(List.of("RS256"));
 
         service.create(domain, input, null).test()
                 .assertNoErrors()
-                .assertValue(created -> List.of("RS256").equals(created.getAllowedAlgorithms()));
+                .assertValue(created -> created.getSpiffe() == null)
+                .assertValue(created -> created.getAllowedAlgorithms() == null);
     }
 
     @Test
     public void shouldRejectTrustedDomainWithoutAnyMatcher() {
-        NewTrustDomain input = tokenExchangeInput();
-        input.setIssuer("  ");
+        NewTrustedDomain input = tokenExchangeInput();
+        tokenExchangeIssuer(input, "  ");
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -759,8 +792,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectAnIssuerLongerThanTheColumn() {
-        NewTrustDomain input = tokenExchangeInput();
-        input.setIssuer("https://issuer.example.com/" + "a".repeat(TrustDomain.ISSUER_MAX_LENGTH));
+        NewTrustedDomain input = tokenExchangeInput();
+        tokenExchangeIssuer(input, "https://issuer.example.com/" + "a".repeat(TrustedDomain.ISSUER_MAX_LENGTH));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -769,7 +802,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldAcceptAnIssuerOnlyTrustedDomainWithoutASpiffeTrustDomain() {
-        NewTrustDomain input = tokenExchangeInput();
+        NewTrustedDomain input = tokenExchangeInput();
         stubRepoForCreate();
 
         service.create(domain, input, null).test().assertNoErrors();
@@ -777,8 +810,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectScopeMappingsWithoutAnIssuer() {
-        NewTrustDomain input = validInput();
-        input.setScopeMappings(Map.of("read", "domain:read"));
+        NewTrustedDomain input = validInput();
+        tokenExchangeOf(input).setScopeMappings(Map.of("read", "domain:read"));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -787,8 +820,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectUserBindingWithoutAnIssuer() {
-        NewTrustDomain input = validInput();
-        input.setUserBindingEnabled(true);
+        NewTrustedDomain input = validInput();
+        tokenExchangeOf(input).setUserBindingEnabled(true);
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -797,8 +830,8 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectUserBindingWithoutCriteria() {
-        NewTrustDomain input = tokenExchangeInput();
-        input.setUserBindingEnabled(true);
+        NewTrustedDomain input = tokenExchangeInput();
+        tokenExchangeOf(input).setUserBindingEnabled(true);
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -807,9 +840,9 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldRejectUserBindingCriterionWithBlankAttribute() {
-        NewTrustDomain input = tokenExchangeInput();
-        input.setUserBindingEnabled(true);
-        input.setUserBindingCriteria(List.of(criterion(" ", "{#token['email']}")));
+        NewTrustedDomain input = tokenExchangeInput();
+        tokenExchangeOf(input).setUserBindingEnabled(true);
+        tokenExchangeOf(input).setUserBindingCriteria(List.of(criterion(" ", "{#token['email']}")));
 
         service.create(domain, input, null).test()
                 .assertError(InvalidTrustDomainException.class)
@@ -819,7 +852,7 @@ public class TrustDomainServiceImplTest {
     @Test
     public void shouldRejectDuplicateIssuerInSameDomain() {
         when(repository.findByIssuer(ReferenceType.DOMAIN, DOMAIN_ID, "https://issuer.example.com"))
-                .thenReturn(Maybe.just(new TrustDomain()));
+                .thenReturn(Maybe.just(new TrustedDomain()));
 
         service.create(domain, tokenExchangeInput(), null).test()
                 .assertError(TrustDomainIssuerAlreadyExistsException.class);
@@ -828,7 +861,7 @@ public class TrustDomainServiceImplTest {
 
     @Test
     public void shouldAuditDuplicateIssuerRejection() {
-        when(repository.findByIssuer(any(), any(), any())).thenReturn(Maybe.just(new TrustDomain()));
+        when(repository.findByIssuer(any(), any(), any())).thenReturn(Maybe.just(new TrustedDomain()));
 
         service.create(domain, tokenExchangeInput(), null).test()
                 .assertError(TrustDomainIssuerAlreadyExistsException.class);
@@ -846,18 +879,73 @@ public class TrustDomainServiceImplTest {
     }
 
     @Test
+    public void shouldCollapseTheSpiffeBlockWhenCreateCarriesNoMatcher() {
+        stubRepoForCreate();
+        stubNoIssuerConflict();
+        NewTrustedDomain input = tokenExchangeInput();
+        spiffeOf(input).setSpiffeTrustDomain("");
+        spiffeOf(input).setAllowedAlgorithms(List.of("RS256"));
+
+        service.create(domain, input, null).test()
+                .assertNoErrors()
+                .assertValue(created -> created.getSpiffe() == null);
+    }
+
+    @Test
+    public void shouldCollapseTheTokenExchangeBlockWhenCreateCarriesNoIssuer() {
+        stubRepoForCreate();
+        NewTrustedDomain input = validInput();
+        input.setDomainIdentifier("");
+        tokenExchangeOf(input);
+
+        service.create(domain, input, null).test()
+                .assertNoErrors()
+                .assertValue(created -> created.getTokenExchange() == null);
+    }
+
+    @Test
     public void shouldUpdateTokenExchangeSettings() {
         stubExistingTokenExchangeForUpdate();
         stubNoIssuerConflict();
 
-        UpdateTrustDomain input = new UpdateTrustDomain();
-        input.setIssuer("https://issuer.example.com/v2");
-        input.setScopeMappings(Map.of("write", "domain:write"));
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        tokenExchangeIssuer(input, "https://issuer.example.com/v2");
+        tokenExchangeOf(input).setScopeMappings(Map.of("write", "domain:write"));
 
         service.update(domain, "td-1", input, null).test()
                 .assertNoErrors()
-                .assertValue(saved -> "https://issuer.example.com/v2".equals(saved.getIssuer()))
+                .assertValue(saved -> "https://issuer.example.com/v2".equals(saved.getDomainIdentifier()))
                 .assertValue(saved -> Map.of("write", "domain:write").equals(saved.getScopeMappings()));
+    }
+
+    @Test
+    public void shouldClearTheIssuerWhenUpdateSendsABlankDomainIdentifier() {
+        stubExistingTokenExchangeForUpdate();
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        input.setDomainIdentifier("");
+        tokenExchangeOf(input).setScopeMappings(Map.of());
+        spiffeOf(input).setSpiffeTrustDomain("issuer.example.com");
+
+        service.update(domain, "td-1", input, null).test()
+                .assertNoErrors()
+                .assertValue(saved -> saved.getDomainIdentifier() == null)
+                .assertValue(saved -> saved.getTokenExchange() == null)
+                .assertValue(saved -> "issuer.example.com".equals(saved.getSpiffeTrustDomain()));
+    }
+
+    @Test
+    public void shouldClearTheSpiffeMatcherWhenUpdateSendsABlankOne() {
+        stubExistingTrustDomainForUpdate();
+        stubNoIssuerConflict();
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        spiffeOf(input).setSpiffeTrustDomain("");
+        tokenExchangeIssuer(input, "https://issuer.example.com");
+
+        service.update(domain, "td-1", input, null).test()
+                .assertNoErrors()
+                .assertValue(saved -> saved.getSpiffeTrustDomain() == null)
+                .assertValue(saved -> saved.getSpiffe() == null)
+                .assertValue(saved -> "https://issuer.example.com".equals(saved.getDomainIdentifier()));
     }
 
     @Test
@@ -866,20 +954,20 @@ public class TrustDomainServiceImplTest {
 
         service.update(domain, "td-1", new UpdateTrustDomain(), null).test()
                 .assertNoErrors()
-                .assertValue(saved -> "https://issuer.example.com".equals(saved.getIssuer()));
+                .assertValue(saved -> "https://issuer.example.com".equals(saved.getDomainIdentifier()));
         verify(repository, never()).findByIssuer(any(), any(), any());
     }
 
     @Test
     public void shouldRejectUpdateIntroducingDuplicateIssuer() {
         stubExistingTokenExchange();
-        TrustDomain other = new TrustDomain();
+        TrustedDomain other = new TrustedDomain();
         other.setId("td-2");
         when(repository.findByIssuer(ReferenceType.DOMAIN, DOMAIN_ID, "https://issuer.example.com/v2"))
                 .thenReturn(Maybe.just(other));
 
-        UpdateTrustDomain input = new UpdateTrustDomain();
-        input.setIssuer("https://issuer.example.com/v2");
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        tokenExchangeIssuer(input, "https://issuer.example.com/v2");
 
         service.update(domain, "td-1", input, null).test()
                 .assertError(TrustDomainIssuerAlreadyExistsException.class);
@@ -890,9 +978,9 @@ public class TrustDomainServiceImplTest {
     public void shouldAllowUpdateKeepingItsOwnIssuer() {
         stubExistingTokenExchangeForUpdate();
 
-        UpdateTrustDomain input = new UpdateTrustDomain();
-        input.setIssuer("https://issuer.example.com");
-        input.setScopeMappings(Map.of("write", "domain:write"));
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        tokenExchangeIssuer(input, "https://issuer.example.com");
+        tokenExchangeOf(input).setScopeMappings(Map.of("write", "domain:write"));
 
         service.update(domain, "td-1", input, null).test().assertNoErrors();
         verify(repository, never()).findByIssuer(any(), any(), any());
@@ -903,14 +991,14 @@ public class TrustDomainServiceImplTest {
         stubExistingSpiffeTrustDomainForUpdate();
         stubNoIssuerConflict();
 
-        UpdateTrustDomain input = new UpdateTrustDomain();
-        input.setSpiffeTrustDomain("example.org");
-        input.setIssuer("https://issuer.example.com");
+        UpdateTrustedDomain input = new UpdateTrustedDomain();
+        spiffeOf(input).setSpiffeTrustDomain("example.org");
+        tokenExchangeIssuer(input, "https://issuer.example.com");
 
         service.update(domain, "td-1", input, null).test()
                 .assertNoErrors()
                 .assertValue(saved -> "example.org".equals(saved.getSpiffeTrustDomain()))
-                .assertValue(saved -> "https://issuer.example.com".equals(saved.getIssuer()));
+                .assertValue(saved -> "https://issuer.example.com".equals(saved.getDomainIdentifier()));
     }
 
     @Test
@@ -942,32 +1030,36 @@ public class TrustDomainServiceImplTest {
         }));
     }
 
-    private NewTrustDomain tokenExchangeInput() {
-        NewTrustDomain input = new NewTrustDomain();
+    private NewTrustedDomain tokenExchangeInput() {
+        NewTrustedDomain input = new NewTrustedDomain();
         input.setName("issuer.example.com");
         input.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://example.com/issuer/keys")
+                .refreshIntervalSeconds(60)
                 .build());
-        input.setRefreshIntervalSeconds(60);
-        input.setIssuer("https://issuer.example.com");
-        input.setScopeMappings(Map.of("read", "domain:read"));
+        input.setDomainIdentifier("https://issuer.example.com");
+        input.setTokenExchange(TokenExchangeTrustSettings.builder()
+                .scopeMappings(Map.of("read", "domain:read"))
+                .build());
         return input;
     }
 
-    private static TrustDomain tokenExchangeEntity() {
-        TrustDomain td = new TrustDomain();
+    private static TrustedDomain tokenExchangeEntity() {
+        TrustedDomain td = new TrustedDomain();
         td.setId("td-1");
         td.setReferenceType(ReferenceType.DOMAIN);
         td.setReferenceId(DOMAIN_ID);
         td.setName("issuer.example.com");
-        td.setRefreshIntervalSeconds(60);
         td.setKeyMaterial(TrustDomainKeyMaterial.builder()
                 .source(KeyMaterialSource.JWKS_URL)
                 .jwksUrl("https://example.com/issuer/keys")
+                .refreshIntervalSeconds(60)
                 .build());
-        td.setIssuer("https://issuer.example.com");
-        td.setScopeMappings(Map.of("read", "domain:read"));
+        td.setDomainIdentifier("https://issuer.example.com");
+        td.setTokenExchange(TokenExchangeTrustSettings.builder()
+                .scopeMappings(Map.of("read", "domain:read"))
+                .build());
         return td;
     }
 

--- a/gravitee-am-test/specs/gateway/trusted-domains/fixtures/trusted-domain-sync-fixture.ts
+++ b/gravitee-am-test/specs/gateway/trusted-domains/fixtures/trusted-domain-sync-fixture.ts
@@ -17,9 +17,7 @@
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { patchDomain, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
 import { Domain } from '@management-models/Domain';
-import { TrustDomain } from '@management-models/TrustDomain';
 import { uniqueName } from '@utils-commands/misc';
-import { createTrustDomain, deleteTrustDomain, updateTrustDomain } from '@management-commands/trust-domain-management-commands';
 import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { Fixture } from '../../../test-fixture';
 
@@ -34,12 +32,37 @@ export const TRUSTED_DOMAIN_SYNC_TEST = {
 
 const distinctLabel = (prefix: string) => uniqueName(prefix, true).toLowerCase();
 
+const trustDomainsUrl = (domainId: string, trustDomainId?: string) =>
+  `${process.env.AM_MANAGEMENT_URL}/management/organizations/${process.env.AM_DEF_ORG_ID}` +
+  `/environments/${process.env.AM_DEF_ENV_ID}/domains/${domainId}/trusted-domains${trustDomainId ? `/${trustDomainId}` : ''}`;
+
+export interface TrustedDomainResponse {
+  id: string;
+  name: string;
+  domainIdentifier?: string;
+  keyMaterial?: { source: string; jwksUrl?: string; refreshIntervalSeconds?: number };
+  spiffe?: { spiffeTrustDomain?: string; allowedAlgorithms?: string[] };
+  tokenExchange?: Record<string, unknown>;
+}
+
+const writeTrustDomain = async (url: string, method: 'POST' | 'PUT', token: string, body: object): Promise<TrustedDomainResponse> => {
+  const response = await fetch(url, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} ${url} failed: ${response.status} ${await response.text()}`);
+  }
+  return response.json();
+};
+
 /** Body of a trusted domain matching SPIFFE only, named so it collides with no other test's. */
 export const spiffeTrustDomainBody = () => {
   const label = distinctLabel('spiffe-sync');
   return {
     name: label,
-    spiffeTrustDomain: `${label}.local`,
+    spiffe: { spiffeTrustDomain: `${label}.local` },
     keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_JWKS_URL },
   };
 };
@@ -49,7 +72,8 @@ export const issuerTrustDomainBody = () => {
   const label = distinctLabel('issuer-sync');
   return {
     name: label,
-    issuer: `https://${label}.example.com`,
+    domainIdentifier: `https://${label}.example.com`,
+    tokenExchange: {},
     keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.TOKEN_EXCHANGE_JWKS_URL },
   };
 };
@@ -59,8 +83,9 @@ export const bothUsagesTrustDomainBody = () => {
   const label = distinctLabel('both-sync');
   return {
     name: label,
-    spiffeTrustDomain: `${label}.local`,
-    issuer: `https://${label}.example.com`,
+    spiffe: { spiffeTrustDomain: `${label}.local` },
+    domainIdentifier: `https://${label}.example.com`,
+    tokenExchange: {},
     keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.BOTH_JWKS_URL },
   };
 };
@@ -69,9 +94,9 @@ export interface TrustedDomainSyncFixture extends Fixture {
   domain: Domain;
   accessToken: string;
   /** Registers a trusted domain and waits for the gateway to apply the change. */
-  registerAndSync: (body: object) => Promise<TrustDomain>;
+  registerAndSync: (body: object) => Promise<TrustedDomainResponse>;
   /** Amends a trusted domain and waits for the gateway to apply the change. */
-  amendAndSync: (trustDomainId: string, body: object) => Promise<TrustDomain>;
+  amendAndSync: (trustDomainId: string, body: object) => Promise<TrustedDomainResponse>;
   /** Removes a trusted domain and waits for the gateway to apply the change. */
   removeAndSync: (trustDomainId: string) => Promise<void>;
 }
@@ -101,9 +126,19 @@ export const setupTrustedDomainSyncFixture = async (): Promise<TrustedDomainSync
     return {
       domain,
       accessToken,
-      registerAndSync: (body) => waitForSyncAfter(domainId, () => createTrustDomain(domainId, token, body)),
-      amendAndSync: (trustDomainId, body) => waitForSyncAfter(domainId, () => updateTrustDomain(domainId, token, trustDomainId, body)),
-      removeAndSync: (trustDomainId) => waitForSyncAfter(domainId, () => deleteTrustDomain(domainId, token, trustDomainId)),
+      registerAndSync: (body) => waitForSyncAfter(domainId, () => writeTrustDomain(trustDomainsUrl(domainId), 'POST', token, body)),
+      amendAndSync: (trustDomainId, body) =>
+        waitForSyncAfter(domainId, () => writeTrustDomain(trustDomainsUrl(domainId, trustDomainId), 'PUT', token, body)),
+      removeAndSync: (trustDomainId) =>
+        waitForSyncAfter(domainId, async () => {
+          const response = await fetch(trustDomainsUrl(domainId, trustDomainId), {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!response.ok) {
+            throw new Error(`DELETE trusted domain failed: ${response.status} ${await response.text()}`);
+          }
+        }),
       cleanUp: async () => {
         await safeDeleteDomain(domainId, token);
       },

--- a/gravitee-am-test/specs/gateway/trusted-domains/trusted-domain-sync.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/trusted-domains/trusted-domain-sync.jest.spec.ts
@@ -46,15 +46,15 @@ describe('Trusted domain changes reach the gateway', () => {
     const created = await fixture.registerAndSync(body);
 
     expect(created.name).toEqual(body.name);
-    expect(created.spiffeTrustDomain).toEqual(body.spiffeTrustDomain);
+    expect(created.spiffe.spiffeTrustDomain).toEqual(body.spiffe.spiffeTrustDomain);
   });
 
-  it('should synchronise the gateway when a trusted-issuer trusted domain is registered', async () => {
+  it('should synchronize the gateway when a trusted-issuer trusted domain is registered', async () => {
     const body = issuerTrustDomainBody();
 
     const created = await fixture.registerAndSync(body);
 
-    expect(created.issuer).toEqual(body.issuer);
+    expect(created.domainIdentifier).toEqual(body.domainIdentifier);
   });
 
   it('should synchronise the gateway when one trusted domain serves both usages', async () => {
@@ -62,20 +62,23 @@ describe('Trusted domain changes reach the gateway', () => {
 
     const created = await fixture.registerAndSync(body);
 
-    expect(created.spiffeTrustDomain).toEqual(body.spiffeTrustDomain);
-    expect(created.issuer).toEqual(body.issuer);
+    expect(created.spiffe.spiffeTrustDomain).toEqual(body.spiffe.spiffeTrustDomain);
+    expect(created.domainIdentifier).toEqual(body.domainIdentifier);
   });
 
   it('should synchronise the gateway when a trusted domain is amended', async () => {
     const registered = await fixture.registerAndSync(spiffeTrustDomainBody());
 
     const amended = await fixture.amendAndSync(registered.id, {
-      keyMaterial: { source: 'JWKS_URL', jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_AMENDED_JWKS_URL },
-      refreshIntervalSeconds: TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS,
+      keyMaterial: {
+        source: 'JWKS_URL',
+        jwksUrl: TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_AMENDED_JWKS_URL,
+        refreshIntervalSeconds: TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS,
+      },
     });
 
     expect(amended.keyMaterial.jwksUrl).toEqual(TRUSTED_DOMAIN_SYNC_TEST.SPIFFE_AMENDED_JWKS_URL);
-    expect(amended.refreshIntervalSeconds).toEqual(TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS);
+    expect(amended.keyMaterial.refreshIntervalSeconds).toEqual(TRUSTED_DOMAIN_SYNC_TEST.AMENDED_REFRESH_INTERVAL_SECONDS);
   });
 
   it('should synchronise the gateway when a trusted domain is removed', async () => {

--- a/gravitee-am-test/specs/management/permissions/fixtures/permission-endpoints.generated.ts
+++ b/gravitee-am-test/specs/management/permissions/fixtures/permission-endpoints.generated.ts
@@ -311,6 +311,12 @@ export const PERMISSION_ENDPOINTS: PermissionEndpoint[] = [
   },
   {
     method: 'GET',
+    route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/trusted-domains',
+    permission: 'domain_trust_domain_list',
+    summary: 'List trusted domains registered against the security domain',
+  },
+  {
+    method: 'GET',
     route: '/organizations/{organizationId}/environments/{environmentId}/domains/{domain}/users',
     permission: 'domain_user_list',
     summary: 'List users for a security domain',

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
@@ -129,7 +129,7 @@
     </mat-form-field>
   </div>
 
-  <div class="gv-form-section" fxLayout="column">
+  <div *ngIf="spiffeEnabled" class="gv-form-section" fxLayout="column">
     <div class="gv-form-section-title">
       <h5>Signing algorithms</h5>
       <mat-divider></mat-divider>

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.ts
@@ -269,7 +269,7 @@ export class TrustDomainFormComponent implements OnInit, OnChanges, OnDestroy {
       issuer: this.issuerEnabled ? (this.model.issuer ?? '').trim() : undefined,
       keyMaterial: this.model.keyMaterial,
       refreshIntervalSeconds: this.model.refreshIntervalSeconds,
-      allowedAlgorithms: this.model.allowedAlgorithms,
+      allowedAlgorithms: this.spiffeEnabled ? this.model.allowedAlgorithms : [],
       scopeMappings: this.issuerEnabled && Object.keys(scopeMappings).length ? scopeMappings : undefined,
       userBindingEnabled,
       userBindingCriteria: userBindingEnabled && this.userBindingRows.length ? this.userBindingRows : undefined,

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/trust-domain.types.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/trust-domain.types.spec.ts
@@ -15,13 +15,14 @@
  */
 import {
   deriveNameFromIssuer,
-  normalizeTrustDomain,
+  fromTrustedDomain,
   isValidSpiffeTrustDomain,
   keyMaterialErrors,
   keyMaterialSourceLabel,
   trustDomainUsageLabel,
   trustDomainUsages,
   trustDomainUsagesLabel,
+  toTrustedDomainRequest,
 } from './trust-domain.types';
 
 describe('trust domain types', () => {
@@ -74,35 +75,48 @@ describe('trust domain types', () => {
     expect(isValidSpiffeTrustDomain('prod.example')).toBe(true);
   });
 
-  describe('normalizeTrustDomain', () => {
-    it('shouldUppercaseTheEnumsTheApiLowercases', () => {
-      const fromApi = {
+  describe('fromTrustedDomain', () => {
+    it('shouldFlattenTheNestedBlocksOntoTheFormModel', () => {
+      const response = {
         id: 'td-1',
-        name: 'issuer.example',
-        issuer: 'https://issuer.example',
-        keyMaterial: { source: 'pem', certificate: '-----BEGIN CERTIFICATE-----' },
-      } as any;
+        name: 'acme-corp',
+        domainIdentifier: 'https://sso.acme.com',
+        keyMaterial: { source: 'jwks_url', jwksUrl: 'https://sso.acme.com/keys', refreshIntervalSeconds: 600 },
+        spiffe: { spiffeTrustDomain: 'acme.org', allowedAlgorithms: ['RS256'] },
+        tokenExchange: {
+          scopeMappings: { 'external:read': 'openid' },
+          userBindingEnabled: true,
+          userBindingCriteria: [{ attribute: 'email', expression: 'email' }],
+        },
+      };
 
-      expect(normalizeTrustDomain(fromApi)).toEqual({
+      expect(fromTrustedDomain(response)).toEqual({
         id: 'td-1',
-        name: 'issuer.example',
-        issuer: 'https://issuer.example',
-        keyMaterial: { source: 'PEM', certificate: '-----BEGIN CERTIFICATE-----' },
+        name: 'acme-corp',
+        description: undefined,
+        spiffeTrustDomain: 'acme.org',
+        issuer: 'https://sso.acme.com',
+        keyMaterial: { source: 'JWKS_URL', jwksUrl: 'https://sso.acme.com/keys', refreshIntervalSeconds: 600 },
+        refreshIntervalSeconds: 600,
+        allowedAlgorithms: ['RS256'],
+        scopeMappings: { 'external:read': 'openid' },
+        userBindingEnabled: true,
+        userBindingCriteria: [{ attribute: 'email', expression: 'email' }],
       });
     });
 
-    it('shouldLeaveCanonicalValuesAlone', () => {
-      const canonical = {
-        name: 'am.local',
-        spiffeTrustDomain: 'am.local',
-        keyMaterial: { source: 'JWKS_URL', jwksUrl: 'https://x/keys' },
-      } as any;
-      expect(normalizeTrustDomain(canonical)).toEqual(canonical);
+    it('shouldDefaultTheAbsentBlocks', () => {
+      const flat = fromTrustedDomain({ id: 'td-1', name: 'spire-prod' }) as any;
+
+      expect(flat.spiffeTrustDomain).toBeUndefined();
+      expect(flat.issuer).toBeUndefined();
+      expect(flat.allowedAlgorithms).toEqual([]);
+      expect(flat.userBindingEnabled).toBe(false);
+      expect(flat.refreshIntervalSeconds).toBe(300);
     });
 
-    it('shouldTolerateMissingKeyMaterial', () => {
-      expect(normalizeTrustDomain({ name: 'am.local' } as any)).toEqual({ name: 'am.local', keyMaterial: undefined });
-      expect(normalizeTrustDomain(undefined)).toBeUndefined();
+    it('shouldPassThroughNothing', () => {
+      expect(fromTrustedDomain(undefined)).toBeUndefined();
     });
   });
 
@@ -124,6 +138,67 @@ describe('trust domain types', () => {
     it('shouldRequireCertificateWhenSourceIsPem', () => {
       expect(keyMaterialErrors({ source: 'PEM' })).toHaveLength(1);
       expect(keyMaterialErrors({ source: 'PEM', certificate: '-----BEGIN CERTIFICATE-----' })).toHaveLength(0);
+    });
+  });
+
+  describe('toTrustedDomainRequest', () => {
+    it('shouldFoldTheRefreshIntervalOntoTheKeyMaterial', () => {
+      const request = toTrustedDomainRequest({
+        name: 'acme',
+        issuer: 'https://sso.acme.com',
+        keyMaterial: { source: 'JWKS_URL', jwksUrl: 'https://sso.acme.com/keys' },
+        refreshIntervalSeconds: 600,
+      });
+
+      expect(request.keyMaterial).toEqual({
+        source: 'JWKS_URL',
+        jwksUrl: 'https://sso.acme.com/keys',
+        refreshIntervalSeconds: 600,
+      });
+    });
+
+    it('shouldCarryScopeMappingsAndUserBindingUnderTokenExchange', () => {
+      const request = toTrustedDomainRequest({
+        name: 'acme',
+        issuer: 'https://sso.acme.com',
+        scopeMappings: { 'external:read': 'openid' },
+        userBindingEnabled: true,
+        userBindingCriteria: [{ attribute: 'email', expression: 'email' }],
+      });
+
+      expect(request.tokenExchange).toEqual({
+        scopeMappings: { 'external:read': 'openid' },
+        userBindingEnabled: true,
+        userBindingCriteria: [{ attribute: 'email', expression: 'email' }],
+      });
+    });
+
+    it('shouldPutTheSpiffeMatcherAndAlgorithmsUnderSpiffe', () => {
+      const request = toTrustedDomainRequest({ name: 'spire-prod', spiffeTrustDomain: 'spire.example', allowedAlgorithms: ['RS256'] });
+
+      expect(request.spiffe).toEqual({ spiffeTrustDomain: 'spire.example', allowedAlgorithms: ['RS256'] });
+    });
+
+    it('shouldDeclareBothBlocksWhenOneAuthorityServesBothUsages', () => {
+      const request = toTrustedDomainRequest({ name: 'acme-corp', spiffeTrustDomain: 'acme.org', issuer: 'https://sso.acme.com' });
+
+      expect(request.spiffe.spiffeTrustDomain).toBe('acme.org');
+      expect(request.domainIdentifier).toBe('https://sso.acme.com');
+    });
+
+    it('shouldBlankTheIssuerWhenTheUsageIsNotDeclared', () => {
+      const request = toTrustedDomainRequest({ name: 'acme', spiffeTrustDomain: 'acme.org' });
+
+      expect(request.domainIdentifier).toBe('');
+      expect(request.tokenExchange).toEqual({ scopeMappings: {}, userBindingEnabled: false, userBindingCriteria: [] });
+      expect(request.spiffe.spiffeTrustDomain).toBe('acme.org');
+    });
+
+    it('shouldBlankTheSpiffeMatcherWhenTheUsageIsNotDeclared', () => {
+      const request = toTrustedDomainRequest({ name: 'acme', issuer: 'https://sso.acme.com' });
+
+      expect(request.spiffe.spiffeTrustDomain).toBe('');
+      expect(request.domainIdentifier).toBe('https://sso.acme.com');
     });
   });
 });

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/trust-domain.types.ts
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/trust-domain.types.ts
@@ -51,6 +51,7 @@ export interface TrustDomainKeyMaterial {
   jwksUrl?: string;
   jwkSet?: JwkSet;
   certificate?: string;
+  refreshIntervalSeconds?: number;
 }
 
 /** One criterion for resolving an external JWT subject to a domain user (attribute + EL expression). */
@@ -73,6 +74,51 @@ export interface TrustDomain {
   scopeMappings?: Record<string, string>;
   userBindingEnabled?: boolean;
   userBindingCriteria?: UserBindingCriterion[];
+}
+
+export interface SpiffeTrustSettings {
+  spiffeTrustDomain?: string;
+  allowedAlgorithms?: string[];
+}
+
+export interface TokenExchangeTrustSettings {
+  scopeMappings?: Record<string, string>;
+  userBindingEnabled?: boolean;
+  userBindingCriteria?: UserBindingCriterion[];
+}
+
+export interface TrustedDomainRequest {
+  name?: string;
+  description?: string;
+  keyMaterial?: TrustDomainKeyMaterial;
+  domainIdentifier: string;
+  spiffe: SpiffeTrustSettings;
+  tokenExchange: TokenExchangeTrustSettings;
+}
+
+function keyMaterialWithInterval(trustDomain: TrustDomain): TrustDomainKeyMaterial | undefined {
+  if (!trustDomain.keyMaterial) {
+    return undefined;
+  }
+  return { ...trustDomain.keyMaterial, refreshIntervalSeconds: trustDomain.refreshIntervalSeconds };
+}
+
+export function toTrustedDomainRequest(trustDomain: TrustDomain): TrustedDomainRequest {
+  return {
+    name: trustDomain.name,
+    description: trustDomain.description,
+    keyMaterial: keyMaterialWithInterval(trustDomain),
+    domainIdentifier: trustDomain.issuer ?? '',
+    spiffe: {
+      spiffeTrustDomain: trustDomain.spiffeTrustDomain ?? '',
+      allowedAlgorithms: trustDomain.allowedAlgorithms ?? [],
+    },
+    tokenExchange: {
+      scopeMappings: trustDomain.scopeMappings ?? {},
+      userBindingEnabled: trustDomain.userBindingEnabled ?? false,
+      userBindingCriteria: trustDomain.userBindingCriteria ?? [],
+    },
+  };
 }
 
 export function trustDomainUsages(trustDomain: TrustDomain | undefined): TrustDomainUsage[] {
@@ -116,20 +162,25 @@ export function keyMaterialSourceLabel(source: KeyMaterialSource | string): stri
   return optionLabel(KEY_MATERIAL_SOURCE_OPTIONS, source);
 }
 
-/**
- * Restores the canonical enum spelling. The management API serializes every enum lowercased
- * (ObjectMapperResolver) and accepts either case back, so responses carry "pem" where the console
- * compares against PEM.
- */
-export function normalizeTrustDomain<T>(trustDomain: T): T {
-  const td = trustDomain as TrustDomain;
-  if (!td) {
-    return trustDomain;
+export function fromTrustedDomain<T>(response: T): T {
+  const trustedDomain = response as unknown as Record<string, any>;
+  if (!trustedDomain) {
+    return response;
   }
+  const keyMaterial = trustedDomain.keyMaterial;
   return {
-    ...td,
-    keyMaterial: td.keyMaterial ? { ...td.keyMaterial, source: td.keyMaterial.source?.toUpperCase() as KeyMaterialSource } : td.keyMaterial,
-  } as T;
+    id: trustedDomain.id,
+    name: trustedDomain.name,
+    description: trustedDomain.description,
+    spiffeTrustDomain: trustedDomain.spiffe?.spiffeTrustDomain,
+    issuer: trustedDomain.domainIdentifier,
+    keyMaterial: keyMaterial ? { ...keyMaterial, source: keyMaterial.source?.toUpperCase() as KeyMaterialSource } : keyMaterial,
+    refreshIntervalSeconds: keyMaterial?.refreshIntervalSeconds ?? DEFAULT_REFRESH_INTERVAL_SECONDS,
+    allowedAlgorithms: trustedDomain.spiffe?.allowedAlgorithms ?? [],
+    scopeMappings: trustedDomain.tokenExchange?.scopeMappings,
+    userBindingEnabled: trustedDomain.tokenExchange?.userBindingEnabled ?? false,
+    userBindingCriteria: trustedDomain.tokenExchange?.userBindingCriteria,
+  } as unknown as T;
 }
 
 const OUTSIDE_LABEL = /[^a-z0-9.-]+/g;

--- a/gravitee-am-ui/src/app/services/trust-domain.service.ts
+++ b/gravitee-am-ui/src/app/services/trust-domain.service.ts
@@ -19,7 +19,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { AppConfig } from '../../config/app.config';
-import { normalizeTrustDomain } from '../domain/settings/trust-domains/trust-domain.types';
+import { fromTrustedDomain, toTrustedDomainRequest } from '../domain/settings/trust-domains/trust-domain.types';
 
 @Injectable()
 export class TrustDomainService {
@@ -29,36 +29,27 @@ export class TrustDomainService {
 
   list(domainId: string): Observable<any> {
     return this.http
-      .get<any>(this.domainBaseURL + domainId + '/trust-domains')
-      .pipe(map((trustDomains) => (trustDomains ?? []).map(normalizeTrustDomain)));
+      .get<any>(this.domainBaseURL + domainId + '/trusted-domains')
+      .pipe(map((trustDomains) => (trustDomains ?? []).map(fromTrustedDomain)));
   }
 
   get(domainId: string, id: string): Observable<any> {
-    return this.http.get<any>(this.domainBaseURL + domainId + '/trust-domains/' + id).pipe(map(normalizeTrustDomain));
+    return this.http.get<any>(this.domainBaseURL + domainId + '/trusted-domains/' + id).pipe(map(fromTrustedDomain));
   }
 
   create(domainId: string, trustDomain: any): Observable<any> {
-    return this.http.post<any>(this.domainBaseURL + domainId + '/trust-domains', trustDomain).pipe(map(normalizeTrustDomain));
+    return this.http
+      .post<any>(this.domainBaseURL + domainId + '/trusted-domains', toTrustedDomainRequest(trustDomain))
+      .pipe(map(fromTrustedDomain));
   }
 
   update(domainId: string, id: string, trustDomain: any): Observable<any> {
     return this.http
-      .put<any>(this.domainBaseURL + domainId + '/trust-domains/' + id, {
-        name: trustDomain.name,
-        description: trustDomain.description,
-        spiffeTrustDomain: trustDomain.spiffeTrustDomain,
-        issuer: trustDomain.issuer,
-        keyMaterial: trustDomain.keyMaterial,
-        refreshIntervalSeconds: trustDomain.refreshIntervalSeconds,
-        allowedAlgorithms: trustDomain.allowedAlgorithms,
-        scopeMappings: trustDomain.scopeMappings,
-        userBindingEnabled: trustDomain.userBindingEnabled,
-        userBindingCriteria: trustDomain.userBindingCriteria,
-      })
-      .pipe(map(normalizeTrustDomain));
+      .put<any>(this.domainBaseURL + domainId + '/trusted-domains/' + id, toTrustedDomainRequest(trustDomain))
+      .pipe(map(fromTrustedDomain));
   }
 
   delete(domainId: string, id: string): Observable<any> {
-    return this.http.delete<any>(this.domainBaseURL + domainId + '/trust-domains/' + id);
+    return this.http.delete<any>(this.domainBaseURL + domainId + '/trusted-domains/' + id);
   }
 }


### PR DESCRIPTION
4.12 NewTrustDomain **/trust-domains**
```
  {
    "name": "spire.example.org",
    "description": "SPIRE production",
    "bundleSource": "JWKS_URL",
    "jwksUrl": "https://spire.example.org/keys",
    "refreshIntervalSeconds": 300,
    "allowedAlgorithms": ["RS256", "ES256"]
  }
```

The new **/trusted-domains** 4.13 payload:
```
  {
    "name": "acme-corp",
    "description": "Acme",
    "domainIdentifier": "https://sso.acme.com",
    "keyMaterial": {
      "source": "JWKS_URL",
      "jwksUrl": "https://sso.acme.com/.well-known/jwks.json",
      "refreshIntervalSeconds": 300
    },
    "spiffe": {
      "spiffeTrustDomain": "acme.org",
      "allowedAlgorithms": ["RS256"]
    },
    "tokenExchange": {
      "scopeMappings": { "external:read": "openid" },
      "userBindingEnabled": true,
      "userBindingCriteria": [{ "attribute": "email", "expression": "{#token['email']}" }]
    }
  }
```
