### PR TITLE
test: drop the offline-verification sleep and claim from introspection spec (AM-7549)

### DIFF
--- a/gravitee-am-test/specs/gateway/protected-resources/introspection-resource-indicators.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/protected-resources/introspection-resource-indicators.jest.spec.ts
@@ -27,7 +27,6 @@ import {
   ProtectedResourcesFixture,
   setupProtectedResourcesFixture,
 } from './fixtures/protected-resources-fixture';
-import { delay } from '@utils-commands/misc';
 
 // RFC 8707 Introspection: Protected Resource can introspect tokens obtained via authorization_code grant with resource indicators
 // AuthZen Introspection: Protected Resource can introspect tokens obtained via client_credentials grant with aud = clientId
@@ -66,9 +65,6 @@ describe('Protected Resource Introspection with Resource Indicators (RFC 8707)',
     expect(protectedResource).toBeDefined();
     expect(protectedResource.clientId).toBeDefined();
     expect(protectedResource.clientSecret).toBeDefined();
-
-    // Add a 10 second delay to ensure offline verification is not conducted
-    await delay(10000);
 
     // Step 4: Introspect the token using the Protected Resource credentials
     // Note that the client ID of the resources indicated in the token exchange must match the client ID of the Authorization header
@@ -111,7 +107,6 @@ describe('Protected Resource Introspection with Resource Indicators (RFC 8707)',
     );
     expect(accessToken).toBeDefined();
 
-    // No offline-verification wait: exercise with the offline path
     const introspectionResponse = await fixture.introspectToken(accessToken, multiAudResource).expect(200);
 
     expect(introspectionResponse.body.active).toBe(true);


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7549

## :pencil2: A description of the changes proposed in the pull request
The test stack sets `offlineVerificationTimerSeconds=0`, so the gateway consults the token store on every introspection call. Two things in this spec assumed otherwise:

- a 10 second sleep "to ensure offline verification is not conducted", which the configuration already guarantees
- a comment claiming a test exercises the offline path, which cannot happen with the window at zero

Both removed, along with the now-unused `delay` import. Neither test changes what it covers.

Confirmed with Eric on the ticket: an integration test for offline verification is not worth having, since the setting is static per stack rather than per test. Offline verification stays covered by `IntrospectionAccessTokenServiceTest` and `IntrospectionRefreshTokenServiceTest`.

## :memo: Test scenarios 
`npm --prefix gravitee-am-test run test -- specs/gateway/protected-resources/introspection-resource-indicators.jest.spec.ts`

5/5 pass in 8.4s, down from ~18s. The jest gateway job runs on both Mongo and Postgres, so roughly 20s per PR.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am
