### PR TITLE
feat: AM-7647 display IDP descriptions at creation

### DIFF
--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.html
@@ -28,7 +28,7 @@
           <h5>Platform</h5>
           <small>Identity Provider type</small>
         </ng-template>
-        <provider-creation-step1 [provider]="provider"></provider-creation-step1>
+        <provider-creation-step1 [provider]="provider" (typeSelected)="onTypeSelected($event)"></provider-creation-step1>
         <div class="stepper-button-zone" fxLayout="row" fxLayoutAlign="end end">
           <button mat-raised-button color="primary" matStepperNext type="button" [disabled]="!provider.type">Next</button>
         </div>
@@ -53,7 +53,13 @@
     <div class="gv-page-description" fxFlex>
       <h3>Identity Provider</h3>
       <div class="gv-page-description-content">
-        <p>Identity providers offer user authentication as a service.</p>
+        <p *ngIf="stepper.selectedIndex === 0">Identity providers offer user authentication as a service.</p>
+        <pre
+          *ngIf="providerDescription"
+          class="plugin-description"
+          [class.is-sticky]="stepper.selectedIndex === 0"
+          [innerHTML]="providerDescription"
+        ></pre>
         <ng-container *ngIf="showMongoStorageGuidance && stepper.selectedIndex === 1">
           <h5>User storage</h5>
           <small>

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.scss
@@ -1,0 +1,13 @@
+.gv-page-description {
+  display: flex;
+  flex-direction: column;
+
+  .gv-page-description-content {
+    flex: 1 1 auto;
+  }
+}
+
+.plugin-description.is-sticky {
+  position: sticky;
+  top: 20px;
+}

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/provider-creation.component.ts
@@ -17,6 +17,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatStepper } from '@angular/material/stepper';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { OrganizationService } from '../../../../services/organization.service';
 import { ProviderService } from '../../../../services/provider.service';
 import { SnackbarService } from '../../../../services/snackbar.service';
 import { MONGO_IDP_TYPE } from '../provider/provider.form.enricher';
@@ -32,10 +33,12 @@ export class ProviderCreationComponent implements OnInit {
   private domainId: string;
   private organizationContext: boolean;
   configurationIsValid = false;
+  providerDescription: string;
   @ViewChild('stepper', { static: true }) stepper: MatStepper;
 
   constructor(
     private providerService: ProviderService,
+    private organizationService: OrganizationService,
     private snackbarService: SnackbarService,
     private router: Router,
     private route: ActivatedRoute,
@@ -50,6 +53,15 @@ export class ProviderCreationComponent implements OnInit {
 
   get showMongoStorageGuidance(): boolean {
     return this.provider?.type === MONGO_IDP_TYPE;
+  }
+
+  onTypeSelected(type: string): void {
+    this.providerDescription = null;
+    this.organizationService.identitySchema(type).subscribe((schema) => {
+      if (this.provider?.type === type) {
+        this.providerDescription = schema?.description;
+      }
+    });
   }
 
   create() {

--- a/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/providers/creation/steps/step1/step1.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { OrganizationService } from '../../../../../../services/organization.service';
@@ -29,6 +29,7 @@ import { LicensedPlugin, PluginFeatureService } from '../../../../../../services
 export class ProviderCreationStep1Component implements OnInit {
   identities: (IdentityProvider & LicensedPlugin)[];
   @Input() provider;
+  @Output() typeSelected = new EventEmitter<string>();
   filter: string;
   filteredIdentities: (IdentityProvider & LicensedPlugin)[];
 
@@ -62,6 +63,7 @@ export class ProviderCreationStep1Component implements OnInit {
     this.provider.external = idp.external === true;
     this.provider.type = idp.id;
     this.initDomainWhitelist(idp.id);
+    this.typeSelected.emit(idp.id);
   }
 
   displayName(identityProvider) {

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.html
@@ -16,9 +16,6 @@
 
 -->
 <div fxLayout="column">
-  <div *ngIf="providerSchema && providerSchema.description" class="provider-settings-contextual-help">
-    <pre [innerHTML]="providerSchema?.description"></pre>
-  </div>
   <div fxLayout="row">
     <div fxLayout="column" fxFlex="70">
       <form #providerForm="ngForm">
@@ -102,6 +99,7 @@
       <h3>Manage identity provider</h3>
       <div class="gv-page-description-content">
         <p>Register your users to interact with the Access Management {{ organizationContext ? 'Portal' : 'Server' }}.</p>
+        <pre *ngIf="providerSchema?.description" class="plugin-description" [innerHTML]="providerSchema.description"></pre>
         <ng-container *ngIf="showMongoStorageGuidance">
           <h5>User storage</h5>
           <small>

--- a/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/providers/provider/settings/settings.component.scss
@@ -1,10 +1,3 @@
-.provider-settings-contextual-help {
-  padding: 20px;
-  border: 1px solid rgb(226 229 231);
-  border-radius: 2px;
-  margin-bottom: 10px;
-}
-
 .social-provider-settings-description {
   .social-provider-settings-description-contextual-help {
     color: rgb(0 0 0 / 38%);

--- a/gravitee-am-ui/src/styles.scss
+++ b/gravitee-am-ui/src/styles.scss
@@ -281,6 +281,15 @@ ngx-datatable {
       color: rgb(0 0 0 / 38%);
       font-size: 12px;
     }
+
+    .plugin-description {
+      margin: 20px 0 0;
+      color: rgb(0 0 0 / 38%);
+      font-family: inherit;
+      font-size: 12px;
+      overflow-wrap: anywhere;
+      white-space: pre-wrap;
+    }
   }
 }
 


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7647](https://gravitee.atlassian.net/browse/AM-7647)

## :pencil2: A description of the changes proposed in the pull request
Add IDP descriptions to the IDP creation wizard so the information is available when an admin is first configuring an IDP. On this view, the description is _sticky_ and scrolls with the page.

Additionally, move where these descriptions are displayed in the edit IDP page, from a leading box to the right-hand side page description space so an admin can always find it in the same area.

## :memo: Test scenarios 
1. Log in to the console UI
2. Navigate to Settings > Identities > Providers
3. Press +
4. Select an IDP and complete wizard

## :computer: Add screenshots for UI
<img width="1576" height="800" alt="sticky idp creation description" src="https://github.com/user-attachments/assets/9d89db31-1dec-4d45-918f-b0392a773751" />

<img width="1641" height="800" alt="Screenshot 2026-09-08 at 08 39 40" src="https://github.com/user-attachments/assets/723beebb-6a40-45d2-b944-b57e23e9e1ba" />

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7647]: https://gravitee.atlassian.net/browse/AM-7647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ