### PR TITLE
test: Console SMTP resource form credential handling (AM-7641)

### DIFF
--- a/gravitee-am-test/api/commands/management/resource-management-commands.ts
+++ b/gravitee-am-test/api/commands/management/resource-management-commands.ts
@@ -23,3 +23,18 @@ export const createResource = (domainId, accessToken, body) =>
     domain: domainId,
     newServiceResource: body,
   });
+
+export const getResource = (domainId, accessToken, resourceId) =>
+  getResourceApi(accessToken).getResource({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+    resource: resourceId,
+  });
+
+export const listResources = (domainId, accessToken) =>
+  getResourceApi(accessToken).listResources({
+    organizationId: process.env.AM_DEF_ORG_ID,
+    environmentId: process.env.AM_DEF_ENV_ID,
+    domain: domainId,
+  });

--- a/gravitee-am-test/playwright/pages/domain-resources.page.ts
+++ b/gravitee-am-test/playwright/pages/domain-resources.page.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+
+/**
+ * Page object for Domain > Settings > Resources.
+ *
+ * The configuration form is rendered by @ajsf from the plugin's schema, so its
+ * fields are addressed by the schema property name rather than by a test id.
+ * Fields whose schema condition is false are absent from the DOM, not hidden.
+ */
+export class DomainResourcesPage extends BasePage {
+  async navigateToList(domainId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/resources`);
+  }
+
+  async navigateToDetail(domainId: string, resourceId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/resources/${resourceId}`);
+    await this.configurationForm.waitFor({ state: 'visible' });
+  }
+
+  async navigateToCreate(domainId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/resources/new`);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Resource list                                                      */
+  /* ------------------------------------------------------------------ */
+
+  get resourceRows(): Locator {
+    return this.page.locator('ngx-datatable .datatable-body-row');
+  }
+
+  resourceRow(name: string | RegExp): Locator {
+    return this.resourceRows.filter({ hasText: name });
+  }
+
+  /** Settings link for a specific row, which opens the resource for editing. */
+  settingsLink(row: Locator): Locator {
+    return row.locator('a').filter({ has: this.page.locator('mat-icon:has-text("settings")') });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Creation wizard                                                    */
+  /* ------------------------------------------------------------------ */
+
+  get typeCards(): Locator {
+    return this.page.locator('mat-card.plugin-type-card');
+  }
+
+  async selectResourceType(name: string | RegExp): Promise<void> {
+    await this.typeCards.first().waitFor({ state: 'visible' });
+    await this.typeCards.filter({ hasText: name }).first().click();
+  }
+
+  async clickNext(): Promise<void> {
+    await this.page.locator('button').filter({ hasText: /next/i }).first().click();
+    await this.configurationForm.waitFor({ state: 'visible' });
+  }
+
+  /** Submit the creation wizard and wait for the app to leave the wizard route. */
+  async clickCreate(): Promise<void> {
+    await this.page
+      .locator('button')
+      .filter({ hasText: /create/i })
+      .first()
+      .click();
+    await this.page.waitForURL((url) => !url.pathname.endsWith('/new'));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Schema-driven configuration form                                   */
+  /* ------------------------------------------------------------------ */
+
+  get configurationForm(): Locator {
+    return this.page.locator('json-schema-form');
+  }
+
+  /** A text or number input, addressed by its schema property name. */
+  field(property: string): Locator {
+    return this.configurationForm.locator(`input[name="${property}"]`);
+  }
+
+  /** A mat-select, addressed by its schema property name. */
+  select(property: string): Locator {
+    return this.configurationForm.locator(`mat-select[name="${property}"]`);
+  }
+
+  /** The mat-checkbox wrapping a boolean property's input. */
+  checkbox(property: string): Locator {
+    return this.configurationForm.locator('mat-checkbox').filter({ has: this.page.locator(`input[name="${property}"]`) });
+  }
+
+  async setField(property: string, value: string): Promise<void> {
+    const input = this.field(property);
+    await input.fill(value);
+    await input.blur();
+  }
+
+  async toggleCheckbox(property: string): Promise<void> {
+    await this.checkbox(property).click();
+  }
+
+  async chooseOption(property: string, option: string | RegExp): Promise<void> {
+    await this.select(property).click();
+    await this.page.locator('mat-option').filter({ hasText: option }).first().click();
+  }
+
+  /** Fill the SMTP fields that every scenario needs. */
+  async fillSmtpBasics(host: string, from: string): Promise<void> {
+    await this.setField('host', host);
+    await this.setField('from', from);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Resource detail                                                    */
+  /* ------------------------------------------------------------------ */
+
+  get nameInput(): Locator {
+    return this.page.locator('input[name="name"]');
+  }
+
+  get saveButton(): Locator {
+    return this.page.locator('button').filter({ hasText: /save/i }).first();
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+  }
+}

--- a/gravitee-am-test/playwright/tests/settings/resources/smtp-resource-form.spec.ts
+++ b/gravitee-am-test/playwright/tests/settings/resources/smtp-resource-form.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test, expect } from '../../../fixtures/base.fixture';
+import { linkJira } from '../../../utils/jira';
+import { uniqueTestName } from '../../../utils/fixture-helpers';
+import { DomainResourcesPage } from '../../../pages/domain-resources.page';
+import { createResource, getResource, listResources } from '@management-commands/resource-management-commands';
+
+const SMTP_HOST = 'smtp';
+const SMTP_PORT = 5025;
+const SMTP_FROM = 'admin@test.com';
+
+/** The management API replaces stored secrets with this before returning them. */
+const MASKED_SECRET = '********';
+
+/** The stored configuration, as the management API reports it. */
+async function storedConfiguration(domainId: string, token: string, resourceId: string): Promise<Record<string, any>> {
+  const resource: any = await getResource(domainId, token, resourceId);
+  return JSON.parse(resource.configuration);
+}
+
+async function findResourceIdByName(domainId: string, token: string, name: string): Promise<string> {
+  const resources: any = await listResources(domainId, token);
+  const match = resources.find((r: any) => r.name === name);
+  expect(match, `resource "${name}" was not created`).toBeTruthy();
+  return match.id;
+}
+
+test.describe('SMTP resource form', () => {
+  test('AM-7642: the credential fields appear and disappear with the authentication flag', async ({ page, testDomain }, testInfo) => {
+    linkJira(testInfo, 'AM-7642');
+
+    const resourcesPage = new DomainResourcesPage(page);
+    await resourcesPage.navigateToCreate(testDomain.id);
+    await resourcesPage.selectResourceType(/smtp/i);
+    await resourcesPage.clickNext();
+
+    // `host` has no schema condition, so it anchors the assertions below: it proves the
+    // form rendered, which is what makes the absence of the credential fields meaningful.
+    // A false condition removes a control from the DOM rather than hiding it.
+    await expect(resourcesPage.field('host')).toBeVisible();
+    await expect(resourcesPage.field('username')).toHaveCount(0);
+    await expect(resourcesPage.field('password')).toHaveCount(0);
+    await expect(resourcesPage.select('authenticationType')).toHaveCount(0);
+
+    await resourcesPage.toggleCheckbox('authentication');
+
+    await expect(resourcesPage.field('username')).toBeVisible();
+    await expect(resourcesPage.field('password')).toBeVisible();
+    await expect(resourcesPage.select('authenticationType')).toBeVisible();
+
+    await resourcesPage.toggleCheckbox('authentication');
+
+    await expect(resourcesPage.field('host')).toBeVisible();
+    await expect(resourcesPage.field('username')).toHaveCount(0);
+    await expect(resourcesPage.field('password')).toHaveCount(0);
+  });
+
+  test('AM-7642: the OAuth2 branch replaces the basic credential fields', async ({ page, testDomain }, testInfo) => {
+    linkJira(testInfo, 'AM-7642');
+
+    const resourcesPage = new DomainResourcesPage(page);
+    await resourcesPage.navigateToCreate(testDomain.id);
+    await resourcesPage.selectResourceType(/smtp/i);
+    await resourcesPage.clickNext();
+
+    await resourcesPage.toggleCheckbox('authentication');
+    await expect(resourcesPage.field('username')).toBeVisible();
+    await resourcesPage.setField('username', 'basic-user');
+    await resourcesPage.setField('password', 'basic-password');
+
+    await resourcesPage.chooseOption('authenticationType', /oauth2/i);
+
+    await expect(resourcesPage.field('oauth2ClientId')).toBeVisible();
+    await expect(resourcesPage.field('tokenEndpoint')).toBeVisible();
+    await expect(resourcesPage.field('username')).toHaveCount(0);
+    await expect(resourcesPage.field('password')).toHaveCount(0);
+
+    // Returning to basic restores what was typed: the schema stops rendering the control,
+    // it does not clear the underlying model.
+    await resourcesPage.chooseOption('authenticationType', /basic/i);
+    await expect(resourcesPage.field('username')).toHaveValue('basic-user');
+  });
+
+  test('AM-7642: an explicit authentication flag is stored even when credentials were entered first', async ({
+    page,
+    testDomain,
+    adminToken,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7642');
+
+    const name = uniqueTestName('smtp-unticked');
+    const resourcesPage = new DomainResourcesPage(page);
+    await resourcesPage.navigateToCreate(testDomain.id);
+    await resourcesPage.selectResourceType(/smtp/i);
+    await resourcesPage.clickNext();
+
+    await expect(resourcesPage.nameInput).toBeVisible();
+    await resourcesPage.nameInput.fill(name);
+    await resourcesPage.fillSmtpBasics(SMTP_HOST, SMTP_FROM);
+
+    await resourcesPage.toggleCheckbox('authentication');
+    await expect(resourcesPage.field('username')).toBeVisible();
+    await resourcesPage.setField('username', 'the-user');
+    await resourcesPage.setField('password', 'the-password');
+    await resourcesPage.toggleCheckbox('authentication');
+
+    await resourcesPage.clickCreate();
+
+    const resourceId = await findResourceIdByName(testDomain.id, adminToken, name);
+    const configuration = await storedConfiguration(testDomain.id, adminToken, resourceId);
+
+    // The Console always submits the flag, so SmtpResourceConfiguration reads it directly
+    // and never falls back to inferring authentication from the credentials (AM-7622).
+    expect(configuration).toHaveProperty('authentication', false);
+
+    // The credentials are retained rather than cleared. That is safe only while the explicit
+    // flag above is present, which is why this test pins the two together.
+    expect(configuration.username).toBe('the-user');
+  });
+
+  test('AM-7642: an existing password survives an unrelated edit', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7642');
+
+    const resource: any = await createResource(testDomain.id, adminToken, {
+      type: 'smtp-am-resource',
+      name: uniqueTestName('smtp-round-trip'),
+      configuration: JSON.stringify({
+        host: SMTP_HOST,
+        port: SMTP_PORT,
+        from: SMTP_FROM,
+        protocol: 'smtp',
+        authentication: true,
+        authenticationType: 'basic',
+        username: 'original-user',
+        password: 'original-password',
+        startTls: false,
+      }),
+    });
+
+    const resourcesPage = new DomainResourcesPage(page);
+    await resourcesPage.navigateToDetail(testDomain.id, resource.id);
+
+    // The API masks the secret, so the form renders the mask rather than the password.
+    await expect(resourcesPage.field('password')).toHaveValue(MASKED_SECRET);
+
+    await resourcesPage.setField('from', 'changed@test.com');
+    await resourcesPage.save();
+    await resourcesPage.expectSnackbar(/updated/i);
+
+    const configuration = await storedConfiguration(testDomain.id, adminToken, resource.id);
+    // `from` changing proves the update was applied, so the untouched fields below are a
+    // genuine round trip rather than a save that silently did nothing.
+    expect(configuration.from).toBe('changed@test.com');
+    expect(configuration.username).toBe('original-user');
+    expect(configuration.authentication).toBe(true);
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue.
[AM-7641](https://gravitee.atlassian.net/browse/AM-7641)

## :pencil2: A description of the changes proposed in the pull request
The Console's resource configuration form is rendered by `@ajsf` from the plugin's `schema-form.json`, which drives field visibility from JavaScript conditions — `username`/`password` render only for basic auth, `oauth2Configuration` only for OAuth2. A false condition removes the control from the DOM rather than hiding it. None of that was covered: no Playwright test touched Resources at all, and `ResourceFormComponent`'s only unit test is the generated `should create` stub.

- The credential controls are added to and removed from the form as the authentication flag is toggled
- The OAuth2 branch replaces the basic credential controls, and a value typed into a control that stops rendering is still there on return
- An explicit `authentication` flag is stored even when credentials were entered first
- An existing password survives an edit that does not touch it

One new spec, one new page object, plus `getResource`/`listResources` appended to the existing resource commands. No production code touched, no existing test changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**The password round trip was checked against the stored value, not the API response.** The management API masks secrets on read, so a preserved password and one overwritten with the literal mask look identical from the response. The test asserts on a second field changing in the same save, which proves the update was applied rather than silently skipped.

**This does not overlap AM-7622.** Because the schema defaults `authentication` to false, the Console always submits an explicit flag, so `SmtpResourceConfiguration.authenticateEnabled()` never reaches its inference branch from the UI. The third test pins exactly that, since it is what keeps the two paths separate.

**Unrelated, but worth someone picking up:** `npm run lint:license` in `gravitee-am-test` fails with `Odd number of regex identifiers found` before it scans anything. It fails identically on master with these changes stashed, so it is pre-existing — but it means the license check is currently a no-op there.

Verification is on [AM-7641](https://gravitee.atlassian.net/browse/AM-7641); the coverage is documented on [AM-7642](https://gravitee.atlassian.net/browse/AM-7642).

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7641]: https://gravitee.atlassian.net/browse/AM-7641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-7641]: https://gravitee.atlassian.net/browse/AM-7641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ