### PR TITLE
fix(jdbc): recycle stale r2dbc connections after a silent DB failover

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProvider.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/main/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProvider.java
@@ -60,13 +60,16 @@ public class ConnectionFactoryProvider {
     public static final String TAG_DRIVER = "r2dbc_driver";
     public static final String TAG_DATABASE = "r2dbc_db";
     public static final String TAG_SERVER = "r2dbc_server";
+    public static final String TAG_TCP_KEEP_ALIVE = "tcpKeepAlive";
     public static final int DEFAULT_SETTINGS_ACQUIRE_RETRY = 1;
     public static final int DEFAULT_SETTINGS_INITIAL_SIZE = 1;
     public static final int DEFAULT_SETTINGS_MAX_SIZE = 50;
     public static final long DEFAULT_SETTINGS_MAX_IDLE_TIME = 30000;
-    public static final long DEFAULT_SETTINGS_MAX_LIFE_TIME = -1;
+    public static final long DEFAULT_SETTINGS_MAX_LIFE_TIME = 1_800_000; // 30 minutes
     public static final long DEFAULT_SETTINGS_MAX_ACQUIRE_TIME = 3000;
+    public static final long DEFAULT_SETTINGS_MAX_VALIDATION_TIME = 5000;
     public static final long DEFAULT_SETTINGS_MAX_CREATE_CNX_TIME = 5000;
+    public static final boolean DEFAULT_SETTINGS_TCP_KEEP_ALIVE = true;
 
 
 
@@ -136,68 +139,7 @@ public class ConnectionFactoryProvider {
         if (uri != null) {
             connectionPool = ConnectionFactories.get(uri);
         } else {
-
-            String driver = getJdbcDriver();
-            String host = getJdbcHostname();
-            String port = getJdbcPort();
-            String user = getJdbcUsername();
-            String pwd = getJdbcPassword();
-            String db = getJdbcDatabase();
-            var jdbcSchema = getJdbcSchema();
-
-            if (driver == null || host == null) {
-                LOGGER.error("Missing one of connection parameters 'driver', 'host' or 'port' for {} database", prefix);
-                throw new IllegalArgumentException("Missing properties for '" + prefix + "' database");
-            }
-
-            ConnectionFactoryOptions.Builder builder = ConnectionFactoryOptions.builder()
-                    .option(DRIVER, "pool") // force connection pool (https://github.com/r2dbc/r2dbc-pool#getting-started)
-                    .option(PROTOCOL, driver) // set driver as protocol  (https://github.com/r2dbc/r2dbc-pool#getting-started)
-                    .option(HOST, host)
-                    .option(USER, user)
-                    .option(DATABASE, db)
-                    .option(PoolingConnectionFactoryProvider.ACQUIRE_RETRY, Integer.parseInt(environment.getProperty(prefix+"acquireRetry", ""+DEFAULT_SETTINGS_ACQUIRE_RETRY)))
-                    .option(PoolingConnectionFactoryProvider.INITIAL_SIZE, Integer.parseInt(environment.getProperty(prefix+"initialSize", ""+DEFAULT_SETTINGS_INITIAL_SIZE)))
-                    .option(PoolingConnectionFactoryProvider.MAX_SIZE, Integer.parseInt(environment.getProperty(prefix+"maxSize", ""+DEFAULT_SETTINGS_MAX_SIZE)))
-                    .option(PoolingConnectionFactoryProvider.MAX_IDLE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxIdleTime", ""+DEFAULT_SETTINGS_MAX_IDLE_TIME)), ChronoUnit.MILLIS))
-                    .option(PoolingConnectionFactoryProvider.MAX_LIFE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxLifeTime", ""+DEFAULT_SETTINGS_MAX_LIFE_TIME)), ChronoUnit.MILLIS))
-                    .option(PoolingConnectionFactoryProvider.MAX_ACQUIRE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxAcquireTime", ""+DEFAULT_SETTINGS_MAX_ACQUIRE_TIME)), ChronoUnit.MILLIS))
-                    .option(PoolingConnectionFactoryProvider.MAX_CREATE_CONNECTION_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxCreateConnectionTime", ""+DEFAULT_SETTINGS_MAX_CREATE_CNX_TIME)), ChronoUnit.MILLIS));
-
-            if (port != null) {
-                builder.option(PORT, Integer.parseInt(port));
-            }
-
-            final String validationQuery = environment.getProperty(prefix + "validationQuery");
-            if (validationQuery != null) {
-                builder.option(PoolingConnectionFactoryProvider.VALIDATION_QUERY, validationQuery)
-                        .option(PoolingConnectionFactoryProvider.VALIDATION_DEPTH, ValidationDepth.REMOTE);
-            } else {
-                builder.option(PoolingConnectionFactoryProvider.VALIDATION_DEPTH, ValidationDepth.LOCAL);
-            }
-
-            if (pwd != null) {
-                builder.option(PASSWORD, pwd);
-            }
-
-            builder = TlsOptionsHelper.setSSLOptions(builder, environment, prefix, driver);
-
-            // Add schema support for postgres
-            if(jdbcSchema.isPresent()){
-                String currentSchema = jdbcSchema.get();
-                if(SchemaSupport.supportsSchema(driver)){
-                    builder.option(Option.valueOf(TAG_CURRENT_SCHEMA), currentSchema);
-                } else {
-                    LOGGER.warn("Schema parameter '{}' detected for {} driver. Note: {} does not support schemas. This parameter will be ignored.", currentSchema, driver, driver);
-                }
-            }
-
-            final String preferCursorExecution = environment.getProperty(prefix + TAG_PREFER_CURSORED_EXECUTION);
-            if (StringUtils.hasLength(preferCursorExecution)) {
-                builder.option(Option.valueOf(TAG_PREFER_CURSORED_EXECUTION), preferCursorExecution);
-            }
-
-            connectionPool = ConnectionFactories.get(builder.build());
+            connectionPool = ConnectionFactories.get(buildConnectionFactoryOptions());
         }
 
         LOGGER.info("Connection pool created for {} database", prefix);
@@ -212,6 +154,75 @@ public class ConnectionFactoryProvider {
                     .register(connection);
         }
         return connectionPool;
+    }
+
+    ConnectionFactoryOptions buildConnectionFactoryOptions() {
+        String driver = getJdbcDriver();
+        String host = getJdbcHostname();
+        String port = getJdbcPort();
+        String user = getJdbcUsername();
+        String pwd = getJdbcPassword();
+        String db = getJdbcDatabase();
+        var jdbcSchema = getJdbcSchema();
+
+        if (driver == null || host == null) {
+            LOGGER.error("Missing one of connection parameters 'driver', 'host' or 'port' for {} database", prefix);
+            throw new IllegalArgumentException("Missing properties for '" + prefix + "' database");
+        }
+
+        ConnectionFactoryOptions.Builder builder = ConnectionFactoryOptions.builder()
+                .option(DRIVER, "pool") // force connection pool (https://github.com/r2dbc/r2dbc-pool#getting-started)
+                .option(PROTOCOL, driver) // set driver as protocol  (https://github.com/r2dbc/r2dbc-pool#getting-started)
+                .option(HOST, host)
+                .option(USER, user)
+                .option(DATABASE, db)
+                .option(PoolingConnectionFactoryProvider.ACQUIRE_RETRY, Integer.parseInt(environment.getProperty(prefix+"acquireRetry", ""+DEFAULT_SETTINGS_ACQUIRE_RETRY)))
+                .option(PoolingConnectionFactoryProvider.INITIAL_SIZE, Integer.parseInt(environment.getProperty(prefix+"initialSize", ""+DEFAULT_SETTINGS_INITIAL_SIZE)))
+                .option(PoolingConnectionFactoryProvider.MAX_SIZE, Integer.parseInt(environment.getProperty(prefix+"maxSize", ""+DEFAULT_SETTINGS_MAX_SIZE)))
+                .option(PoolingConnectionFactoryProvider.MAX_IDLE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxIdleTime", ""+DEFAULT_SETTINGS_MAX_IDLE_TIME)), ChronoUnit.MILLIS))
+                .option(PoolingConnectionFactoryProvider.MAX_LIFE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxLifeTime", ""+DEFAULT_SETTINGS_MAX_LIFE_TIME)), ChronoUnit.MILLIS))
+                .option(PoolingConnectionFactoryProvider.MAX_ACQUIRE_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxAcquireTime", ""+DEFAULT_SETTINGS_MAX_ACQUIRE_TIME)), ChronoUnit.MILLIS))
+                .option(PoolingConnectionFactoryProvider.MAX_CREATE_CONNECTION_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix+"maxCreateConnectionTime", ""+DEFAULT_SETTINGS_MAX_CREATE_CNX_TIME)), ChronoUnit.MILLIS));
+
+        if (port != null) {
+            builder.option(PORT, Integer.parseInt(port));
+        }
+
+        final String validationQuery = environment.getProperty(prefix + "validationQuery");
+        if (validationQuery != null) {
+            builder.option(PoolingConnectionFactoryProvider.VALIDATION_QUERY, validationQuery)
+                    .option(PoolingConnectionFactoryProvider.VALIDATION_DEPTH, ValidationDepth.REMOTE)
+                    .option(PoolingConnectionFactoryProvider.MAX_VALIDATION_TIME, Duration.of(Long.parseLong(environment.getProperty(prefix + "maxValidationTime", "" + DEFAULT_SETTINGS_MAX_VALIDATION_TIME)), ChronoUnit.MILLIS));
+        } else {
+            builder.option(PoolingConnectionFactoryProvider.VALIDATION_DEPTH, ValidationDepth.LOCAL);
+        }
+
+        if (pwd != null) {
+            builder.option(PASSWORD, pwd);
+        }
+
+        // TCP keepalive detects a half-open socket (e.g. after a DB failover) that LOCAL validation
+        // (channel.isOpen()) cannot see, since the OS never signals the application on such a socket
+        builder.option(Option.valueOf(TAG_TCP_KEEP_ALIVE), Boolean.parseBoolean(environment.getProperty(prefix + "tcpKeepAlive", "" + DEFAULT_SETTINGS_TCP_KEEP_ALIVE)));
+
+        builder = TlsOptionsHelper.setSSLOptions(builder, environment, prefix, driver);
+
+        // Add schema support for postgres
+        if (jdbcSchema.isPresent()) {
+            String currentSchema = jdbcSchema.get();
+            if (SchemaSupport.supportsSchema(driver)) {
+                builder.option(Option.valueOf(TAG_CURRENT_SCHEMA), currentSchema);
+            } else {
+                LOGGER.warn("Schema parameter '{}' detected for {} driver. Note: {} does not support schemas. This parameter will be ignored.", currentSchema, driver, driver);
+            }
+        }
+
+        final String preferCursorExecution = environment.getProperty(prefix + TAG_PREFER_CURSORED_EXECUTION);
+        if (StringUtils.hasLength(preferCursorExecution)) {
+            builder.option(Option.valueOf(TAG_PREFER_CURSORED_EXECUTION), preferCursorExecution);
+        }
+
+        return builder.build();
     }
 
     public String getJdbcDriver() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/test/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProviderTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc-api/src/test/java/io/gravitee/am/repository/jdbc/provider/impl/ConnectionFactoryProviderTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.repository.jdbc.provider.impl;
+
+import io.gravitee.am.common.env.RepositoriesEnvironment;
+import io.r2dbc.pool.PoolingConnectionFactoryProvider;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import io.r2dbc.spi.ValidationDepth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ConnectionFactoryProviderTest {
+
+    private static final String PREFIX = "repositories.gateway";
+    private static final String JDBC_PREFIX = PREFIX + ".jdbc.";
+
+    @Mock
+    private RepositoriesEnvironment environment;
+
+    private ConnectionFactoryProvider cut;
+
+    @BeforeEach
+    void setUp() {
+        // simulate Spring Environment#getProperty(key, default) returning the supplied default
+        // for every property that isn't explicitly stubbed by a test
+        when(environment.getProperty(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(environment.getProperty(JDBC_PREFIX + "driver")).thenReturn("postgresql");
+        when(environment.getProperty(JDBC_PREFIX + "host")).thenReturn("localhost");
+        when(environment.getProperty(JDBC_PREFIX + "username")).thenReturn("am-user");
+        when(environment.getProperty(JDBC_PREFIX + "database")).thenReturn("am-db");
+
+        cut = new ConnectionFactoryProvider(environment, PREFIX);
+    }
+
+    @Test
+    void should_apply_recovery_defaults_when_nothing_is_overridden() {
+        ConnectionFactoryOptions options = cut.buildConnectionFactoryOptions();
+
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.MAX_LIFE_TIME))
+                .as("maxLifeTime must default to a finite value so dead connections eventually get recycled")
+                .isEqualTo(Duration.ofMillis(ConnectionFactoryProvider.DEFAULT_SETTINGS_MAX_LIFE_TIME));
+
+        assertThat((Boolean) options.getValue(Option.valueOf(ConnectionFactoryProvider.TAG_TCP_KEEP_ALIVE)))
+                .as("tcpKeepAlive must default to true")
+                .isTrue();
+
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.VALIDATION_DEPTH))
+                .isEqualTo(ValidationDepth.LOCAL);
+        assertThat(options.hasOption(PoolingConnectionFactoryProvider.MAX_VALIDATION_TIME))
+                .as("maxValidationTime is only relevant when a validationQuery is configured")
+                .isFalse();
+    }
+
+    @Test
+    void should_apply_max_validation_time_when_validation_query_is_set() {
+        when(environment.getProperty(JDBC_PREFIX + "validationQuery")).thenReturn("SELECT 1");
+
+        ConnectionFactoryOptions options = cut.buildConnectionFactoryOptions();
+
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.VALIDATION_DEPTH)).isEqualTo(ValidationDepth.REMOTE);
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.MAX_VALIDATION_TIME))
+                .as("a hanging validation query must be bounded, otherwise it can loop on one dead connection")
+                .isEqualTo(Duration.ofMillis(ConnectionFactoryProvider.DEFAULT_SETTINGS_MAX_VALIDATION_TIME));
+    }
+
+    @Test
+    void should_use_configured_max_validation_time_when_provided() {
+        when(environment.getProperty(JDBC_PREFIX + "validationQuery")).thenReturn("SELECT 1");
+        when(environment.getProperty(JDBC_PREFIX + "maxValidationTime", "" + ConnectionFactoryProvider.DEFAULT_SETTINGS_MAX_VALIDATION_TIME))
+                .thenReturn("9000");
+
+        ConnectionFactoryOptions options = cut.buildConnectionFactoryOptions();
+
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.MAX_VALIDATION_TIME)).isEqualTo(Duration.ofMillis(9000));
+    }
+
+    @Test
+    void should_disable_tcp_keep_alive_when_configured() {
+        when(environment.getProperty(JDBC_PREFIX + "tcpKeepAlive", "" + ConnectionFactoryProvider.DEFAULT_SETTINGS_TCP_KEEP_ALIVE))
+                .thenReturn("false");
+
+        ConnectionFactoryOptions options = cut.buildConnectionFactoryOptions();
+
+        assertThat((Boolean) options.getValue(Option.valueOf(ConnectionFactoryProvider.TAG_TCP_KEEP_ALIVE))).isFalse();
+    }
+
+    @Test
+    void should_use_configured_max_life_time_when_provided() {
+        when(environment.getProperty(JDBC_PREFIX + "maxLifeTime", "" + ConnectionFactoryProvider.DEFAULT_SETTINGS_MAX_LIFE_TIME))
+                .thenReturn("60000");
+
+        ConnectionFactoryOptions options = cut.buildConnectionFactoryOptions();
+
+        assertThat(options.getValue(PoolingConnectionFactoryProvider.MAX_LIFE_TIME)).isEqualTo(Duration.ofMillis(60000));
+    }
+}

--- a/helm/tests/api/configmap_dataplanes.yaml
+++ b/helm/tests/api/configmap_dataplanes.yaml
@@ -27,7 +27,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                 type: jdbc

--- a/helm/tests/api/configmap_repositories.yaml
+++ b/helm/tests/api/configmap_repositories.yaml
@@ -31,7 +31,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               oauth2:
@@ -45,7 +45,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               gateway:
@@ -59,7 +59,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               ratelimit:
@@ -73,7 +73,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
             
@@ -111,7 +111,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -126,7 +126,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -141,7 +141,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -156,7 +156,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha

--- a/helm/tests/gateway/configmap_repositories.yaml
+++ b/helm/tests/gateway/configmap_repositories.yaml
@@ -34,7 +34,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               oauth2:
@@ -48,7 +48,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               gateway:
@@ -62,7 +62,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
               ratelimit:
@@ -76,7 +76,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
 
@@ -114,7 +114,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -129,7 +129,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -144,7 +144,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha
@@ -159,7 +159,7 @@ tests:
                   maxAcquireTime: 5000
                   maxCreateConnectionTime: 3000
                   maxIdleTime: 30000
-                  maxLifeTime: -1
+                  maxLifeTime: 1800000
                   maxSize: 50
                   port: 3306
                   schema: haha

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -189,7 +189,7 @@ jdbc:
     initialSize: 1
     maxSize: 50
     maxIdleTime: 30000
-    maxLifeTime: -1
+    maxLifeTime: 1800000
     maxAcquireTime: 5000
     maxCreateConnectionTime: 3000
 #  sslEnabled: false


### PR DESCRIPTION
## Summary
- r2dbc pool could not recover connections stuck on a half-open socket after a DB failover: LOCAL validation (`channel.isOpen()`) passes on such a socket, and no other setting forced the pool to release a checked-out connection.
- `maxLifeTime` now defaults to 30 minutes instead of unlimited (`-1`), so connections are recycled periodically regardless of pool activity.
- Expose `jdbc.maxValidationTime`, applied whenever a `validationQuery` is configured, so a hanging validation gets cut off and the connection invalidated instead of silently released back to the pool.
- Expose `jdbc.tcpKeepAlive` (default `true`) so the OS can detect a dead socket that LOCAL validation cannot see.

## Test plan
- [x] New unit tests in `ConnectionFactoryProviderTest` cover the default values and the `jdbc.maxLifeTime` / `jdbc.maxValidationTime` / `jdbc.tcpKeepAlive` overrides
- [x] `mvn test -pl gravitee-am-repository/gravitee-am-repository-jdbc-api`
- [ ] Manual verification against a simulated failover (e.g. Toxiproxy) recommended before release, to confirm the pool actually recovers within the configured windows

Fixes AM-7597