### PR TITLE
fix: AM-7628 reject write of SCIM user with missing attributes

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/mapper/UserMapper.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/main/java/io/gravitee/am/gateway/handler/scim/mapper/UserMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.scim.mapper;
 import io.gravitee.am.common.oidc.StandardClaims;
 import io.gravitee.am.common.oidc.idtoken.Claims;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.scim.exception.InvalidValueException;
 import io.gravitee.am.gateway.handler.scim.model.Address;
 import io.gravitee.am.gateway.handler.scim.model.Attribute;
 import io.gravitee.am.gateway.handler.scim.model.Certificate;
@@ -40,6 +41,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -92,7 +94,7 @@ public class UserMapper {
             attribute.setValue(user.getEmail());
             attribute.setPrimary(true);
             if (scimUser.getEmails() != null) {
-                Optional<Attribute> optional = scimUser.getEmails().stream().filter(attribute1 -> attribute1.getValue().equals(attribute.getValue())).findFirst();
+                Optional<Attribute> optional = scimUser.getEmails().stream().filter(attribute1 -> Objects.equals(attribute1.getValue(), attribute.getValue())).findFirst();
                 if (optional.isEmpty()) {
                     scimUser.setEmails(Collections.singletonList(attribute));
                 }
@@ -147,6 +149,11 @@ public class UserMapper {
     }
 
     public static io.gravitee.am.model.User convert(User scimUser) {
+        requireAttributeValues("emails", scimUser.getEmails());
+        requireAttributeValues("phoneNumbers", scimUser.getPhoneNumbers());
+        requireAttributeValues("ims", scimUser.getIms());
+        requireAttributeValues("photos", scimUser.getPhotos());
+
         io.gravitee.am.model.User user = new io.gravitee.am.model.User();
         Map<String, Object> additionalInformation = new HashMap<>();
         if (scimUser.getExternalId() != null) {
@@ -321,6 +328,7 @@ public class UserMapper {
         }
         return modelAttributes
                 .stream()
+                .filter(modelAttribute -> modelAttribute != null && hasValue(modelAttribute.getValue()))
                 .map(modelAttribute -> {
                     Attribute scimAttribute = new Attribute();
                     scimAttribute.setPrimary(modelAttribute.isPrimary());
@@ -394,6 +402,19 @@ public class UserMapper {
                     scimCertificate.setValue(modelCertificate.getValue());
                     return scimCertificate;
                 }).collect(toList());
+    }
+
+    private static void requireAttributeValues(String attributeName, List<Attribute> attributes) {
+        if (attributes == null) {
+            return;
+        }
+        if (attributes.stream().anyMatch(attribute -> attribute == null || !hasValue(attribute.getValue()))) {
+            throw new InvalidValueException("Field [" + attributeName + "] contains an entry without a value");
+        }
+    }
+
+    private static boolean hasValue(String value) {
+        return value != null && !value.isBlank();
     }
 
     private static List<String> restrictedClaims() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/mapper/UserMapperTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/mapper/UserMapperTest.java
@@ -19,6 +19,8 @@ import io.gravitee.am.common.oidc.StandardClaims;
 import io.gravitee.am.common.oidc.idtoken.Claims;
 import io.gravitee.am.common.scim.Schema;
 import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.am.gateway.handler.scim.exception.InvalidValueException;
+import io.gravitee.am.gateway.handler.scim.model.Attribute;
 import io.gravitee.am.gateway.handler.scim.model.GraviteeUser;
 import io.gravitee.am.gateway.handler.scim.model.User;
 import org.junit.Test;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -159,5 +162,116 @@ public class UserMapperTest {
         // Both should be removed from additionalInformation
         assertFalse(user.getAdditionalInformation().containsKey("preRegistration"));
         assertFalse(user.getAdditionalInformation().containsKey("client"));
+    }
+
+    @Test
+    public void shouldConvert_emailWithoutValue_orderedBeforeThePrimaryEmail() {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setEmail("real@example.com");
+        user.setEmails(List.of(modelAttribute(null, "home", null), modelAttribute("real@example.com", null, true)));
+
+        User scimUser = UserMapper.convert(user, "/", true);
+
+        assertEquals(1, scimUser.getEmails().size());
+        assertEquals("real@example.com", scimUser.getEmails().get(0).getValue());
+    }
+
+    @Test
+    public void shouldConvert_emailWithoutValue_asTheOnlyEntry() {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setEmails(List.of(modelAttribute(null, "home", null)));
+
+        User scimUser = UserMapper.convert(user, "/", false);
+
+        assertTrue(scimUser.getEmails().isEmpty());
+    }
+
+    @Test
+    public void shouldConvert_emailWithoutValue_replacedByThePrimaryEmail() {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setEmail("real@example.com");
+        user.setEmails(List.of(modelAttribute(null, "home", null)));
+
+        User scimUser = UserMapper.convert(user, "/", true);
+
+        assertEquals(1, scimUser.getEmails().size());
+        assertEquals("real@example.com", scimUser.getEmails().get(0).getValue());
+        assertTrue(scimUser.getEmails().get(0).isPrimary());
+    }
+
+    @Test
+    public void shouldConvert_multiValuedAttributesWithoutValue() {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setPhoneNumbers(List.of(modelAttribute(null, "mobile", null), modelAttribute("+33600000000", "mobile", true)));
+        user.setIms(List.of(modelAttribute("", "skype", null)));
+        user.setPhotos(List.of(modelAttribute(null, "photo", null)));
+
+        User scimUser = UserMapper.convert(user, "/", false);
+
+        assertEquals(1, scimUser.getPhoneNumbers().size());
+        assertEquals("+33600000000", scimUser.getPhoneNumbers().get(0).getValue());
+        assertTrue(scimUser.getIms().isEmpty());
+        assertTrue(scimUser.getPhotos().isEmpty());
+    }
+
+    @Test
+    public void shouldConvert_keepEveryWellFormedEmail() {
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setEmail("primary@example.com");
+        user.setEmails(List.of(modelAttribute("home@example.com", "home", false), modelAttribute("primary@example.com", "work", true)));
+
+        User scimUser = UserMapper.convert(user, "/", false);
+
+        assertEquals(List.of("home@example.com", "primary@example.com"),
+                scimUser.getEmails().stream().map(Attribute::getValue).collect(Collectors.toList()));
+    }
+
+    @Test(expected = InvalidValueException.class)
+    public void shouldRejectScimUser_whenAnEmailHasNoValue() {
+        User scimUser = new User();
+        scimUser.setUserName("testuser");
+        scimUser.setEmails(List.of(new Attribute(null, "home"), new Attribute("real@example.com", null, true)));
+
+        UserMapper.convert(scimUser);
+    }
+
+    @Test(expected = InvalidValueException.class)
+    public void shouldRejectScimUser_whenAnEmailValueIsBlank() {
+        User scimUser = new User();
+        scimUser.setUserName("testuser");
+        scimUser.setEmails(List.of(new Attribute(" ", "home")));
+
+        UserMapper.convert(scimUser);
+    }
+
+    @Test(expected = InvalidValueException.class)
+    public void shouldRejectScimUser_whenAPhoneNumberHasNoValue() {
+        User scimUser = new User();
+        scimUser.setUserName("testuser");
+        scimUser.setPhoneNumbers(List.of(new Attribute(null, "mobile")));
+
+        UserMapper.convert(scimUser);
+    }
+
+    @Test
+    public void shouldAcceptScimUser_whenEveryMultiValuedAttributeHasAValue() {
+        User scimUser = new User();
+        scimUser.setUserName("testuser");
+        scimUser.setEmails(List.of(new Attribute("home@example.com", "home"), new Attribute("real@example.com", "work", true)));
+        scimUser.setPhoneNumbers(List.of(new Attribute("+33600000000", "mobile")));
+
+        io.gravitee.am.model.User user = UserMapper.convert(scimUser);
+
+        assertEquals("real@example.com", user.getEmail());
+        assertEquals(2, user.getEmails().size());
+        assertEquals(1, user.getPhoneNumbers().size());
+    }
+
+    private static io.gravitee.am.model.scim.Attribute modelAttribute(String value, String type, Boolean primary) {
+        io.gravitee.am.model.scim.Attribute attribute = new io.gravitee.am.model.scim.Attribute();
+        attribute.setValue(value);
+        attribute.setType(type);
+        attribute.setPrimary(primary);
+        return attribute;
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -37,6 +37,7 @@ import io.gravitee.am.gateway.handler.common.service.mfa.RateLimiterService;
 import io.gravitee.am.gateway.handler.common.service.mfa.VerifyAttemptService;
 import io.gravitee.am.gateway.handler.scim.exception.InvalidValueException;
 import io.gravitee.am.gateway.handler.scim.exception.UniquenessException;
+import io.gravitee.am.gateway.handler.scim.model.Attribute;
 import io.gravitee.am.gateway.handler.scim.model.GraviteeUser;
 import io.gravitee.am.gateway.handler.scim.model.ListResponse;
 import io.gravitee.am.gateway.handler.scim.model.Operation;
@@ -71,6 +72,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.functions.Predicate;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.vertx.core.json.Json;
@@ -1539,4 +1541,95 @@ public class ProvisioningUserServiceTest {
         assertEquals("app-id-123", clientCaptor.getValue().getId());
     }
 
+    @Test
+    public void shouldListUsers_withStoredEmailAttributeWithoutValue() {
+        final String domainID = "any-domain-id";
+        final io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setId("user-id");
+        user.setUsername("nullmail2");
+        user.setEmail("real@example.com");
+        user.setEmails(List.of(modelAttribute(null), modelAttribute("real@example.com")));
+
+        when(domain.getId()).thenReturn(domainID);
+        when(userRepository.findAllScim(new Reference(ReferenceType.DOMAIN, domainID), 0, 10))
+                .thenReturn(Single.just(new Page(List.of(user), 0, 1)));
+        when(groupService.findByMember(any())).thenReturn(Flowable.empty());
+
+        TestObserver<ListResponse<User>> observer = userService.list(null, 0, 10, "").test();
+        observer.assertNoErrors();
+        observer.assertComplete();
+        observer.assertValue(listResp -> listResp.getResources().size() == 1
+                && listResp.getResources().get(0).getEmails().size() == 1
+                && "real@example.com".equals(listResp.getResources().get(0).getEmails().get(0).getValue()));
+    }
+
+    @Test
+    public void shouldNotCreateUser_whenAnEmailHasNoValue() {
+        User newUser = new User();
+        newUser.setUserName("nullmail2");
+        newUser.setEmails(List.of(new Attribute(null, "home"), new Attribute("real@example.com", null, true)));
+
+        TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+        testObserver.assertNotComplete();
+        testObserver.assertError(rejectedEmails());
+
+        verify(userRepository, never()).create(any());
+    }
+
+    @Test
+    public void shouldNotUpdateUser_whenAnEmailHasNoValue() {
+        final String userId = "user-id";
+        User scimUser = new User();
+        scimUser.setUserName("nullmail2");
+        scimUser.setEmails(List.of(new Attribute(null, "home"), new Attribute("real@example.com", null, true)));
+
+        when(userRepository.findById(userId)).thenReturn(Maybe.just(new io.gravitee.am.model.User()));
+
+        TestObserver<User> testObserver = userService.update(userId, scimUser, null, "/", null, null).test();
+        testObserver.assertNotComplete();
+        testObserver.assertError(rejectedEmails());
+
+        verify(userRepository, never()).update(any(), any());
+    }
+
+    @Test
+    public void shouldNotPatchUser_whenAnEmailHasNoValue() throws Exception {
+        final String userId = "user-id";
+
+        io.gravitee.am.model.User existingUser = new io.gravitee.am.model.User();
+        existingUser.setId(userId);
+        existingUser.setUsername("nullmail2");
+        existingUser.setSource("user-idp");
+
+        User patchedScimUser = new User();
+        patchedScimUser.setUserName("nullmail2");
+        patchedScimUser.setEmails(List.of(new Attribute(null, "home"), new Attribute("real@example.com", null, true)));
+
+        ObjectNode userNode = mock(ObjectNode.class);
+        PatchOp patchOp = mock(PatchOp.class);
+        when(patchOp.getOperations()).thenReturn(Collections.emptyList());
+
+        when(userRepository.findById(userId)).thenReturn(Maybe.just(existingUser));
+        when(groupService.findByMember(userId)).thenReturn(Flowable.empty());
+        when(objectMapper.convertValue(any(), eq(ObjectNode.class))).thenReturn(userNode);
+        when(objectMapper.treeToValue(userNode, User.class)).thenReturn(patchedScimUser);
+
+        TestObserver<User> testObserver = userService.patch(userId, patchOp, null, "/", null, null).test();
+        testObserver.assertNotComplete();
+        testObserver.assertError(rejectedEmails());
+
+        verify(userRepository, never()).update(any(), any());
+    }
+
+    /** Unrelated failures in these flows also surface as {@link InvalidValueException}. */
+    private static Predicate<Throwable> rejectedEmails() {
+        return throwable -> throwable instanceof InvalidValueException
+                && throwable.getMessage().contains("[emails]");
+    }
+
+    private static io.gravitee.am.model.scim.Attribute modelAttribute(String value) {
+        io.gravitee.am.model.scim.Attribute attribute = new io.gravitee.am.model.scim.Attribute();
+        attribute.setValue(value);
+        return attribute;
+    }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7628](https://gravitee.atlassian.net/browse/AM-7628)

## :pencil2: A description of the changes proposed in the pull request
Respond with `invalidValue` scimType when `emails`, `phoneNumbers`, `ims` or `photos` fields contain valueless entries and prevent user creation.

Self-heal reading or updating of persisted users with missing values.

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7628]: https://gravitee.atlassian.net/browse/AM-7628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ