### PR TITLE
fix: enhance domain user resolved via trusted-issuer user binding

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolver.java
@@ -72,7 +72,7 @@ public class TrustedIssuerUserResolver implements TokenExchangeUserResolver {
                             if (users.size() > 1) {
                                 return Maybe.error(new InvalidRequestException("Multiple domain users match token binding"));
                             }
-                            return Maybe.just(users.getFirst());
+                            return userGatewayService.enhance(users.getFirst()).toMaybe();
                         }));
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -1472,6 +1472,7 @@ public class TokenExchangeServiceImplTest {
         domainUser.setAdditionalInformation(new HashMap<>());
 
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of(domainUser)));
+        when(userGatewayService.enhance(domainUser)).thenReturn(Single.just(domainUser));
 
         TokenRequest tokenRequest = new TokenRequest();
         tokenRequest.setClientId("client-id");
@@ -1486,6 +1487,7 @@ public class TokenExchangeServiceImplTest {
         assertThat(result.user().getId()).isEqualTo("domain-user-id");
         assertThat(result.user().getUsername()).isEqualTo("john.doe");
         verify(userGatewayService).findByCriteria(any());
+        verify(userGatewayService).enhance(domainUser);
     }
 
     @Test
@@ -1592,6 +1594,7 @@ public class TokenExchangeServiceImplTest {
         domainUser.setAdditionalInformation(new HashMap<>());
 
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of(domainUser)));
+        when(userGatewayService.enhance(domainUser)).thenReturn(Single.just(domainUser));
 
         TokenRequest tokenRequest = new TokenRequest();
         tokenRequest.setClientId("client-id");
@@ -1621,6 +1624,7 @@ public class TokenExchangeServiceImplTest {
         domainUser.setAdditionalInformation(new HashMap<>());
 
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of(domainUser)));
+        when(userGatewayService.enhance(domainUser)).thenReturn(Single.just(domainUser));
 
         TokenRequest tokenRequest = new TokenRequest();
         tokenRequest.setClientId("client-id");

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TrustedIssuerUserResolverTest.java
@@ -114,11 +114,41 @@ class TrustedIssuerUserResolverTest {
         User domainUser = new User();
         domainUser.setId("domain-user-id");
         when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of(domainUser)));
+        when(userGatewayService.enhance(any())).thenReturn(Single.just(domainUser));
 
         User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
 
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo("domain-user-id");
+    }
+
+    @Test
+    void resolve_enhancesUserWithRolesAndGroups_reproducesAM7611() {
+        // trusted-issuer/user-binding match must be enhanced with
+        // roles/groups the same way interactive login and TokenUserResolver are,
+        // so custom claims such as {#context.attributes['user'].roles} are populated.
+        TrustedIssuer trusted = new TrustedIssuer();
+        trusted.setUserBindingEnabled(true);
+        UserBindingCriterion c = new UserBindingCriterion();
+        c.setAttribute("emails.value");
+        c.setExpression("{#token['email']}");
+        trusted.setUserBindingCriteria(List.of(c));
+
+        User domainUser = new User();
+        domainUser.setId("domain-user-id");
+        when(userGatewayService.findByCriteria(any())).thenReturn(Single.just(List.of(domainUser)));
+
+        User enhancedUser = new User();
+        enhancedUser.setId("domain-user-id");
+        enhancedUser.setRolesPermissions(java.util.Set.of(new io.gravitee.am.model.Role()));
+        when(userGatewayService.enhance(any())).thenReturn(Single.just(enhancedUser));
+
+        User result = resolver.resolve(subjectTokenWith(trusted)).blockingGet();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getRolesPermissions())
+                .as("resolved user should be enhanced with roles, like the interactive login path")
+                .isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `TrustedIssuerUserResolver` returned the raw domain user matched by trusted-issuer user-binding criteria without loading roles/groups, unlike `TokenUserResolver` and the interactive login path.
- As a result, role-derived custom claims (and groups) were omitted from tokens minted via OAuth2 Token Exchange when the subject was resolved through trusted-issuer user binding, while profile claims (e.g. `userId`) were still present.
- Fix: chain `userGatewayService.enhance(...)` on the resolved user before returning it, matching the sibling `TokenUserResolver` and the interactive login enrichment path (`BaseUserEnhancer`).

## Test plan
- [x] Added `resolve_enhancesUserWithRolesAndGroups_reproducesAM7611` in `TrustedIssuerUserResolverTest` — reproduces the bug (fails before the fix).
- [x] Updated existing resolver/service unit tests to stub the now-mandatory `enhance` call.
- [x] Full `gravitee-am-gateway-handler-oidc` module test suite passes (1350+ tests, JDK 21).

fix AM-7611