### PR TITLE
feat: AM-7555 add attribute mapping UI

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationReporter.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.automation.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.am.model.ReporterAttributeMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -25,6 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -74,6 +76,7 @@ public class AutomationReporter {
 
     @Schema(description = "Audit event types the attribute mappings apply to. Empty means every event type. " +
             "Ignored when system is true.")
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> attributeMappingEventTypes;
 
     /**

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/NewReporter.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.am.service.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.am.model.ReporterAttributeMapping;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -49,6 +51,7 @@ public class NewReporter {
      */
     private List<ReporterAttributeMapping> attributeMappings;
 
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> attributeMappingEventTypes;
 
     @Override

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/UpdateReporter.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.am.service.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.gravitee.am.model.ReporterAttributeMapping;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -48,6 +50,7 @@ public class UpdateReporter {
      */
     private List<ReporterAttributeMapping> attributeMappings;
 
+    @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> attributeMappingEventTypes;
 
     @Override

--- a/gravitee-am-test/playwright/pages/domain-reporter.page.ts
+++ b/gravitee-am-test/playwright/pages/domain-reporter.page.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Locator } from '@playwright/test';
+
+import { BasePage } from './base.page';
+
+/**
+ * Page object for Domain > Settings > Audit Log > Settings, where reporters are listed and edited.
+ *
+ * The plugin configuration is rendered by @ajsf from the reporter's own schema, so those fields are
+ * addressed by schema property name. The attribute mapping section is a hand-written form and is
+ * addressed by test id.
+ */
+export class DomainReporterPage extends BasePage {
+  async navigateToList(domainId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/audits/settings`);
+  }
+
+  async navigateToCreate(domainId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/audits/settings/new`);
+  }
+
+  async navigateToDetail(domainId: string, reporterId: string): Promise<void> {
+    await this.navigate(`/environments/${this.envHrid}/domains/${domainId}/settings/audits/settings/${reporterId}`);
+  }
+
+  /** Organization-level reporters live outside the environment tree. */
+  async navigateToOrgDetail(reporterId: string): Promise<void> {
+    await this.navigate(`/settings/audits/settings/${reporterId}`);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Reporter detail                                                    */
+  /* ------------------------------------------------------------------ */
+
+  get nameInput(): Locator {
+    return this.page.getByTestId('reporterNameInput');
+  }
+
+  get typeSelect(): Locator {
+    return this.page.getByTestId('reporterTypeSelect');
+  }
+
+  get saveButton(): Locator {
+    return this.page.getByTestId('reporterSaveButton');
+  }
+
+  /** A configuration field, addressed by its schema property name. */
+  configurationField(property: string): Locator {
+    return this.page.locator(`json-schema-form input[name="${property}"]`);
+  }
+
+  async save(): Promise<void> {
+    await this.saveButton.click();
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Attribute mapping                                                  */
+  /* ------------------------------------------------------------------ */
+
+  get attributeMappingsSection(): Locator {
+    return this.page.getByTestId('attributeMappingsSection');
+  }
+
+  get mappingRows(): Locator {
+    return this.page.getByTestId('attributeMappingRow');
+  }
+
+  mappingNameInput(index: number): Locator {
+    return this.mappingRows.nth(index).getByTestId('attributeMappingNameInput');
+  }
+
+  mappingExpressionInput(index: number): Locator {
+    return this.mappingRows.nth(index).getByTestId('attributeMappingExpressionInput');
+  }
+
+  /** Append a mapping and fill the row it created. */
+  async addMapping(exportedName: string, expression: string): Promise<void> {
+    const index = await this.mappingRows.count();
+    await this.page.getByTestId('addAttributeMappingButton').click();
+    await this.mappingNameInput(index).fill(exportedName);
+    await this.mappingExpressionInput(index).fill(expression);
+    await this.mappingExpressionInput(index).blur();
+  }
+
+  async removeMapping(index: number): Promise<void> {
+    await this.mappingRows.nth(index).getByTestId('removeAttributeMappingButton').click();
+  }
+
+  mappingFieldError(index: number): Locator {
+    return this.mappingRows.nth(index).locator('mat-error');
+  }
+
+  get validationErrors(): Locator {
+    return this.page.getByTestId('attributeMappingValidationError');
+  }
+
+  /** The event types the mappings are limited to, as listed under the picker. */
+  get selectedEventTypes(): Locator {
+    return this.page.getByTestId('attributeMappingEventTypesSelectedItem');
+  }
+
+  get eventTypesEmptyMessage(): Locator {
+    return this.page.getByTestId('attributeMappingEventTypesEmptyMessage');
+  }
+
+  /** Open the event type picker, tick each name, and close the overlay. */
+  async selectEventTypes(eventTypes: string[]): Promise<void> {
+    await this.page.getByTestId('attributeMappingEventTypesSelect').click();
+    // The panel renders in the CDK overlay, outside the field.
+    const panel = this.page.locator('.mat-mdc-select-panel');
+    await panel.waitFor({ state: 'visible' });
+    for (const eventType of eventTypes) {
+      await this.page.getByTestId('attributeMappingEventTypesSearchInput').fill(eventType);
+      await panel
+        .locator('mat-option')
+        .filter({ hasText: new RegExp(`^\\s*${eventType}\\s*$`) })
+        .click();
+    }
+    await this.page.keyboard.press('Escape');
+    await panel.waitFor({ state: 'hidden' });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Kafka's own event filter, which is a separate control              */
+  /* ------------------------------------------------------------------ */
+
+  get reportedEventTypesSection(): Locator {
+    return this.page.locator('json-schema-form material-multiselect-widget');
+  }
+}

--- a/gravitee-am-test/playwright/tests/settings/reporters/reporter-attribute-mappings.spec.ts
+++ b/gravitee-am-test/playwright/tests/settings/reporters/reporter-attribute-mappings.spec.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Reporter } from '@management-models/Reporter';
+import {
+  createDomainReporter,
+  createOrgReporter,
+  deleteOrgReporter,
+  getDomainReporter,
+  getOrgReporter,
+  listDomainReporters,
+} from '@management-commands/reporter-management-commands';
+
+import { test, expect } from '../../../fixtures/base.fixture';
+import { linkJira } from '../../../utils/jira';
+import { uniqueTestName } from '../../../utils/fixture-helpers';
+import { DomainReporterPage } from '../../../pages/domain-reporter.page';
+
+const USER_ID_EXPRESSION = "{#context.attributes['user'].id}";
+const REQUEST_IP_EXPRESSION = "{#context.attributes['request']['ip']}";
+
+async function createFileReporter(domainId: string, token: string): Promise<Reporter> {
+  const name = uniqueTestName('file-reporter');
+  return createDomainReporter(domainId, token, {
+    type: 'reporter-am-file',
+    name,
+    enabled: true,
+    // Filenames are unique per domain.
+    configuration: JSON.stringify({ filename: name }),
+  });
+}
+
+test.describe('Reporter attribute mappings', () => {
+  test('AM-7554: mappings entered in the console are stored on the reporter', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporter = await createFileReporter(testDomain.id, adminToken);
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await expect(reporterPage.attributeMappingsSection).toBeVisible();
+    await expect(reporterPage.eventTypesEmptyMessage).toContainText(/all event types/i);
+
+    await reporterPage.addMapping('user_id', USER_ID_EXPRESSION);
+    await reporterPage.addMapping('client_ip', REQUEST_IP_EXPRESSION);
+    await reporterPage.selectEventTypes(['USER_LOGIN']);
+
+    await reporterPage.save();
+    await reporterPage.expectSnackbar(/updated/i);
+
+    const stored = await getDomainReporter(testDomain.id, adminToken, reporter.id);
+    expect(stored.attributeMappings).toEqual([
+      { exportedName: 'user_id', expression: USER_ID_EXPRESSION },
+      { exportedName: 'client_ip', expression: REQUEST_IP_EXPRESSION },
+    ]);
+    expect(stored.attributeMappingEventTypes).toEqual(['USER_LOGIN']);
+  });
+
+  test('AM-7554: stored mappings are rendered when the reporter is reopened', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const name = uniqueTestName('file-reporter');
+    const reporter = await createDomainReporter(testDomain.id, adminToken, {
+      type: 'reporter-am-file',
+      name,
+      enabled: true,
+      configuration: JSON.stringify({ filename: name }),
+      attributeMappings: [{ exportedName: 'user_id', expression: USER_ID_EXPRESSION }],
+      attributeMappingEventTypes: ['USER_LOGIN'],
+    });
+
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await expect(reporterPage.mappingRows).toHaveCount(1);
+    await expect(reporterPage.mappingNameInput(0)).toHaveValue('user_id');
+    await expect(reporterPage.mappingExpressionInput(0)).toHaveValue(USER_ID_EXPRESSION);
+    await expect(reporterPage.selectedEventTypes).toHaveText(['USER_LOGIN']);
+  });
+
+  test('AM-7554: a system reporter offers no attribute mapping section', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporters = await listDomainReporters(testDomain.id, adminToken);
+    const systemReporter = reporters.find((reporter) => reporter.system);
+    expect(systemReporter, 'the domain has no system reporter to open').toBeTruthy();
+
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, systemReporter.id);
+
+    // The name field proves the page rendered, which is what makes the absence below meaningful.
+    await expect(reporterPage.nameInput).toBeVisible();
+    await expect(reporterPage.attributeMappingsSection).toHaveCount(0);
+  });
+
+  test('AM-7554: event types cannot be kept without an attribute mapping', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporter = await createFileReporter(testDomain.id, adminToken);
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await reporterPage.addMapping('user_id', USER_ID_EXPRESSION);
+    await reporterPage.selectEventTypes(['USER_LOGIN']);
+    await expect(reporterPage.saveButton).toBeEnabled();
+
+    await reporterPage.removeMapping(0);
+
+    await expect(reporterPage.validationErrors).toContainText([/event types apply to attribute mappings/i]);
+    await expect(reporterPage.saveButton).toBeDisabled();
+  });
+
+  test('AM-7554: a repeated exported name blocks the save until it is renamed', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporter = await createFileReporter(testDomain.id, adminToken);
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await reporterPage.addMapping('user_id', USER_ID_EXPRESSION);
+    await reporterPage.addMapping('user_id', REQUEST_IP_EXPRESSION);
+
+    await expect(reporterPage.validationErrors).toContainText([/used more than once/i]);
+    await expect(reporterPage.saveButton).toBeDisabled();
+
+    await reporterPage.mappingNameInput(1).fill('client_ip');
+
+    await expect(reporterPage.validationErrors).toHaveCount(0);
+    await expect(reporterPage.saveButton).toBeEnabled();
+  });
+
+  test('AM-7554: an exported name the reporter cannot use is rejected in place', async ({ page, testDomain, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporter = await createFileReporter(testDomain.id, adminToken);
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await reporterPage.addMapping('bad-name', USER_ID_EXPRESSION);
+    await reporterPage.mappingNameInput(0).blur();
+
+    await expect(reporterPage.mappingFieldError(0)).toContainText(/letters, digits and underscore/i);
+    await expect(reporterPage.saveButton).toBeDisabled();
+  });
+
+  // The organization page builds its own request payload.
+  test('AM-7554: mappings entered on an organization reporter are stored too', async ({ page, adminToken }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const name = uniqueTestName('org-file-reporter');
+    const reporter = await createOrgReporter(adminToken, {
+      type: 'reporter-am-file',
+      name,
+      enabled: true,
+      configuration: JSON.stringify({ filename: name }),
+    });
+
+    try {
+      const reporterPage = new DomainReporterPage(page);
+      await reporterPage.navigateToOrgDetail(reporter.id);
+
+      await expect(reporterPage.attributeMappingsSection).toBeVisible();
+      await reporterPage.addMapping('user_id', USER_ID_EXPRESSION);
+      await reporterPage.save();
+      await reporterPage.expectSnackbar(/updated/i);
+
+      const stored = await getOrgReporter(adminToken, reporter.id);
+      expect(stored.attributeMappings).toEqual([{ exportedName: 'user_id', expression: USER_ID_EXPRESSION }]);
+    } finally {
+      await deleteOrgReporter(adminToken, reporter.id);
+    }
+  });
+
+  test('AM-7554: the mapping event types are separate from a Kafka reporter’s reported events', async ({
+    page,
+    testDomain,
+    adminToken,
+  }, testInfo) => {
+    linkJira(testInfo, 'AM-7554');
+
+    const reporter = await createDomainReporter(testDomain.id, adminToken, {
+      type: 'reporter-am-kafka',
+      name: uniqueTestName('kafka-reporter'),
+      enabled: true,
+      configuration: JSON.stringify({
+        bootstrapServers: 'localhost:9092',
+        topic: 'gravitee-audit',
+        acks: '1',
+        auditTypes: ['USER_LOGOUT'],
+      }),
+    });
+
+    const reporterPage = new DomainReporterPage(page);
+    await reporterPage.navigateToDetail(testDomain.id, reporter.id);
+
+    await expect(reporterPage.reportedEventTypesSection).toBeVisible();
+    await expect(reporterPage.attributeMappingsSection).toBeVisible();
+    await expect(reporterPage.selectedEventTypes).toHaveCount(0);
+
+    await reporterPage.addMapping('user_id', USER_ID_EXPRESSION);
+    await reporterPage.selectEventTypes(['USER_LOGIN']);
+    await reporterPage.save();
+    await reporterPage.expectSnackbar(/updated/i);
+
+    const stored = await getDomainReporter(testDomain.id, adminToken, reporter.id);
+    expect(stored.attributeMappingEventTypes).toEqual(['USER_LOGIN']);
+    expect(JSON.parse(stored.configuration).auditTypes).toEqual(['USER_LOGOUT']);
+  });
+});

--- a/gravitee-am-test/specs/management/reporters/domain-reporter.jest.spec.ts
+++ b/gravitee-am-test/specs/management/reporters/domain-reporter.jest.spec.ts
@@ -64,11 +64,12 @@ describe('Domain Kafka Reporter CRUD', () => {
     });
 
     it('should create a reporter that scopes its mappings to event types', async () => {
-      const reporter: Reporter = await fixture.createReporter({
-        attributeMappingEventTypes: ['USER_LOGIN', 'USER_LOGOUT'],
-      });
+      // Deliberately not alphabetical: the order the caller sent has to survive the round trip.
+      const eventTypes = ['USER_LOGOUT', 'USER_ENABLED', 'USER_LOGIN'];
 
-      expect([...reporter.attributeMappingEventTypes].sort()).toEqual(['USER_LOGIN', 'USER_LOGOUT']);
+      const reporter: Reporter = await fixture.createReporter({ attributeMappingEventTypes: eventTypes });
+
+      expect([...reporter.attributeMappingEventTypes]).toEqual(eventTypes);
     });
 
     it('should create a reporter that exports no additional attributes', async () => {

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -505,6 +505,8 @@ import {
 import { DomainMcpServerToolEditDialogComponent } from './domain/mcp-servers/mcp-server/tools/tool-edit-dialog/tool-edit-dialog.component';
 import { McpToolsTableComponent } from './domain/components/mcp-tools-table/mcp-tools-table.component';
 import { MaterialMultiselectComponent } from './components/json-schema-form/material-multiselect.component';
+import { MultiselectListComponent } from './components/multiselect/multiselect-list.component';
+import { ReporterAttributeMappingsComponent } from './domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component';
 import { GrantFlowsComponent } from './domain/components/oauth2-settings/grant-flows/grant-flows.component';
 import { ScopesComponent } from './domain/components/oauth2-settings/scopes/scopes.component';
 import { AddScopeComponent } from './domain/components/oauth2-settings/add/add-scope.component';
@@ -644,6 +646,8 @@ import { McpServerPermissionsResolver } from './resolvers/mcp-server-permissions
     ScopeComponent,
     MaterialFileComponent,
     MaterialMultiselectComponent,
+    MultiselectListComponent,
+    ReporterAttributeMappingsComponent,
     MaterialCertificateComponent,
     ManagementComponent,
     ManagementGeneralComponent,

--- a/gravitee-am-ui/src/app/components/json-schema-form/material-multiselect.component.spec.ts
+++ b/gravitee-am-ui/src/app/components/json-schema-form/material-multiselect.component.spec.ts
@@ -17,7 +17,6 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { JsonSchemaFormService } from '@ajsf/core';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { MatSelectChange } from '@angular/material/select';
 
 import { AppConfig } from '../../../config/app.config';
 
@@ -106,8 +105,8 @@ describe('MaterialMultiselectComponent', () => {
     expect(component.allItems).toEqual(['X', 'Y']);
   }));
 
-  it('should call jsf.updateArrayCheckboxList when selected changes', () => {
-    component.selected = ['A'];
+  it('should call jsf.updateArrayCheckboxList when the selection changes', () => {
+    component.onSelectedChange(['A']);
 
     expect(jsf.updateArrayCheckboxList).toHaveBeenCalledWith(component, [
       {
@@ -116,116 +115,5 @@ describe('MaterialMultiselectComponent', () => {
         checked: true,
       },
     ]);
-  });
-
-  it('should remove item on onUnselect()', () => {
-    component.selected = ['A', 'B'];
-
-    component.onUnselect('A');
-
-    expect(component.selected).toEqual(['B']);
-  });
-
-  it('should update selected from MatSelectChange', () => {
-    const event = {
-      value: ['X', 'Y'],
-    } as MatSelectChange<string[]>;
-
-    component.onSelectionChange(event);
-
-    expect(component.selected).toEqual(['X', 'Y']);
-  });
-
-  it('should update searchText on onSearch()', () => {
-    const inputEvent = {
-      target: { value: 'abc' },
-    } as any;
-
-    component.onSearch(inputEvent);
-
-    expect(component.searchText).toBe('abc');
-  });
-
-  it('should update visibleItems based on searchText', () => {
-    component.allItems = ['Apple', 'Banana', 'Cherry'];
-    component.searchText = 'ap';
-
-    (component as any).refreshOptions();
-
-    expect(component.visibleItems).toEqual(['Apple']);
-    expect(component.selectAllLabel).toBe('Select visible');
-  });
-
-  it('should show all items and label "Select all" when searchText is empty', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-
-    expect(component.visibleItems).toEqual(['A', 'B', 'C']);
-    expect(component.selectAllLabel).toBe('Select all');
-  });
-
-  it('should set selectAllState to unchecked when no visible items are selected', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.selected = [];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-
-    expect(component.selectAllState).toBe('unchecked');
-  });
-
-  it('should set selectAllState to checked when all visible items are selected', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.selected = ['A', 'B', 'C'];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-
-    expect(component.selectAllState).toBe('checked');
-  });
-
-  it('should set selectAllState to indeterminate when some visible items are selected', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.selected = ['A'];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-
-    expect(component.selectAllState).toBe('indeterminate');
-  });
-
-  it('should select all visible items when none selected', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.selected = [];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-    component.toggleSelectVisible();
-
-    expect(component.selected.sort()).toEqual(['A', 'B', 'C']);
-  });
-
-  it('should deselect all visible items when all visible selected', () => {
-    component.allItems = ['A', 'B', 'C'];
-    component.selected = ['A', 'B', 'C'];
-    component.searchText = '';
-
-    (component as any).refreshOptions();
-    component.toggleSelectVisible();
-
-    expect(component.selected).toEqual([]);
-  });
-
-  it('should select only visible items when some visible items selected', () => {
-    component.allItems = ['A', 'B', 'C', 'D'];
-    component.selected = ['A', 'D'];
-    component.searchText = 'A';
-
-    (component as any).refreshOptions();
-    component.toggleSelectVisible();
-
-    expect(component.selected).toEqual(['D']);
   });
 });

--- a/gravitee-am-ui/src/app/components/json-schema-form/material-multiselect.component.ts
+++ b/gravitee-am-ui/src/app/components/json-schema-form/material-multiselect.component.ts
@@ -15,7 +15,6 @@
  */
 import { Component, Input, OnInit } from '@angular/core';
 import { JsonSchemaFormService } from '@ajsf/core';
-import { MatSelectChange } from '@angular/material/select';
 import { HttpClient } from '@angular/common/http';
 import { take } from 'rxjs/operators';
 
@@ -24,76 +23,15 @@ import { AppConfig } from '../../../config/app.config';
 @Component({
   selector: 'material-multiselect-widget',
   template: `
-    <div class="mat-input-wrapper mat-form-field-wrapper">
-      <mat-card appearance="outlined" class="mat-multiselect">
-        <mat-form-field appearance="outline" floatLabel="always">
-          <mat-label>{{ options.title }}</mat-label>
-
-          <mat-select placeholder="Click to select" [value]="selected" multiple (selectionChange)="onSelectionChange($event)">
-            <mat-select-trigger>Click to select</mat-select-trigger>
-
-            <mat-form-field>
-              <input matInput type="text" placeholder="Search" (input)="onSearch($event)" />
-              <mat-icon matPrefix>search</mat-icon>
-            </mat-form-field>
-
-            <mat-checkbox
-              class="select-all-option no-hover mat-primary"
-              (click)="$event.stopPropagation(); toggleSelectVisible()"
-              [disabled]="visibleItems.length === 0"
-              [checked]="selectAllState === 'checked'"
-              [indeterminate]="selectAllState === 'indeterminate'"
-            >
-              {{ selectAllLabel }}
-            </mat-checkbox>
-
-            <mat-option *ngFor="let item of allItems || []" [value]="item" [class.hide]="!visibleItems.includes(item)">
-              <span>{{ item }}</span>
-            </mat-option>
-          </mat-select>
-          <mat-hint>{{ options.description }}</mat-hint>
-        </mat-form-field>
-
-        <mat-list *ngIf="selected.length">
-          <mat-list-item *ngFor="let item of selected">
-            <div class="list-row">
-              <span class="label">{{ item }}</span>
-              <button mat-icon-button (click)="onUnselect(item)">
-                <mat-icon>clear</mat-icon>
-              </button>
-            </div>
-          </mat-list-item>
-        </mat-list>
-        <mat-card-content *ngIf="!selected.length && this.options.onEmptySelectionMessage">
-          {{ this.options.onEmptySelectionMessage }}
-        </mat-card-content>
-      </mat-card>
-    </div>
-  `,
-  styles: `
-    .mat-multiselect {
-      padding: 10px;
-    }
-    .no-hover:hover {
-      background: none !important;
-    }
-    .select-all-option {
-      padding-left: 5px;
-    }
-    .hide {
-      display: none;
-    }
-    .list-row {
-      width: 100%;
-      display: flex;
-      align-items: center;
-    }
-    .label {
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+    <gv-multiselect-list
+      [label]="options.title"
+      [hint]="options.description"
+      [emptySelectionMessage]="options.onEmptySelectionMessage"
+      [items]="allItems"
+      [selected]="selected"
+      (selectedChange)="onSelectedChange($event)"
+    >
+    </gv-multiselect-list>
   `,
   standalone: false,
 })
@@ -102,31 +40,10 @@ export class MaterialMultiselectComponent implements OnInit {
   @Input() controlName: string;
 
   options: any;
-  searchText = '';
   allItems: string[] = [];
-  visibleItems: string[] = [];
-  selectAllLabel = 'Select all';
-  selectAllState: 'checked' | 'unchecked' | 'indeterminate' = 'unchecked';
+  selected: string[] = [];
 
   private baseURL = AppConfig.settings.baseURL;
-
-  private _selected: string[] = [];
-
-  get selected(): string[] {
-    return this._selected;
-  }
-
-  set selected(value: string[]) {
-    this._selected = value || [];
-    const updatedValues = this._selected.map((t: string) => ({
-      name: t,
-      value: t,
-      checked: true,
-    }));
-
-    this.jsf.updateArrayCheckboxList(this, updatedValues);
-    this.refreshOptions();
-  }
 
   constructor(
     private jsf: JsonSchemaFormService,
@@ -136,7 +53,7 @@ export class MaterialMultiselectComponent implements OnInit {
   ngOnInit() {
     this.options = this.layoutNode.options;
     this.jsf.initializeControl(this);
-    this.selected = this.jsf.data[this.controlName] || [];
+    this.onSelectedChange(this.jsf.data[this.controlName] || []);
 
     if (this.options.itemsDictionaryEndpoint) {
       const url = this.baseURL + this.options.itemsDictionaryEndpoint;
@@ -145,62 +62,20 @@ export class MaterialMultiselectComponent implements OnInit {
         .pipe(take(1))
         .subscribe((data) => {
           this.allItems = data;
-          this.refreshOptions();
         });
     } else {
-      this.allItems = this.options.enum;
-      this.refreshOptions();
+      this.allItems = this.options.enum || [];
     }
   }
 
-  onSearch(event: Event) {
-    this.searchText = (event.target as HTMLInputElement).value;
-    this.refreshOptions();
-  }
+  onSelectedChange(selected: string[]) {
+    this.selected = selected || [];
+    const updatedValues = this.selected.map((t: string) => ({
+      name: t,
+      value: t,
+      checked: true,
+    }));
 
-  onUnselect(item: string) {
-    this.selected = this.selected.filter((i) => i !== item);
-  }
-
-  onSelectionChange(event: MatSelectChange<string[]>) {
-    this.selected = event.value;
-  }
-
-  toggleSelectVisible() {
-    if (this.visibleItems.length === 0) return;
-
-    const selectedVisible = this.visibleItems.filter((i) => this.selected.includes(i));
-
-    const allVisibleSelected = selectedVisible.length === this.visibleItems.length;
-
-    if (allVisibleSelected) {
-      this.selected = this.selected.filter((i) => !this.visibleItems.includes(i));
-    } else {
-      const merged = new Set([...this.selected, ...this.visibleItems]);
-      this.selected = Array.from(merged);
-    }
-  }
-
-  private refreshOptions() {
-    const query = this.searchText.toLowerCase();
-
-    this.visibleItems = this.allItems.filter((item) => item.toLowerCase().includes(query));
-
-    this.selectAllLabel = query ? 'Select visible' : 'Select all';
-
-    if (this.visibleItems.length === 0) {
-      this.selectAllState = 'unchecked';
-      return;
-    }
-
-    const selectedVisible = this.visibleItems.filter((i) => this.selected.includes(i));
-
-    if (selectedVisible.length === 0) {
-      this.selectAllState = 'unchecked';
-    } else if (selectedVisible.length === this.visibleItems.length) {
-      this.selectAllState = 'checked';
-    } else {
-      this.selectAllState = 'indeterminate';
-    }
+    this.jsf.updateArrayCheckboxList(this, updatedValues);
   }
 }

--- a/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.html
+++ b/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.html
@@ -1,0 +1,70 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="mat-input-wrapper mat-form-field-wrapper">
+  <mat-card appearance="outlined" class="mat-multiselect">
+    <mat-form-field appearance="outline" floatLabel="always">
+      <mat-label>{{ label }}</mat-label>
+
+      <mat-select
+        placeholder="Click to select"
+        [value]="selected"
+        multiple
+        (selectionChange)="onSelectionChange($event)"
+        [attr.data-testid]="testId('Select')"
+      >
+        <mat-select-trigger>Click to select</mat-select-trigger>
+
+        <!-- MatFormField collects prefixes from every descendant, so a matPrefix here would indent
+             the label of the field above. -->
+        <mat-form-field>
+          <input matInput type="text" placeholder="Search" (input)="onSearch($event)" [attr.data-testid]="testId('SearchInput')" />
+        </mat-form-field>
+
+        <mat-checkbox
+          class="select-all-option no-hover mat-primary"
+          (click)="$event.stopPropagation(); toggleSelectVisible()"
+          [disabled]="visibleItems.length === 0"
+          [checked]="selectAllState === 'checked'"
+          [indeterminate]="selectAllState === 'indeterminate'"
+          [attr.data-testid]="testId('SelectAllCheckbox')"
+        >
+          {{ selectAllLabel }}
+        </mat-checkbox>
+
+        <mat-option *ngFor="let item of items || []" [value]="item" [class.hide]="!visibleItems.includes(item)">
+          <span>{{ item }}</span>
+        </mat-option>
+      </mat-select>
+      <mat-hint align="end">{{ hint }}</mat-hint>
+    </mat-form-field>
+
+    <mat-list *ngIf="selected.length">
+      <mat-list-item *ngFor="let item of selected">
+        <div class="list-row">
+          <span class="label" [attr.data-testid]="testId('SelectedItem')">{{ item }}</span>
+          <button mat-icon-button type="button" (click)="onUnselect(item)">
+            <mat-icon>clear</mat-icon>
+          </button>
+        </div>
+      </mat-list-item>
+    </mat-list>
+    <mat-card-content *ngIf="!selected.length && emptySelectionMessage" [attr.data-testid]="testId('EmptyMessage')">
+      {{ emptySelectionMessage }}
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.scss
+++ b/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.scss
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+:host {
+  display: block;
+}
+
+.mat-multiselect {
+  padding: 10px;
+}
+
+.no-hover:hover {
+  background: none !important;
+}
+
+.select-all-option {
+  padding-left: 5px;
+}
+
+.hide {
+  display: none;
+}
+
+.list-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+.list-row .label {
+  overflow: hidden;
+  flex: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.spec.ts
+++ b/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
+
+import { MultiselectListComponent } from './multiselect-list.component';
+
+describe('MultiselectListComponent', () => {
+  let component: MultiselectListComponent;
+  let fixture: ComponentFixture<MultiselectListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MultiselectListComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultiselectListComponent);
+    component = fixture.componentInstance;
+  });
+
+  function setItems(items: string[]) {
+    component.items = items;
+    component.ngOnChanges({ items: new SimpleChange(null, items, true) });
+  }
+
+  it('should refresh the visible items when the items arrive', () => {
+    setItems(['A', 'B', 'C']);
+
+    expect(component.visibleItems).toEqual(['A', 'B', 'C']);
+  });
+
+  it('should remove an item on onUnselect()', () => {
+    component.selected = ['A', 'B'];
+
+    component.onUnselect('A');
+
+    expect(component.selected).toEqual(['B']);
+  });
+
+  it('should emit the new selection on onUnselect()', () => {
+    const emitted: string[][] = [];
+    component.selectedChange.subscribe((selected) => emitted.push(selected));
+    component.selected = ['A', 'B'];
+
+    component.onUnselect('A');
+
+    expect(emitted).toEqual([['B']]);
+  });
+
+  it('should update selected from MatSelectChange', () => {
+    component.onSelectionChange({ value: ['X', 'Y'] } as MatSelectChange<string[]>);
+
+    expect(component.selected).toEqual(['X', 'Y']);
+  });
+
+  it('should emit the new selection on onSelectionChange()', () => {
+    const emitted: string[][] = [];
+    component.selectedChange.subscribe((selected) => emitted.push(selected));
+
+    component.onSelectionChange({ value: ['X'] } as MatSelectChange<string[]>);
+
+    expect(emitted).toEqual([['X']]);
+  });
+
+  it('should update searchText on onSearch()', () => {
+    const inputEvent = {
+      target: { value: 'abc' },
+    } as any;
+
+    component.onSearch(inputEvent);
+
+    expect(component.searchText).toBe('abc');
+  });
+
+  it('should update visibleItems based on searchText', () => {
+    setItems(['Apple', 'Banana', 'Cherry']);
+
+    component.onSearch({ target: { value: 'ap' } } as any);
+
+    expect(component.visibleItems).toEqual(['Apple']);
+    expect(component.selectAllLabel).toBe('Select visible');
+  });
+
+  it('should show all items and label "Select all" when searchText is empty', () => {
+    setItems(['A', 'B', 'C']);
+
+    expect(component.visibleItems).toEqual(['A', 'B', 'C']);
+    expect(component.selectAllLabel).toBe('Select all');
+  });
+
+  it('should set selectAllState to unchecked when no visible items are selected', () => {
+    component.selected = [];
+    setItems(['A', 'B', 'C']);
+
+    expect(component.selectAllState).toBe('unchecked');
+  });
+
+  it('should set selectAllState to checked when all visible items are selected', () => {
+    component.selected = ['A', 'B', 'C'];
+    setItems(['A', 'B', 'C']);
+
+    expect(component.selectAllState).toBe('checked');
+  });
+
+  it('should set selectAllState to indeterminate when some visible items are selected', () => {
+    component.selected = ['A'];
+    setItems(['A', 'B', 'C']);
+
+    expect(component.selectAllState).toBe('indeterminate');
+  });
+
+  it('should select all visible items when none selected', () => {
+    component.selected = [];
+    setItems(['A', 'B', 'C']);
+
+    component.toggleSelectVisible();
+
+    expect([...component.selected].sort()).toEqual(['A', 'B', 'C']);
+  });
+
+  it('should deselect all visible items when all visible selected', () => {
+    component.selected = ['A', 'B', 'C'];
+    setItems(['A', 'B', 'C']);
+
+    component.toggleSelectVisible();
+
+    expect(component.selected).toEqual([]);
+  });
+
+  it('should select only visible items when some visible items selected', () => {
+    component.selected = ['A', 'D'];
+    setItems(['A', 'B', 'C', 'D']);
+    component.onSearch({ target: { value: 'A' } } as any);
+
+    component.toggleSelectVisible();
+
+    expect(component.selected).toEqual(['D']);
+  });
+
+  it('should build a data-testid from the prefix', () => {
+    component.testIdPrefix = 'attributeMappingEventTypes';
+
+    expect(component.testId('Select')).toBe('attributeMappingEventTypesSelect');
+  });
+
+  it('should omit the data-testid when no prefix is given', () => {
+    expect(component.testId('Select')).toBeNull();
+  });
+});

--- a/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.ts
+++ b/gravitee-am-ui/src/app/components/multiselect/multiselect-list.component.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { MatSelectChange } from '@angular/material/select';
+
+@Component({
+  selector: 'gv-multiselect-list',
+  templateUrl: './multiselect-list.component.html',
+  styleUrls: ['./multiselect-list.component.scss'],
+  standalone: false,
+})
+export class MultiselectListComponent implements OnChanges {
+  @Input() label: string;
+  @Input() hint: string;
+  @Input() emptySelectionMessage: string;
+  @Input() testIdPrefix: string;
+  @Input() items: string[] = [];
+  @Input() selected: string[] = [];
+  @Output() selectedChange = new EventEmitter<string[]>();
+
+  searchText = '';
+  visibleItems: string[] = [];
+  selectAllLabel = 'Select all';
+  selectAllState: 'checked' | 'unchecked' | 'indeterminate' = 'unchecked';
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.selected) {
+      this.selected = this.selected || [];
+    }
+    if (changes.items) {
+      this.items = this.items || [];
+    }
+    this.refreshOptions();
+  }
+
+  testId(suffix: string): string {
+    return this.testIdPrefix ? this.testIdPrefix + suffix : null;
+  }
+
+  onSearch(event: Event) {
+    this.searchText = (event.target as HTMLInputElement).value;
+    this.refreshOptions();
+  }
+
+  onUnselect(item: string) {
+    this.select(this.selected.filter((i) => i !== item));
+  }
+
+  onSelectionChange(event: MatSelectChange<string[]>) {
+    this.select(event.value);
+  }
+
+  toggleSelectVisible() {
+    if (this.visibleItems.length === 0) return;
+
+    const selectedVisible = this.visibleItems.filter((i) => this.selected.includes(i));
+
+    const allVisibleSelected = selectedVisible.length === this.visibleItems.length;
+
+    if (allVisibleSelected) {
+      this.select(this.selected.filter((i) => !this.visibleItems.includes(i)));
+    } else {
+      const merged = new Set([...this.selected, ...this.visibleItems]);
+      this.select(Array.from(merged));
+    }
+  }
+
+  private select(selected: string[]) {
+    this.selected = selected || [];
+    this.refreshOptions();
+    this.selectedChange.emit(this.selected);
+  }
+
+  private refreshOptions() {
+    const query = this.searchText.toLowerCase();
+
+    this.visibleItems = (this.items || []).filter((item) => item.toLowerCase().includes(query));
+
+    this.selectAllLabel = query ? 'Select visible' : 'Select all';
+
+    if (this.visibleItems.length === 0) {
+      this.selectAllState = 'unchecked';
+      return;
+    }
+
+    const selectedVisible = this.visibleItems.filter((i) => this.selected.includes(i));
+
+    if (selectedVisible.length === 0) {
+      this.selectAllState = 'unchecked';
+    } else if (selectedVisible.length === this.visibleItems.length) {
+      this.selectAllState = 'checked';
+    } else {
+      this.selectAllState = 'indeterminate';
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.html
@@ -1,0 +1,88 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gv-form-section" data-testid="attributeMappingsSection">
+  <div class="gv-form-section-title">
+    <h5>Attribute mapping</h5>
+    <mat-divider></mat-divider>
+  </div>
+
+  <mat-hint class="section-hint">
+    Export additional attributes alongside each audit record. Attributes holding credentials or tokens are never exported.
+  </mat-hint>
+
+  <div class="mapping-row" *ngFor="let row of rows; let i = index" data-testid="attributeMappingRow">
+    <mat-form-field appearance="outline" class="mapping-name">
+      <mat-label>Exported name</mat-label>
+      <input
+        matInput
+        data-testid="attributeMappingNameInput"
+        [ngModelOptions]="{ standalone: true }"
+        [(ngModel)]="row.exportedName"
+        (ngModelChange)="onRowInput()"
+        required
+        [maxlength]="maxExportedNameLength"
+        [pattern]="exportedNamePattern"
+        placeholder="user_sub"
+        #exportedName="ngModel"
+      />
+      <mat-error *ngIf="exportedName.errors?.pattern">Letters, digits and underscore only.</mat-error>
+      <mat-error *ngIf="exportedName.errors?.required">An exported name is required.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="mapping-expression">
+      <mat-label>Expression</mat-label>
+      <input
+        matInput
+        data-testid="attributeMappingExpressionInput"
+        [ngModelOptions]="{ standalone: true }"
+        [(ngModel)]="row.expression"
+        (ngModelChange)="onRowInput()"
+        required
+        [maxlength]="maxExpressionLength"
+        placeholder="{{ '{#context.attributes[\'user\'].additionalInformation[\'sub\']}' }}"
+        #expression="ngModel"
+      />
+      <mat-error *ngIf="expression.errors?.required">An expression is required.</mat-error>
+    </mat-form-field>
+
+    <button mat-icon-button type="button" data-testid="removeAttributeMappingButton" (click)="removeMapping(i)">
+      <mat-icon>clear</mat-icon>
+    </button>
+  </div>
+
+  <button mat-stroked-button type="button" data-testid="addAttributeMappingButton" (click)="addMapping()" [disabled]="!canAdd">
+    <mat-icon>add</mat-icon> ADD ATTRIBUTE
+  </button>
+
+  <gv-multiselect-list
+    class="event-types"
+    label="Limit to event types"
+    hint="This does not change which events are reported, only which reported events carry the exported attributes."
+    emptySelectionMessage="Attributes are exported for all event types"
+    testIdPrefix="attributeMappingEventTypes"
+    [items]="allEventTypes"
+    [selected]="eventTypes"
+    (selectedChange)="onEventTypesChange($event)"
+  >
+  </gv-multiselect-list>
+
+  <div *ngFor="let error of errors" class="validation-error" data-testid="attributeMappingValidationError">
+    <mat-icon>warning</mat-icon>
+    <span>{{ error }}</span>
+  </div>
+</div>

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+:host {
+  display: block;
+}
+
+.section-hint {
+  display: block;
+  margin-bottom: 12px;
+  font-size: 75%;
+}
+
+.mapping-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.mapping-name {
+  flex: 2;
+}
+
+.mapping-expression {
+  flex: 5;
+}
+
+.event-types {
+  display: block;
+  margin-top: 16px;
+}
+
+.validation-error {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+  color: var(--mat-sys-error, #b3261e);
+  gap: 8px;
+}

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.spec.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
+import { of } from 'rxjs';
+
+import { OrganizationService } from '../../../../../../services/organization.service';
+
+import { ReporterAttributeMappingsComponent } from './reporter-attribute-mappings.component';
+import { AttributeMappingsChange, AttributeMappingsSeed, MAX_ATTRIBUTE_MAPPINGS } from './reporter-attribute-mappings.types';
+
+describe('ReporterAttributeMappingsComponent', () => {
+  let component: ReporterAttributeMappingsComponent;
+  let fixture: ComponentFixture<ReporterAttributeMappingsComponent>;
+  let emitted: AttributeMappingsChange[];
+
+  beforeEach(async () => {
+    const organizationService = {
+      auditEventTypes: jest.fn().mockReturnValue(of(['USER_LOGIN', 'USER_LOGOUT'])),
+    } as unknown as OrganizationService;
+
+    await TestBed.configureTestingModule({
+      declarations: [ReporterAttributeMappingsComponent],
+      providers: [{ provide: OrganizationService, useValue: organizationService }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReporterAttributeMappingsComponent);
+    component = fixture.componentInstance;
+    emitted = [];
+    component.attributeMappingsChanged.subscribe((change) => emitted.push(change));
+  });
+
+  function seed(value: AttributeMappingsSeed) {
+    component.seed = value;
+    component.ngOnChanges({ seed: new SimpleChange(null, value, true) });
+  }
+
+  it('loads the event types on init', () => {
+    component.ngOnInit();
+
+    expect(component.allEventTypes).toEqual(['USER_LOGIN', 'USER_LOGOUT']);
+  });
+
+  it('builds a row per seeded mapping', () => {
+    seed({ mappings: [{ exportedName: 'user_sub', expression: 'a' }], eventTypes: ['USER_LOGIN'] });
+
+    expect(component.rows).toHaveLength(1);
+    expect(component.rows[0]).toMatchObject({ exportedName: 'user_sub', expression: 'a' });
+    expect(component.eventTypes).toEqual(['USER_LOGIN']);
+  });
+
+  it('treats missing seed values as nothing configured', () => {
+    seed({ mappings: null, eventTypes: null });
+
+    expect(component.rows).toEqual([]);
+    expect(component.eventTypes).toEqual([]);
+  });
+
+  it('does not emit when seeded', () => {
+    seed({ mappings: [{ exportedName: 'user_sub', expression: 'a' }], eventTypes: [] });
+
+    expect(emitted).toEqual([]);
+  });
+
+  it('discards local edits when reseeded', () => {
+    seed({ mappings: [{ exportedName: 'user_sub', expression: 'a' }], eventTypes: [] });
+    component.addMapping();
+
+    seed({ mappings: [{ exportedName: 'user_sub', expression: 'a' }], eventTypes: [] });
+
+    expect(component.rows).toHaveLength(1);
+  });
+
+  it('appends an incomplete row on add, and reports it as invalid', () => {
+    seed({ mappings: [], eventTypes: [] });
+
+    component.addMapping();
+
+    expect(component.rows).toHaveLength(1);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].isValid).toBe(false);
+  });
+
+  it('reports a completed row as valid, without the row bookkeeping', () => {
+    seed({ mappings: [], eventTypes: [] });
+    component.addMapping();
+
+    component.rows[0].exportedName = 'user_sub';
+    component.rows[0].expression = "{#context.attributes['user'].id}";
+    component.onRowInput();
+
+    const last = emitted[emitted.length - 1];
+    expect(last.isValid).toBe(true);
+    expect(last.mappings).toEqual([{ exportedName: 'user_sub', expression: "{#context.attributes['user'].id}" }]);
+  });
+
+  it('removes the row at the given index', () => {
+    seed({
+      mappings: [
+        { exportedName: 'first', expression: 'a' },
+        { exportedName: 'second', expression: 'b' },
+        { exportedName: 'third', expression: 'c' },
+      ],
+      eventTypes: [],
+    });
+
+    component.removeMapping(1);
+
+    expect(component.rows.map((row) => row.exportedName)).toEqual(['first', 'third']);
+  });
+
+  it('keeps the surviving rows themselves, so their controls are not rebuilt', () => {
+    seed({
+      mappings: [
+        { exportedName: 'first', expression: 'a' },
+        { exportedName: 'second', expression: 'b' },
+      ],
+      eventTypes: [],
+    });
+    const survivor = component.rows[1];
+
+    component.removeMapping(0);
+
+    expect(component.rows[0]).toBe(survivor);
+  });
+
+  it('reports event types chosen without a mapping as invalid', () => {
+    seed({ mappings: [], eventTypes: [] });
+
+    component.onEventTypesChange(['USER_LOGIN']);
+
+    expect(emitted[emitted.length - 1].isValid).toBe(false);
+  });
+
+  it('stops offering to add once the maximum is reached', () => {
+    seed({
+      mappings: Array.from({ length: MAX_ATTRIBUTE_MAPPINGS }, (_, i) => ({ exportedName: `field${i}`, expression: 'a' })),
+      eventTypes: [],
+    });
+
+    expect(component.canAdd).toBe(false);
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.component.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+
+import { OrganizationService } from '../../../../../../services/organization.service';
+
+import {
+  AttributeMappingsChange,
+  AttributeMappingsSeed,
+  attributeMappingErrors,
+  EXPORTED_NAME_PATTERN,
+  MAX_ATTRIBUTE_MAPPINGS,
+  MAX_EXPORTED_NAME_LENGTH,
+  MAX_EXPRESSION_LENGTH,
+  ReporterAttributeMapping,
+} from './reporter-attribute-mappings.types';
+
+@Component({
+  selector: 'app-reporter-attribute-mappings',
+  templateUrl: './reporter-attribute-mappings.component.html',
+  styleUrls: ['./reporter-attribute-mappings.component.scss'],
+  standalone: false,
+})
+export class ReporterAttributeMappingsComponent implements OnInit, OnChanges {
+  /** Only a new object reseeds the rows, discarding local edits. */
+  @Input() seed: AttributeMappingsSeed;
+  @Output() attributeMappingsChanged = new EventEmitter<AttributeMappingsChange>();
+
+  readonly exportedNamePattern = EXPORTED_NAME_PATTERN;
+  readonly maxExportedNameLength = MAX_EXPORTED_NAME_LENGTH;
+  readonly maxExpressionLength = MAX_EXPRESSION_LENGTH;
+  readonly maxMappings = MAX_ATTRIBUTE_MAPPINGS;
+
+  rows: ReporterAttributeMapping[] = [];
+  eventTypes: string[] = [];
+  allEventTypes: string[] = [];
+
+  constructor(private organizationService: OrganizationService) {}
+
+  ngOnInit() {
+    this.organizationService.auditEventTypes().subscribe((types) => (this.allEventTypes = types || []));
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.seed) {
+      // A freshly loaded page must not look changed, so seeding never emits.
+      this.rows = (this.seed?.mappings ?? []).map((mapping) => ({ ...mapping }));
+      this.eventTypes = [...(this.seed?.eventTypes ?? [])];
+    }
+  }
+
+  get errors(): string[] {
+    return attributeMappingErrors(this.rows, this.eventTypes);
+  }
+
+  get isValid(): boolean {
+    return this.errors.length === 0;
+  }
+
+  get canAdd(): boolean {
+    return this.rows.length < this.maxMappings;
+  }
+
+  addMapping() {
+    this.rows = [...this.rows, { exportedName: '', expression: '' }];
+    this.emit();
+  }
+
+  removeMapping(index: number) {
+    this.rows = this.rows.filter((row, i) => i !== index);
+    this.emit();
+  }
+
+  onRowInput() {
+    this.emit();
+  }
+
+  onEventTypesChange(eventTypes: string[]) {
+    this.eventTypes = eventTypes || [];
+    this.emit();
+  }
+
+  private emit() {
+    this.attributeMappingsChanged.emit({
+      mappings: this.rows.map((row) => ({ ...row })),
+      eventTypes: [...this.eventTypes],
+      isValid: this.isValid,
+    });
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.types.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.types.spec.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  attributeMappingErrors,
+  MAX_ATTRIBUTE_MAPPINGS,
+  ReporterAttributeMapping,
+  supportsAttributeMappings,
+} from './reporter-attribute-mappings.types';
+
+function mapping(exportedName: string, expression = 'value'): ReporterAttributeMapping {
+  return { exportedName, expression };
+}
+
+describe('attributeMappingErrors', () => {
+  it('accepts nothing configured', () => {
+    expect(attributeMappingErrors([], [])).toEqual([]);
+  });
+
+  it('accepts a valid mapping', () => {
+    expect(attributeMappingErrors([mapping('user_sub', "{#context.attributes['user'].id}")], ['USER_LOGIN'])).toEqual([]);
+  });
+
+  it('rejects more mappings than the reporter accepts', () => {
+    const tooMany = Array.from({ length: MAX_ATTRIBUTE_MAPPINGS + 1 }, (_, i) => mapping(`field${i}`));
+
+    expect(attributeMappingErrors(tooMany, [])).toContain('A reporter can export at most 20 attributes.');
+  });
+
+  it('accepts exactly the maximum number of mappings', () => {
+    const atLimit = Array.from({ length: MAX_ATTRIBUTE_MAPPINGS }, (_, i) => mapping(`field${i}`));
+
+    expect(attributeMappingErrors(atLimit, [])).toEqual([]);
+  });
+
+  it.each([
+    ['an empty expression', ''],
+    ['a whitespace-only expression', '   '],
+    ['a tab-only expression', '\t'],
+  ])('rejects %s', (_label, expression) => {
+    expect(attributeMappingErrors([mapping('user_sub', expression)], [])).toContain('Every attribute mapping needs an expression.');
+  });
+
+  it('rejects an expression over 512 characters', () => {
+    expect(attributeMappingErrors([mapping('user_sub', 'a'.repeat(513))], [])).toContain('Every attribute mapping needs an expression.');
+  });
+
+  it('accepts an expression of exactly 512 characters', () => {
+    expect(attributeMappingErrors([mapping('user_sub', 'a'.repeat(512))], [])).toEqual([]);
+  });
+
+  it('accepts a literal expression, which the reporter exports verbatim', () => {
+    expect(attributeMappingErrors([mapping('environment', 'production')], [])).toEqual([]);
+  });
+
+  it('accepts an expression with surrounding whitespace', () => {
+    expect(attributeMappingErrors([mapping('environment', ' production ')], [])).toEqual([]);
+  });
+
+  it.each([['bad-name'], ['user.sub'], ['user sub'], [' user_sub'], ['naïve'], ['']])('rejects the exported name %p', (exportedName) => {
+    expect(attributeMappingErrors([mapping(exportedName)], [])).toContain(
+      'Exported names use letters, digits and underscore only, up to 64 characters.',
+    );
+  });
+
+  it.each([['user_sub'], ['USER_SUB'], ['A_1'], ['_leading'], ['trailing_'], ['0']])('accepts the exported name %p', (exportedName) => {
+    expect(attributeMappingErrors([mapping(exportedName)], [])).toEqual([]);
+  });
+
+  it('rejects an exported name over 64 characters', () => {
+    expect(attributeMappingErrors([mapping('a'.repeat(65))], [])).toContain(
+      'Exported names use letters, digits and underscore only, up to 64 characters.',
+    );
+  });
+
+  it('accepts an exported name of exactly 64 characters', () => {
+    expect(attributeMappingErrors([mapping('a'.repeat(64))], [])).toEqual([]);
+  });
+
+  it('rejects a repeated exported name', () => {
+    expect(attributeMappingErrors([mapping('user_sub'), mapping('user_sub')], [])).toContain(
+      'Exported name "user_sub" is used more than once.',
+    );
+  });
+
+  it('treats exported names that differ only in case as distinct, as the API does', () => {
+    expect(attributeMappingErrors([mapping('user_sub'), mapping('USER_SUB')], [])).toEqual([]);
+  });
+
+  it('rejects event types chosen without any mapping', () => {
+    expect(attributeMappingErrors([], ['USER_LOGIN'])).toContain(
+      'Event types apply to attribute mappings; add one to keep this selection.',
+    );
+  });
+});
+
+describe('supportsAttributeMappings', () => {
+  it.each([['reporter-am-kafka'], ['reporter-am-tcp'], ['reporter-am-file']])('is true for %s', (type) => {
+    expect(supportsAttributeMappings({ type })).toBe(true);
+  });
+
+  it.each([['mongodb'], ['reporter-am-jdbc']])('is false for %s, which drops the exported attributes', (type) => {
+    expect(supportsAttributeMappings({ type })).toBe(false);
+  });
+
+  it('is false for a system reporter, which the API refuses mappings on', () => {
+    expect(supportsAttributeMappings({ type: 'reporter-am-file', system: true })).toBe(false);
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.types.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/attribute-mappings/reporter-attribute-mappings.types.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** One extra attribute a reporter exports, read from the audit context by expression. */
+export interface ReporterAttributeMapping {
+  expression: string;
+  exportedName: string;
+}
+
+export const MAX_ATTRIBUTE_MAPPINGS = 20;
+export const MAX_EXPRESSION_LENGTH = 512;
+export const MAX_EXPORTED_NAME_LENGTH = 64;
+export const EXPORTED_NAME_PATTERN = '^[A-Za-z0-9_]+$';
+
+export interface AttributeMappingsSeed {
+  mappings: ReporterAttributeMapping[];
+  eventTypes: string[];
+}
+
+export interface AttributeMappingsChange extends AttributeMappingsSeed {
+  isValid: boolean;
+}
+
+/** Reporter types whose payload carries the exported attributes. */
+export const REPORTER_TYPES_SUPPORTING_ATTRIBUTE_MAPPINGS = ['reporter-am-kafka', 'reporter-am-tcp', 'reporter-am-file'];
+
+export function supportsAttributeMappings(reporter: any): boolean {
+  return !reporter?.system && REPORTER_TYPES_SUPPORTING_ATTRIBUTE_MAPPINGS.includes(reporter?.type);
+}
+
+const exportedNameRegExp = new RegExp(EXPORTED_NAME_PATTERN);
+
+export function isValidExportedName(exportedName: string): boolean {
+  return !!exportedName && exportedName.length <= MAX_EXPORTED_NAME_LENGTH && exportedNameRegExp.test(exportedName);
+}
+
+/** Expressions reach the API exactly as typed, so surrounding whitespace is significant. */
+export function isValidExpression(expression: string): boolean {
+  return !!expression && expression.trim().length > 0 && expression.length <= MAX_EXPRESSION_LENGTH;
+}
+
+/** The rules ReporterAttributeMappingsValidator applies server-side, one message per broken rule. */
+export function attributeMappingErrors(mappings: ReporterAttributeMapping[], eventTypes: string[]): string[] {
+  const errors: string[] = [];
+  const rows = mappings ?? [];
+  const types = eventTypes ?? [];
+
+  if (rows.length > MAX_ATTRIBUTE_MAPPINGS) {
+    errors.push(`A reporter can export at most ${MAX_ATTRIBUTE_MAPPINGS} attributes.`);
+  }
+  if (rows.some((mapping) => !isValidExpression(mapping?.expression))) {
+    errors.push(`Every attribute mapping needs an expression.`);
+  }
+  if (rows.some((mapping) => !isValidExportedName(mapping?.exportedName))) {
+    errors.push(`Exported names use letters, digits and underscore only, up to ${MAX_EXPORTED_NAME_LENGTH} characters.`);
+  }
+
+  const names = rows.map((mapping) => mapping?.exportedName).filter((name) => isValidExportedName(name));
+  const duplicates = [...new Set(names.filter((name, index) => names.indexOf(name) !== index))];
+  duplicates.forEach((name) => errors.push(`Exported name "${name}" is used more than once.`));
+
+  if (types.length > 0 && rows.length === 0) {
+    errors.push('Event types apply to attribute mappings; add one to keep this selection.');
+  }
+
+  return errors;
+}

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.html
@@ -36,7 +36,13 @@
         <div *ngIf="createMode">
           <mat-form-field appearance="outline" floatLabel="always">
             <mat-label>Reporter Type</mat-label>
-            <mat-select [(value)]="reporter.type" name="type" (selectionChange)="onReporterTypeChanged($event)" [(ngModel)]="reporter.type">
+            <mat-select
+              [(value)]="reporter.type"
+              name="type"
+              data-testid="reporterTypeSelect"
+              (selectionChange)="onReporterTypeChanged($event)"
+              [(ngModel)]="reporter.type"
+            >
               <mat-option *ngFor="let plugin of plugins" [value]="plugin.id" required>
                 {{ labelFor(plugin.id) }}
               </mat-option>
@@ -47,7 +53,16 @@
         <div>
           <mat-form-field appearance="outline" floatLabel="always">
             <mat-label>Name</mat-label>
-            <input matInput type="text" placeholder="Name" name="name" [(ngModel)]="reporter.name" (input)="validateName()" required />
+            <input
+              matInput
+              type="text"
+              placeholder="Name"
+              name="name"
+              data-testid="reporterNameInput"
+              [(ngModel)]="reporter.name"
+              (input)="validateName()"
+              required
+            />
             <mat-hint>A name for your reporter.</mat-hint>
           </mat-form-field>
           <mat-slide-toggle
@@ -74,8 +89,20 @@
           ></reporter-form>
         </div>
       </div>
+      <app-reporter-attribute-mappings
+        *ngIf="supportsAttributeMappings()"
+        [seed]="attributeMappingsSeed"
+        (attributeMappingsChanged)="onAttributeMappingsChanged($event)"
+      ></app-reporter-attribute-mappings>
+
       <div fxLayout="row">
-        <button mat-raised-button [licenseGuard]="licenseOptions" [disabled]="!readyToSave()" (click)="save()">
+        <button
+          mat-raised-button
+          data-testid="reporterSaveButton"
+          [licenseGuard]="licenseOptions"
+          [disabled]="!readyToSave()"
+          (click)="save()"
+        >
           <mat-icon *ngIf="isMissingFeature$ | async" svgIcon="gio:lock"></mat-icon>
           SAVE
         </button>
@@ -97,6 +124,30 @@
       <div class="gv-page-description-content">
         <p>A reporter is used by the platform to report many types of event (e.g Audit logs).</p>
       </div>
+
+      <ng-container *ngIf="supportsAttributeMappings()">
+        <h3>Attribute mapping</h3>
+        <div class="gv-page-description-content">
+          <p>An attribute mapping exports one extra field on every audit record this reporter writes.</p>
+          <p>
+            The expression is evaluated against the audit context, which carries <code>user</code>, <code>client</code>,
+            <code>request</code> (ip, userAgent) and <code>audit</code> (id, type, transactionId, status).
+          </p>
+          <small>For example:</small>
+          <small>
+            <pre fxLayout="column">
+        <code>&#123;#context.attributes['user'].id&#125;</code>
+        <code>&#123;#context.attributes['user'].additionalInformation['sub']&#125;</code>
+        <code>&#123;#context.attributes['client'].clientId&#125;</code>
+        <code>&#123;#context.attributes['request']['ip']&#125;</code>
+      </pre
+            >
+          </small>
+          <p>A plain value such as <code>production</code> is exported as it is written.</p>
+          <p>Only single values are exported, and attributes holding credentials or tokens never are.</p>
+          <p>Leaving the event types empty exports the attributes on every audit record.</p>
+        </div>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.scss
@@ -2,3 +2,13 @@
   display: flex;
   align-items: center;
 }
+
+/* A flex item defaults to min-width:auto, so the column has to be told it may shrink. */
+.gv-page-description {
+  min-width: 0;
+}
+
+.gv-page-description-content pre {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { OrganizationService } from '../../../../../services/organization.service';
+import { ReporterService } from '../../../../../services/reporter.service';
+import { SnackbarService } from '../../../../../services/snackbar.service';
+import { DialogService } from '../../../../../services/dialog.service';
+import { PluginFeatureService } from '../../../../../services/plugin-feature.service';
+
+import { ReporterComponent } from './reporter.component';
+
+describe('ReporterComponent', () => {
+  let component: ReporterComponent;
+
+  function build(routeData: any) {
+    const route = { snapshot: { data: routeData } } as unknown as ActivatedRoute;
+    const router = { routerState: { snapshot: { url: '/domains/a-domain/settings/audits/settings' } } } as unknown as Router;
+    const organizationService = {
+      reporterSchema: jest.fn().mockReturnValue(of({ properties: {} })),
+    } as unknown as OrganizationService;
+    const pluginFeatureService = {
+      getFeature$: jest.fn().mockReturnValue(of('reporter')),
+      isMissingFeatureForType$: jest.fn().mockReturnValue(of(false)),
+    } as unknown as PluginFeatureService;
+
+    const reporter = new ReporterComponent(
+      route,
+      router,
+      organizationService,
+      {} as ReporterService,
+      {} as SnackbarService,
+      {} as DialogService,
+      pluginFeatureService,
+    );
+    reporter.form = { pristine: false, valid: true, reset: jest.fn() };
+    return reporter;
+  }
+
+  function editing(reporter: any) {
+    return build({
+      organizationContext: false,
+      createMode: false,
+      domain: { id: 'a-domain' },
+      reporterPlugins: [{ id: 'reporter-am-file' }, { id: 'reporter-am-kafka' }, { id: 'reporter-am-tcp' }],
+      reporter,
+    });
+  }
+
+  describe('attribute mapping support', () => {
+    it.each([['reporter-am-kafka'], ['reporter-am-tcp'], ['reporter-am-file']])('offers the section for %s', (type) => {
+      component = editing({ type, name: 'a-reporter' });
+      component.ngOnInit();
+
+      expect(component.supportsAttributeMappings()).toBe(true);
+    });
+
+    it('withholds the section from a reporter whose payload would drop the attributes', () => {
+      component = editing({ type: 'reporter-am-jdbc', name: 'a-reporter' });
+      component.ngOnInit();
+
+      expect(component.supportsAttributeMappings()).toBe(false);
+    });
+
+    it('withholds the section from a system reporter, which the API refuses mappings on', () => {
+      component = editing({ type: 'reporter-am-file', name: 'a-reporter', system: true });
+      component.ngOnInit();
+
+      expect(component.supportsAttributeMappings()).toBe(false);
+    });
+  });
+
+  describe('seeding', () => {
+    it('seeds the section from the stored reporter', () => {
+      component = editing({
+        type: 'reporter-am-file',
+        name: 'a-reporter',
+        attributeMappings: [{ exportedName: 'user_sub', expression: 'a' }],
+        attributeMappingEventTypes: ['USER_LOGIN'],
+      });
+
+      component.ngOnInit();
+
+      expect(component.attributeMappingsSeed).toEqual({
+        mappings: [{ exportedName: 'user_sub', expression: 'a' }],
+        eventTypes: ['USER_LOGIN'],
+      });
+    });
+
+    it('seeds an unconfigured reporter with nothing', () => {
+      component = editing({ type: 'reporter-am-file', name: 'a-reporter' });
+
+      component.ngOnInit();
+
+      expect(component.attributeMappingsSeed).toEqual({ mappings: [], eventTypes: [] });
+    });
+  });
+
+  describe('changes', () => {
+    beforeEach(() => {
+      component = editing({ type: 'reporter-am-file', name: 'a-reporter' });
+      component.ngOnInit();
+    });
+
+    it('carries the section changes onto the reporter it saves', () => {
+      component.onAttributeMappingsChanged({
+        mappings: [{ exportedName: 'user_sub', expression: 'a' }],
+        eventTypes: ['USER_LOGIN'],
+        isValid: true,
+      });
+
+      expect(component.reporter.attributeMappings).toEqual([{ exportedName: 'user_sub', expression: 'a' }]);
+      expect(component.reporter.attributeMappingEventTypes).toEqual(['USER_LOGIN']);
+      expect(component.readyToSave()).toBe(true);
+    });
+
+    it('blocks the save while the section is invalid', () => {
+      component.onAttributeMappingsChanged({ mappings: [], eventTypes: ['USER_LOGIN'], isValid: false });
+
+      expect(component.readyToSave()).toBe(false);
+    });
+  });
+
+  describe('changing the reporter type while creating', () => {
+    function creating() {
+      return build({
+        organizationContext: false,
+        createMode: true,
+        domain: { id: 'a-domain' },
+        reporterPlugins: [{ id: 'reporter-am-file' }],
+      });
+    }
+
+    it('drops mappings that the newly chosen type would not export', () => {
+      component = creating();
+      component.ngOnInit();
+      component.onAttributeMappingsChanged({
+        mappings: [{ exportedName: 'user_sub', expression: 'a' }],
+        eventTypes: ['USER_LOGIN'],
+        isValid: true,
+      });
+
+      component.onReporterTypeChanged({ value: 'reporter-am-jdbc' });
+
+      expect(component.reporter.attributeMappings).toEqual([]);
+      expect(component.reporter.attributeMappingEventTypes).toEqual([]);
+      expect(component.attributeMappingsSeed).toEqual({ mappings: [], eventTypes: [] });
+    });
+
+    it('keeps mappings when the newly chosen type exports them', () => {
+      component = creating();
+      component.ngOnInit();
+      component.onAttributeMappingsChanged({
+        mappings: [{ exportedName: 'user_sub', expression: 'a' }],
+        eventTypes: [],
+        isValid: true,
+      });
+
+      component.onReporterTypeChanged({ value: 'reporter-am-tcp' });
+
+      expect(component.reporter.attributeMappings).toEqual([{ exportedName: 'user_sub', expression: 'a' }]);
+    });
+  });
+});

--- a/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/audits/settings/reporter/reporter.component.ts
@@ -25,6 +25,12 @@ import { ReporterService } from '../../../../../services/reporter.service';
 import { SnackbarService } from '../../../../../services/snackbar.service';
 import { PluginFeatureService } from '../../../../../services/plugin-feature.service';
 
+import {
+  AttributeMappingsChange,
+  AttributeMappingsSeed,
+  supportsAttributeMappings,
+} from './attribute-mappings/reporter-attribute-mappings.types';
+
 @Component({
   selector: 'app-reporter',
   templateUrl: './reporter.component.html',
@@ -48,6 +54,8 @@ export class ReporterComponent implements OnInit {
   hasName = false;
   licenseOptions: LicenseOptions = {};
   isMissingFeature$: Observable<boolean>;
+  attributeMappingsSeed: AttributeMappingsSeed = { mappings: [], eventTypes: [] };
+  attributeMappingsValid = true;
 
   constructor(
     private route: ActivatedRoute,
@@ -88,6 +96,7 @@ export class ReporterComponent implements OnInit {
       this.reporterConfiguration = this.reporter.configuration ? JSON.parse(this.reporter.configuration) : {};
       this.updateReporterConfiguration = this.reporterConfiguration;
     }
+    this.seedAttributeMappings(this.reporter);
     this.validateName();
     this.getSchemaFor(this.reporter.type);
     this.updateLicenseOptions(this.reporter.type);
@@ -118,6 +127,11 @@ export class ReporterComponent implements OnInit {
   }
 
   onReporterTypeChanged(event) {
+    if (this.createMode && !supportsAttributeMappings({ type: event.value })) {
+      this.reporter.attributeMappings = [];
+      this.reporter.attributeMappingEventTypes = [];
+      this.seedAttributeMappings(this.reporter);
+    }
     this.getSchemaFor(event.value);
     this.updateLicenseOptions(event.value);
   }
@@ -152,6 +166,7 @@ export class ReporterComponent implements OnInit {
         this.reporter = data;
         this.reporterConfiguration = JSON.parse(this.reporter.configuration);
         this.updateReporterConfiguration = this.reporterConfiguration;
+        this.seedAttributeMappings(this.reporter);
         this.formChanged = false;
         this.form.reset(this.reporter);
         this.snackbarService.open('Reporter updated');
@@ -182,6 +197,17 @@ export class ReporterComponent implements OnInit {
     });
   }
 
+  supportsAttributeMappings(): boolean {
+    return supportsAttributeMappings(this.reporter);
+  }
+
+  onAttributeMappingsChanged(change: AttributeMappingsChange) {
+    this.reporter.attributeMappings = change.mappings;
+    this.reporter.attributeMappingEventTypes = change.eventTypes;
+    this.attributeMappingsValid = change.isValid;
+    this.formChanged = true;
+  }
+
   enableReporter(event) {
     this.reporter.enabled = event.checked;
     this.formChanged = true;
@@ -206,6 +232,14 @@ export class ReporterComponent implements OnInit {
 
   readyToSave() {
     const anyChanged = !this.form.pristine || !this.configurationPristine || this.formChanged;
-    return this.form.valid && anyChanged && this.configurationIsValid && this.hasName;
+    return this.form.valid && anyChanged && this.configurationIsValid && this.hasName && this.attributeMappingsValid;
+  }
+
+  private seedAttributeMappings(reporter) {
+    this.attributeMappingsSeed = {
+      mappings: reporter.attributeMappings ?? [],
+      eventTypes: reporter.attributeMappingEventTypes ?? [],
+    };
+    this.attributeMappingsValid = true;
   }
 }

--- a/gravitee-am-ui/src/app/services/organization.service.ts
+++ b/gravitee-am-ui/src/app/services/organization.service.ts
@@ -364,6 +364,8 @@ export class OrganizationService {
       enabled: reporter.enabled,
       inherited: reporter.inherited,
       configuration: reporter.configuration,
+      attributeMappings: reporter.attributeMappings,
+      attributeMappingEventTypes: reporter.attributeMappingEventTypes,
     });
   }
 
@@ -378,6 +380,8 @@ export class OrganizationService {
       enabled: reporter.enabled,
       configuration: reporter.configuration,
       inherited: reporter.inherited,
+      attributeMappings: reporter.attributeMappings,
+      attributeMappingEventTypes: reporter.attributeMappingEventTypes,
     });
   }
 

--- a/gravitee-am-ui/src/app/services/reporter.service.ts
+++ b/gravitee-am-ui/src/app/services/reporter.service.ts
@@ -54,6 +54,8 @@ export class ReporterService {
       type: reporter.type,
       enabled: reporter.enabled,
       configuration: reporter.configuration,
+      attributeMappings: reporter.attributeMappings,
+      attributeMappingEventTypes: reporter.attributeMappingEventTypes,
     });
   }
 
@@ -66,6 +68,8 @@ export class ReporterService {
       type: reporter.type,
       enabled: reporter.enabled,
       configuration: reporter.configuration,
+      attributeMappings: reporter.attributeMappings,
+      attributeMappingEventTypes: reporter.attributeMappingEventTypes,
     });
   }
 }


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7555](https://gravitee.atlassian.net/browse/AM-7555)

## :pencil2: A description of the changes proposed in the pull request
Add an **Attribute mapping** section to reporter settings UI with editable lists of mappings and event types.

- Validate individual attribute mappings in the same way as in the API.
- Preserve ordering of `attributeMappingEventTypes` in persisted reporters.
- Display guidance in page description section.
- UI for default reporter types (`mongodb` and `reporter-am-jdbc`) is unaffected. 

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
#### Section shown below reporter configuration
<img width="989" height="585" alt="image" src="https://github.com/user-attachments/assets/48ef93c7-93f3-42b8-b995-13a5bca9e0c8" />

#### On screen guidance
<img width="519" height="693" alt="image" src="https://github.com/user-attachments/assets/e1675101-f92c-4a4f-9392-d98e73379ec9" />


## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am

[AM-7555]: https://gravitee.atlassian.net/browse/AM-7555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ