### PR TITLE
test: map a provider duplicate to a SCIM conflict (AM-7620)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -367,25 +367,12 @@ public class ProvisioningUserServiceTest {
         verify(userRepository, never()).create(any());
     }
 
-    /**
-     * The two checks above run before the user is persisted, so they are not atomic. Two concurrent
-     * requests for the same username both pass them and race to the identity provider; the loser hits
-     * the database's unique constraint, which the provider reports as
-     * {@link UserAlreadyExistsException}. That much is covered at the provider layer by
-     * {@code JdbcUserProvider_Test#shouldReturnUserAlreadyExists_onConcurrentCreate}.
-     *
-     * <p>This pins the hop after it. {@code ScimErrorMapper} turns {@link UniquenessException} into
-     * the 409 the caller sees, so leaving the provider's exception unmapped surfaces a 500 instead —
-     * which is what was reported for {@code POST /scim/Users} on AM-7285, fixed in 4.9.27, 4.10.18,
-     * 4.11.12 and 4.12.2.
-     */
     @Test
     public void shouldNotCreateUserWhenTheProviderReportsADuplicate() {
         UserProvider userProvider = mock(UserProvider.class);
         when(userProvider.create(any())).thenReturn(Single.error(new UserAlreadyExistsException("username-1")));
 
-        // nothing exists yet, so both checks pass and the request reaches the provider — the window
-        // two concurrent creates get through together
+        // nothing exists yet, so the pre-checks pass and the request reaches the provider
         when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
         when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
         when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -62,6 +62,7 @@ import io.gravitee.am.service.ApplicationService;
 import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.EventService;
 import io.gravitee.am.service.PasswordService;
+import io.gravitee.am.service.exception.UserAlreadyExistsException;
 import io.gravitee.am.service.exception.UserInvalidException;
 import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.validators.email.EmailValidatorImpl;
@@ -363,6 +364,41 @@ public class ProvisioningUserServiceTest {
                 && "existing-user-id".equals(uniquenessException.getExistingUserId())
                 && "username-1".equals(uniquenessException.getExistingUsername()));
 
+        verify(userRepository, never()).create(any());
+    }
+
+    /**
+     * The two checks above run before the user is persisted, so they are not atomic. Two concurrent
+     * requests for the same username both pass them and race to the identity provider; the loser hits
+     * the database's unique constraint, which the provider reports as
+     * {@link UserAlreadyExistsException}. That much is covered at the provider layer by
+     * {@code JdbcUserProvider_Test#shouldReturnUserAlreadyExists_onConcurrentCreate}.
+     *
+     * <p>This pins the hop after it. {@code ScimErrorMapper} turns {@link UniquenessException} into
+     * the 409 the caller sees, so leaving the provider's exception unmapped surfaces a 500 instead —
+     * which is what was reported for {@code POST /scim/Users} on AM-7285, fixed in 4.9.27, 4.10.18,
+     * 4.11.12 and 4.12.2.
+     */
+    @Test
+    public void shouldNotCreateUserWhenTheProviderReportsADuplicate() {
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.create(any())).thenReturn(Single.error(new UserAlreadyExistsException("username-1")));
+
+        // nothing exists yet, so both checks pass and the request reaches the provider — the window
+        // two concurrent creates get through together
+        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        when(passwordService.isValid(any(), any(), any())).thenReturn(true);
+
+        User newUser = mock(User.class);
+        when(newUser.getSource()).thenReturn("unknown-idp");
+        when(newUser.getUserName()).thenReturn("username-1");
+        when(newUser.getPassword()).thenReturn(UUID.randomUUID().toString());
+
+        TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+
+        testObserver.assertError(UniquenessException.class);
         verify(userRepository, never()).create(any());
     }
 


### PR DESCRIPTION
## :id: Reference related issue.
[AM-7620](https://gravitee.atlassian.net/browse/AM-7620)

## :pencil2: A description of the changes proposed in the pull request
`ProvisioningUserServiceImpl` checks for an existing username before persisting, but that check is not atomic. Two concurrent `POST /scim/Users` for the same username both pass it and race to the identity provider; the loser hits the database's unique constraint. The provider reports that as `UserAlreadyExistsException`, and `ProvisioningUserServiceImpl:342` maps it to `UniquenessException` so `ScimErrorMapper` can return a 409. Unmapped it surfaces as a 500, which is what was reported on AM-7285.

That mapping had no test. `ProvisioningUserServiceTest` had zero references to `UserAlreadyExistsException`.

- A duplicate reported by the provider is returned to the caller as a conflict, not an internal error

One method appended to `ProvisioningUserServiceTest`, plus its import. No production code touched, no existing test changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**The concurrency itself is already covered**, at the layer below: `JdbcUserProvider_Test#shouldReturnUserAlreadyExists_onConcurrentCreate` runs genuinely concurrent creates and asserts every loser surfaces `UserAlreadyExistsException` rather than a raw database error. It shipped with the AM-7285 fix. What was missing was only the hop after it — the one that decides whether the customer sees 409 or 500.

**It sits with the two tests it completes.** `shouldNotCreateUserWhenUsernameAlreadyUsed` and `shouldNotCreateUserWhenExternalIdAlreadyUsed` cover the pre-check path, which was never the broken one. This covers the race that gets past them.

Verification is on [AM-7620](https://gravitee.atlassian.net/browse/AM-7620).

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7620]: https://gravitee.atlassian.net/browse/AM-7620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-7620]: https://gravitee.atlassian.net/browse/AM-7620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ