### PR TITLE
test: incompatible enum data on paged role queries and membership findById (AM-7623)

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/MembershipRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/MembershipRepositoryTest.java
@@ -291,21 +291,37 @@ public class MembershipRepositoryTest extends AbstractManagementTest {
                 memberships.stream().anyMatch(m -> "testFutureMember".equals(m.getMemberId())));
     }
     
+    @Test
+    public void testFilterOutProtectedResourceMembership_FindById() throws Exception {
+        String incompatibleMembershipId =
+                insertIncompatibleMembershipDirectlyAndGetId("futureMemberFindById", FUTURE_REFERENCE_TYPE, MemberType.USER.name(), ORGANIZATION_ID);
+
+        TestObserver<Membership> testObserver = membershipRepository.findById(incompatibleMembershipId).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+        testObserver.assertNoValues();
+    }
+
     private void insertIncompatibleMembershipDirectly(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
+        insertIncompatibleMembershipDirectlyAndGetId(memberId, referenceType, memberType, referenceId);
+    }
+
+    private String insertIncompatibleMembershipDirectlyAndGetId(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
         String repoClassName = membershipRepository.getClass().getSimpleName();
         String repoFullName = membershipRepository.getClass().getName();
         
         if (repoClassName.contains("Mongo") || repoFullName.contains("mongodb")) {
-            insertIncompatibleMembershipMongoDB(memberId, referenceType, memberType, referenceId);
+            return insertIncompatibleMembershipMongoDB(memberId, referenceType, memberType, referenceId);
         } else if (repoClassName.contains("Jdbc") || repoFullName.contains("jdbc")) {
-            insertIncompatibleMembershipJDBC(memberId, referenceType, memberType, referenceId);
+            return insertIncompatibleMembershipJDBC(memberId, referenceType, memberType, referenceId);
         } else {
             throw new UnsupportedOperationException("Unknown repository type: " + repoClassName + " (" + repoFullName + ")");
         }
     }
     
-    private void insertIncompatibleMembershipMongoDB(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
-        IncompatibleDataTestUtils.insertIncompatibleEntityMongoDB(
+    private String insertIncompatibleMembershipMongoDB(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
+        return IncompatibleDataTestUtils.insertIncompatibleEntityMongoDB(
             membershipRepository,
             "memberships",
             "io.gravitee.am.repository.mongodb.management.internal.model.MembershipMongo",
@@ -320,8 +336,8 @@ public class MembershipRepositoryTest extends AbstractManagementTest {
         );
     }
     
-    private void insertIncompatibleMembershipJDBC(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
-        IncompatibleDataTestUtils.insertIncompatibleEntityJDBC(
+    private String insertIncompatibleMembershipJDBC(String memberId, String referenceType, String memberType, String referenceId) throws Exception {
+        return IncompatibleDataTestUtils.insertIncompatibleEntityJDBC(
             membershipRepository,
             "io.gravitee.am.repository.jdbc.management.api.model.JdbcMembership",
             jdbcMembership -> {

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/RoleRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/RoleRepositoryTest.java
@@ -19,6 +19,7 @@ import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.Platform;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Role;
+import io.gravitee.am.model.common.Page;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.repository.management.AbstractManagementTest;
 import io.gravitee.am.repository.management.test.IncompatibleDataTestUtils;
@@ -329,6 +330,54 @@ public class RoleRepositoryTest extends AbstractManagementTest {
         testObserver.assertNoValues();
     }
     
+    @Test
+    public void testFilterOutIncompatibleRoles_PagedFindAll() throws Exception {
+        Role readableRole = new Role();
+        readableRole.setName("pagedReadableRole");
+        readableRole.setReferenceType(ReferenceType.DOMAIN);
+        readableRole.setReferenceId(DOMAIN_ID);
+        roleRepository.create(readableRole).blockingGet();
+
+        insertIncompatibleRoleDirectly("pagedIncompatibleRole", ReferenceType.DOMAIN.name(), FUTURE_ASSIGNABLE_TYPE, DOMAIN_ID);
+
+        TestObserver<Page<Role>> testObserver = roleRepository.findAll(ReferenceType.DOMAIN, DOMAIN_ID, 0, 10).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        Page<Role> result = testObserver.values().get(0);
+        assertEquals("Only the readable role should be returned", 1, result.getData().size());
+        assertTrue("The readable role should be returned",
+                result.getData().stream().anyMatch(r -> "pagedReadableRole".equals(r.getName())));
+        assertFalse("The role with an unreadable assignableType should be filtered out",
+                result.getData().stream().anyMatch(r -> "pagedIncompatibleRole".equals(r.getName())));
+        assertEquals("The total counts the discarded role, by design", 2, result.getTotalCount());
+    }
+
+    @Test
+    public void testFilterOutIncompatibleRoles_Search() throws Exception {
+        Role readableRole = new Role();
+        readableRole.setName("searchReadableRole");
+        readableRole.setReferenceType(ReferenceType.DOMAIN);
+        readableRole.setReferenceId(DOMAIN_ID);
+        roleRepository.create(readableRole).blockingGet();
+
+        insertIncompatibleRoleDirectly("searchIncompatibleRole", ReferenceType.DOMAIN.name(), FUTURE_ASSIGNABLE_TYPE, DOMAIN_ID);
+
+        TestObserver<Page<Role>> testObserver = roleRepository.search(ReferenceType.DOMAIN, DOMAIN_ID, "search*", 0, 10).test();
+        testObserver.awaitDone(10, TimeUnit.SECONDS);
+        testObserver.assertComplete();
+        testObserver.assertNoErrors();
+
+        Page<Role> result = testObserver.values().get(0);
+        assertEquals("Only the readable role should be returned", 1, result.getData().size());
+        assertTrue("The readable role should be returned",
+                result.getData().stream().anyMatch(r -> "searchReadableRole".equals(r.getName())));
+        assertFalse("The role with an unreadable assignableType should be filtered out",
+                result.getData().stream().anyMatch(r -> "searchIncompatibleRole".equals(r.getName())));
+        assertEquals("The total counts the discarded role, by design", 2, result.getTotalCount());
+    }
+
     private void insertIncompatibleRoleDirectly(String roleName, String referenceType, String assignableType, String referenceId) throws Exception {
         insertIncompatibleRoleDirectlyAndGetId(roleName, referenceType, assignableType, referenceId);
     }


### PR DESCRIPTION
## :id: Reference related issue.
[AM-7623](https://gravitee.atlassian.net/browse/AM-7623)

## :pencil2: A description of the changes proposed in the pull request
`EnumParsingUtils` and `IncompatibleDataTestUtils` came in with `c320a9c87d`, so a row carrying an enum value the running build cannot read is discarded rather than throwing. The existing tests cover the unpaged read paths. Two gaps were left:

- Role's paged `findAll(referenceType, referenceId, page, size)` and `search(...)` had no test at all — nothing anywhere called them, and `search` backs the domain role list in the Console
- `MembershipRepositoryTest` had no `findById` case with incompatible data, while `RoleRepositoryTest` and `ApplicationRepositoryTest` both pin theirs

Three tests added to two existing classes. No production code touched, no existing test changed.

The Role tests also assert that the reported total still counts the discarded row. That is intended behaviour, confirmed on review: the count is a separate query and the database can see the entity regardless of whether this build can read its enums, and the goal is only to keep an unknown enum from blocking the system. It is asserted so a future change to it has to be deliberate.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**Application needs no equivalent.** It maps an unreadable `applicationType` to null and keeps the row rather than discarding it, so its count always matches the rows returned and the inconsistency above cannot arise. Its paged path is already covered by `testMapUnknownApplicationTypeToNull_findByDomain`.

**Running these locally needs the test jar installed first:**

```
mvn install -pl gravitee-am-repository/gravitee-am-repository-tests -DskipTests
mvn test -pl gravitee-am-repository/gravitee-am-repository-mongodb -Pcicd -Dtest=RoleRepositoryTest,MembershipRepositoryTest
mvn test -pl gravitee-am-repository/gravitee-am-repository-jdbc -Pcicd-jdbc -Ppostgres -Dtest=RoleRepositoryTest,MembershipRepositoryTest
```

The Mongo and JDBC modules consume `gravitee-am-repository-tests` as a packaged test-jar rather than as source, so editing a test and running the module reports green against the previously installed jar without ever executing the change.

Verified on MongoDB and PostgreSQL. Verification is on [AM-7623](https://gravitee.atlassian.net/browse/AM-7623).

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7623]: https://gravitee.atlassian.net/browse/AM-7623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-7623]: https://gravitee.atlassian.net/browse/AM-7623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ