### PR TITLE
test: infer SMTP authentication from the configured credentials (AM-7622)

### DIFF
--- a/gravitee-am-resource/gravitee-am-resource-smtp/src/test/java/io/gravitee/am/resource/smtp/provider/SmtpResourceProviderTest.java
+++ b/gravitee-am-resource/gravitee-am-resource-smtp/src/test/java/io/gravitee/am/resource/smtp/provider/SmtpResourceProviderTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.resource.smtp.provider;
+
+import io.gravitee.am.resource.smtp.configuration.SmtpResourceConfiguration;
+import io.gravitee.am.service.utils.EmailSender;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SmtpResourceProviderTest {
+
+    @Test
+    void should_pass_credentials_to_the_mail_sender_when_authentication_is_inferred() throws Exception {
+        var configuration = baseConfiguration();
+        configuration.setUsername("user");
+        configuration.setPassword("password");
+
+        var javaMailSender = startAndExtractMailSender(configuration);
+
+        assertEquals("user", javaMailSender.getUsername());
+        assertEquals("password", javaMailSender.getPassword());
+        assertEquals("true", javaMailSender.getJavaMailProperties().getProperty("mail.smtp.auth"));
+    }
+
+    @Test
+    void should_not_authenticate_when_no_credentials_are_provided() throws Exception {
+        var javaMailSender = startAndExtractMailSender(baseConfiguration());
+
+        assertNull(javaMailSender.getUsername());
+        assertNull(javaMailSender.getPassword());
+        assertEquals("false", javaMailSender.getJavaMailProperties().getProperty("mail.smtp.auth"));
+    }
+
+    private static SmtpResourceConfiguration baseConfiguration() {
+        var configuration = new SmtpResourceConfiguration();
+        configuration.setHost("localhost");
+        configuration.setPort(25);
+        // the authentication flag is left unset so the provider has to infer it from the credentials
+        return configuration;
+    }
+
+    private static JavaMailSenderImpl startAndExtractMailSender(SmtpResourceConfiguration configuration) throws Exception {
+        var provider = new SmtpResourceProvider();
+        setField(provider, "configuration", configuration);
+        setField(provider, "env", new StandardEnvironment());
+        provider.start();
+
+        var emailSender = (EmailSender) readField(provider, "mailSender");
+        return (JavaMailSenderImpl) readField(emailSender, "mailSender");
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object readField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}


### PR DESCRIPTION
## :id: Reference related issue.
[AM-7622](https://gravitee.atlassian.net/browse/AM-7622)

## :pencil2: A description of the changes proposed in the pull request
When an SMTP resource is configured without an explicit `authentication` flag, `SmtpResourceConfiguration.authenticateEnabled()` infers it from whether credentials were supplied. `SmtpResourceConfigurationTest` already covers that decision, but nothing covered the provider acting on it — `SmtpResourceProvider.start()` picking the basic-auth branch and actually passing the credentials to the `JavaMailSender`. When that hop goes wrong the failure is `TechnicalManagementException: Error while creating email` at send time, not a config error.

- Flag unset with credentials present: the sender carries the username and password, and `mail.smtp.auth` is `true`
- Flag unset with no credentials: no credentials are set and `mail.smtp.auth` is `false`

The second is the negative control — without it the first passes against any provider that always sets credentials.

New test class only. No production code touched, no existing test changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**Plain JUnit 5 and reflection, to match the module.** `gravitee-am-resource-smtp` declares no mockito, assertj or spring-test, and the existing `SmtpResourceConfigurationTest` is plain JUnit. The provider's collaborators are private `@Autowired` fields with no setters, so the test sets them reflectively; `start()` only needs `configuration` and `env`, and `new StandardEnvironment()` covers the latter. No new module dependencies.

**Why this is not covered higher up.** The jest specs that build SMTP resources all pin `authentication: false` explicitly, so the inferred path is never exercised there. It cannot be added against the current local-stack SMTP server either — `fake-smtp-server` advertises no AUTH, so a correct implementation would fail the send while a broken one would pass. Covering it above the unit layer needs an auth-requiring SMTP server in local-stack.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7622]: https://gravitee.atlassian.net/browse/AM-7622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ