### PR TITLE
test: valueless SCIM multi-valued attributes on write and patch (AM-7621)

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -1688,10 +1688,8 @@ public class ProvisioningUserServiceTest {
         testObserver.assertNoErrors();
         testObserver.assertComplete();
 
-        // The stored valueless entry must be dropped while reading, not carried into the patch
-        // and not raised as an error. Reading it is what returned 500 for the whole domain.
         List<Attribute> emailsHandedToThePatch = convertedScimUser.getValue().getEmails();
-        assertEquals(1, emailsHandedToThePatch.size());
+        assertEquals("the valueless entry should be dropped before the patch is applied", 1, emailsHandedToThePatch.size());
         assertEquals("real@example.com", emailsHandedToThePatch.get(0).getValue());
     }
 

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -1647,6 +1647,54 @@ public class ProvisioningUserServiceTest {
         verify(userRepository, never()).update(any(), any());
     }
 
+    @Test
+    public void shouldPatchUser_whenTheStoredUserHasAnEmailWithoutValue() throws Exception {
+        final String userId = "user-id";
+
+        io.gravitee.am.model.User existingUser = new io.gravitee.am.model.User();
+        existingUser.setId(userId);
+        existingUser.setUsername("nullmail2");
+        existingUser.setSource("user-idp");
+        existingUser.setEmail("real@example.com");
+        existingUser.setReferenceId(DOMAIN_ID);
+        existingUser.setReferenceType(ReferenceType.DOMAIN);
+        existingUser.setEmails(List.of(modelAttribute(null), modelAttribute("real@example.com")));
+
+        User patchedScimUser = new User();
+        patchedScimUser.setUserName("nullmail2");
+        patchedScimUser.setDisplayName("patched");
+
+        ObjectNode userNode = mock(ObjectNode.class);
+        PatchOp patchOp = mock(PatchOp.class);
+        when(patchOp.getOperations()).thenReturn(Collections.emptyList());
+
+        io.gravitee.am.identityprovider.api.User idpUser = mock(io.gravitee.am.identityprovider.api.User.class);
+        UserProvider userProvider = mock(UserProvider.class);
+        when(userProvider.create(any())).thenReturn(Single.just(idpUser));
+
+        ArgumentCaptor<User> convertedScimUser = ArgumentCaptor.forClass(User.class);
+
+        when(userRepository.findById(userId)).thenReturn(Maybe.just(existingUser));
+        when(groupService.findByMember(userId)).thenReturn(Flowable.empty());
+        when(objectMapper.convertValue(convertedScimUser.capture(), eq(ObjectNode.class))).thenReturn(userNode);
+        when(objectMapper.treeToValue(userNode, User.class)).thenReturn(patchedScimUser);
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.just(userProvider));
+        when(tokenService.deleteByUser(any())).thenReturn(Completable.complete());
+        when(userRepository.update(any(), any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+        when(eventService.create(any(), any())).thenReturn(Single.just(new Event()));
+
+        TestObserver<User> testObserver = userService.patch(userId, patchOp, null, "/", null, null).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        // The stored valueless entry must be dropped while reading, not carried into the patch
+        // and not raised as an error. Reading it is what returned 500 for the whole domain.
+        List<Attribute> emailsHandedToThePatch = convertedScimUser.getValue().getEmails();
+        assertEquals(1, emailsHandedToThePatch.size());
+        assertEquals("real@example.com", emailsHandedToThePatch.get(0).getValue());
+    }
+
     /** Unrelated failures in these flows also surface as {@link InvalidValueException}. */
     private static Predicate<Throwable> rejectedEmails() {
         return throwable -> throwable instanceof InvalidValueException

--- a/gravitee-am-test/specs/gateway/scim/scim-users.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/scim/scim-users.jest.spec.ts
@@ -267,6 +267,111 @@ describe('SCIM Users', () => {
     });
   });
 
+  describe('Multi-valued attribute validation', () => {
+    const valuelessEmails = [
+      { primary: false, type: 'work' },
+      { value: 'real@example.com', primary: true, type: 'home' },
+    ];
+
+    const expectRejected = (response, field: string) => {
+      expect(response.status).toEqual(400);
+      const resBody = response.body;
+      expect(resBody.status).toEqual('400');
+      expect(resBody.scimType).toEqual('invalidValue');
+      expect(resBody.detail).toEqual(`Field [${field}] contains an entry without a value`);
+      expect(resBody.schemas).toEqual(['urn:ietf:params:scim:api:messages:2.0:Error']);
+    };
+
+    it('should return 400 when creating a user with an email entry that has no value', async () => {
+      const userName = uniqueName('user-valueless-email', true);
+      const body = { ...baseCreateUserRequest, userName: userName, externalId: userName, emails: valuelessEmails };
+
+      const response = await performPost(fixture.scimEndpoint, '/Users', JSON.stringify(body), {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+        'Content-Type': 'application/json',
+      });
+
+      expectRejected(response, 'emails');
+    });
+
+    it('should return 400 when creating a user with a phone number entry that has no value', async () => {
+      const userName = uniqueName('user-valueless-phone', true);
+      const body = {
+        ...baseCreateUserRequest,
+        userName: userName,
+        externalId: userName,
+        phoneNumbers: [{ type: 'work' }, { value: '+33600000000', primary: true }],
+      };
+
+      const response = await performPost(fixture.scimEndpoint, '/Users', JSON.stringify(body), {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+        'Content-Type': 'application/json',
+      });
+
+      expectRejected(response, 'phoneNumbers');
+    });
+
+    it('should return 400 when updating a user with an email entry that has no value', async () => {
+      const userName = uniqueName('user-valueless-put', true);
+      const createdUser = await fixture.createUser(createScimUserBody(`${userName}@example.com`, 'Barbara', 'Jensen', userName));
+
+      const body = {
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: userName,
+        externalId: userName,
+        name: { familyName: 'Jensen', givenName: 'Barbara' },
+        emails: valuelessEmails,
+      };
+
+      const response = await performPut(fixture.scimEndpoint, `/Users/${createdUser.id}`, JSON.stringify(body), {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+        'Content-Type': 'application/json',
+      });
+
+      expectRejected(response, 'emails');
+    });
+
+    it('should return 400 when patching a user with an email entry that has no value', async () => {
+      const userName = uniqueName('user-valueless-patch', true);
+      const createdUser = await fixture.createUser(createScimUserBody(`${userName}@example.com`, 'Barbara', 'Jensen', userName));
+
+      const body = {
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        Operations: [{ op: 'Replace', path: 'emails', value: valuelessEmails }],
+      };
+
+      const response = await performPatch(fixture.scimEndpoint, `/Users/${createdUser.id}`, JSON.stringify(body), {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+        'Content-Type': 'application/json',
+      });
+
+      expectRejected(response, 'emails');
+    });
+
+    it('should create the user when every multi-valued entry has a value', async () => {
+      const userName = uniqueName('user-valued-entries', true);
+      const body = {
+        ...baseCreateUserRequest,
+        userName: userName,
+        externalId: userName,
+        emails: [
+          { value: 'work@example.com', type: 'work' },
+          { value: 'real@example.com', primary: true, type: 'home' },
+        ],
+        phoneNumbers: [{ value: '+33600000000', primary: true }],
+      };
+
+      const response = await performPost(fixture.scimEndpoint, '/Users', JSON.stringify(body), {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+        'Content-Type': 'application/json',
+      });
+
+      expect(response.status).toEqual(201);
+      expect(response.body.emails).toHaveLength(2);
+      expect(response.body.phoneNumbers).toHaveLength(1);
+    });
+  });
+
   describe('CRUD', () => {
     it('should create a user', async () => {
       const email = `${uniqueName('user-crud', true)}@example.com`;
@@ -577,6 +682,5 @@ describe('SCIM Users', () => {
       });
       expect(response.status).toEqual(404);
     });
-
   });
 });


### PR DESCRIPTION
## :id: Reference related issue.
[AM-7621](https://gravitee.atlassian.net/browse/AM-7621)

## :pencil2: A description of the changes proposed in the pull request
Follows the fix in #8521, which rejects SCIM writes where `emails`, `phoneNumbers`, `ims` or `photos` contain an entry without a value, and filters such entries when reading users already persisted in that state. The incident behind it had two symptoms — the write that created the state, and reads failing afterwards — and two paths were left unverified.

**The HTTP contract.** `scim-users.jest.spec.ts` asserted `400` and `scimType: invalidValue` for a malformed body, a missing `userName`, and invalid `userName`, `familyName` and `givenName`, but nothing covered a valueless entry in a multi-valued attribute. Five tests added in a new `Multi-valued attribute validation` block:

- `POST` with a valueless email, and with a valueless phone number, so the check is shown not to be email-only
- `PUT` and `PATCH` with a valueless email
- a positive control creating a user whose entries all have values, without which the rejections would pass against an implementation that rejected everything

Each rejection asserts the full error contract through a shared helper: status, `scimType`, and the exact `detail`.

**Patching a user whose stored record is already affected.** `shouldNotPatchUser_whenAnEmailHasNoValue` covers a bad *payload*. Nothing covered a *stored* record holding a valueless entry, which is the case that failed: `patch()` begins with `innerGet(userId, baseUrl)` and so runs the same conversion. One test added to `ProvisioningUserServiceTest` — it captures the SCIM user handed to the patch operation and asserts the valueless entry was dropped, so it pins the self-heal rather than only the absence of an exception.

No production code touched, no existing test changed.

## :memo: Test scenarios
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
**Why one of these is a unit test rather than an integration one.** After #8521 the affected state can no longer be created through the API, so reproducing "already-persisted bad data, then patch it" over HTTP would need a direct database write. A mocked repository is the right level for it. The equivalent read case was already covered by `shouldListUsers_withStoredEmailAttributeWithoutValue` in #8521.

`ims` and `photos` are covered at the unit layer only. They share the single `requireAttributeValues` path that the `emails` and `phoneNumbers` cases already exercise over HTTP.

Verified against a local stack built from master: jest 30/30 on the full spec file, unit 46/46 on the full test class. Each new assertion was checked by inverting it and confirming the test fails.

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am


[AM-7621]: https://gravitee.atlassian.net/browse/AM-7621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ