### PR TITLE
feat: AM-7639 data plane management in automation API

### DIFF
--- a/docs/automation/GUIDE.md
+++ b/docs/automation/GUIDE.md
@@ -31,6 +31,12 @@ compact **per-resource reference**. New resource types follow the same conventio
 > `/organizations/{orgId}/environments/{envId}/…`; provision the organization and environment via the
 > standard Management API beforehand. The default install ships both with the id `DEFAULT`.
 
+> **Data planes need a permission no built-in role has.** Reading them uses the ordinary
+> `data_plane` read/list permission, but creating, updating and deleting them requires
+> `data_plane_managed_{create,update,delete}`, which is granted by **no** default role — not even
+> Organization Admin. Create a custom organization role carrying those permissions and assign it to the
+> account the automation runs as. Every other resource in this guide works with the usual admin roles.
+
 Base URL: `http://localhost:8093/automation`
 
 ---
@@ -39,8 +45,8 @@ Base URL: `http://localhost:8093/automation`
 
 ## 1. The API pattern
 
-Every resource type (Domain, Identity Provider, Certificate, Reporter) is managed individually and
-follows the same convention:
+Every resource type (Domain, Identity Provider, Certificate, Reporter, Data Plane) is managed
+individually and follows the same convention:
 
 | Operation | Method | Path | Identifier |
 |-----------|--------|------|------------|
@@ -51,6 +57,9 @@ follows the same convention:
 
 PUT is always on the **collection** endpoint; the `key` field in the body identifies which resource to
 create or update. Each PUT manages a single resource and never touches siblings you didn't mention.
+
+> **Data planes spell the identity field `id`, not `key`.** It behaves exactly like a `key` everywhere
+> else in this guide, including `id:` addressing.
 
 ## 2. Addressing a resource
 
@@ -121,6 +130,19 @@ The **`id:` exception:** addressing by internal id bypasses this gate so you *ca
 resource — but only if you already know its id. `id:`-reachable resources never appear in `list`
 responses (which stay automation-only), so there is no enumeration leak.
 
+**Data planes declared in `gravitee.yml`** are outside this API entirely: their ids are reserved, and a
+PUT naming one is rejected. Data planes provisioned through the node's internal API are not
+automation-managed, so they are reachable only by `id:` — which updates them in place without adopting
+them.
+
+**Deleting a data plane is refused while any domain still references it** (`409`). Move or delete those
+domains first. This is the one delete in the API that is not unconditional.
+
+**A domain's `dataPlaneId` is not eventually consistent** the way the references in §6 are: the data
+plane has to exist before a domain can name it, so apply it first. A control plane running more than
+one node picks up a new data plane on its next sync poll, so a create routed to a node that is still
+behind is refused until it catches up.
+
 > **Automation domains start empty.** Unlike domains created via the UI, an automation-managed domain is
 > **not** seeded with a system identity provider, reporter, or certificate. Declare what you need
 > explicitly — including the built-in defaults via the `system` flag.
@@ -158,6 +180,7 @@ All paths are prefixed with
 | Identity Provider | `…/domains/{ref}/identities` | `…/identities/{ref}` | `…/identities` | `…/identities/{ref}` |
 | Certificate | `…/domains/{ref}/certificates` | `…/certificates/{ref}` | `…/certificates` | `…/certificates/{ref}` |
 | Reporter | `…/domains/{ref}/reporters` | `…/reporters/{ref}` | `…/reporters` | `…/reporters/{ref}` |
+| Data Plane | `…/dataplanes` | `…/dataplanes/{ref}` | `…/dataplanes` | `…/dataplanes/{ref}` |
 
 `{ref}` is either an automation `key` or an `id:<internalUuid>` (§2). Resource-specific fields:
 
@@ -167,12 +190,45 @@ All paths are prefixed with
   `groupMapper`, `domainWhitelist`; or `key` + `system: true`.
 - **Certificate** — `key`, `name`, `type`, `configuration`; or `key` + `system: true`.
 - **Reporter** — `key`, `name`, `type`, `configuration`, `enabled`; or `key` + `system: true`.
+- **Data Plane** — `id`, `name`, `type` (`mongodb` or `jdbc`), `configuration`; optional `gatewayUrl`.
+  `configuration` is write-only; reads return `database` and `hosts` instead. `type` is immutable, and
+  so are the organization and environment, which come from the path.
 
 See [`openapi.yaml`](openapi.yaml) for the full field-level contract.
 
 ---
 
 # Worked examples
+
+### Register a data plane, then put a domain on it
+
+```bash
+BASE="http://localhost:8093/automation/organizations/DEFAULT/environments/DEFAULT"
+
+curl -s -X PUT "$BASE/dataplanes" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "id": "acme-eu",
+    "name": "ACME EU data plane",
+    "type": "mongodb",
+    "gatewayUrl": "https://gateway-eu.example.com",
+    "configuration": {
+      "mongodb": { "dbname": "gravitee-am-acme", "host": "mongo", "port": 27017 }
+    }
+  }' | jq '{id, database, hosts}'
+```
+
+A domain's `dataPlaneId` is fixed at creation, so deleting the data plane is refused until that domain
+is gone:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$BASE/dataplanes/acme-eu" \
+  -H "Authorization: Bearer $TOKEN"      # 409 while acme-auth exists
+
+curl -s -X DELETE "$BASE/domains/acme-auth" -H "Authorization: Bearer $TOKEN"
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$BASE/dataplanes/acme-eu" \
+  -H "Authorization: Bearer $TOKEN"      # 204
+```
 
 ### Create / update a domain
 

--- a/docs/automation/GUIDE.md
+++ b/docs/automation/GUIDE.md
@@ -31,12 +31,6 @@ compact **per-resource reference**. New resource types follow the same conventio
 > `/organizations/{orgId}/environments/{envId}/…`; provision the organization and environment via the
 > standard Management API beforehand. The default install ships both with the id `DEFAULT`.
 
-> **Data planes need a permission no built-in role has.** Reading them uses the ordinary
-> `data_plane` read/list permission, but creating, updating and deleting them requires
-> `data_plane_managed_{create,update,delete}`, which is granted by **no** default role — not even
-> Organization Admin. Create a custom organization role carrying those permissions and assign it to the
-> account the automation runs as. Every other resource in this guide works with the usual admin roles.
-
 Base URL: `http://localhost:8093/automation`
 
 ---

--- a/docs/automation/openapi.yaml
+++ b/docs/automation/openapi.yaml
@@ -42,6 +42,9 @@ security:
 tags:
 - description: Certificates configured under a domain to sign and verify tokens.
   name: Certificates
+- description: Data planes configured under an environment to store the runtime data
+    of its domains.
+  name: Data Planes
 - description: "Security domains: the top-level container for an authentication and\
     \ authorization configuration. Create, read, update, and delete domains, and reach\
     \ their sub-resources."
@@ -51,6 +54,317 @@ tags:
 - description: Reporters configured under a domain to persist audit events to a backend.
   name: Reporters
 paths:
+  /organizations/{orgId}/environments/{envId}/dataplanes:
+    get:
+      description: Returns all data planes managed by the Automation API in the environment.
+        Data planes provisioned outside the Automation API are not returned.
+      operationId: automationListDataPlanes
+      parameters:
+      - description: Identifier of the organization that owns the environment.
+        example: DEFAULT
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the environment the resource belongs to.
+        example: DEFAULT
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                DataPlaneList:
+                  description: DataPlaneList
+                  value:
+                  - id: acme-eu
+                    name: ACME EU data plane
+                    type: mongodb
+                    gatewayUrl: https://gateway-eu.example.com
+                    database: gravitee-am-acme
+                    hosts:
+                    - mongo:27017
+                    organizationId: DEFAULT
+                    environmentId: DEFAULT
+                    createdAt: 2026-01-15T09:30:00.000Z
+                    updatedAt: 2026-01-15T09:30:00.000Z
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutomationDataPlane"
+          description: List of data planes
+        "403":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 403
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Permission denied
+        default:
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 500
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Unexpected error
+      summary: List an environment's data planes
+      tags:
+      - Data Planes
+    put:
+      description: "Idempotent create-or-update. Uses the id field in the body to\
+        \ identify the data plane within the environment. The type is immutable, and\
+        \ the organization and environment come from the path. An id: reference updates\
+        \ a data plane the Automation API does not manage, and cannot create one."
+      operationId: automationCreateOrUpdateDataPlane
+      parameters:
+      - description: Identifier of the organization that owns the environment.
+        example: DEFAULT
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the environment the resource belongs to.
+        example: DEFAULT
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            examples:
+              DataPlane:
+                description: A MongoDB data plane
+                value:
+                  id: acme-eu
+                  name: ACME EU data plane
+                  type: mongodb
+                  gatewayUrl: https://gateway-eu.example.com
+                  configuration:
+                    mongodb:
+                      dbname: gravitee-am-acme
+                      host: mongo
+                      port: 27017
+            schema:
+              $ref: "#/components/schemas/AutomationDataPlane"
+        description: Desired state of the data plane.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                DataPlane:
+                  description: DataPlane
+                  value:
+                    id: acme-eu
+                    name: ACME EU data plane
+                    type: mongodb
+                    gatewayUrl: https://gateway-eu.example.com
+                    database: gravitee-am-acme
+                    hosts:
+                    - mongo:27017
+                    organizationId: DEFAULT
+                    environmentId: DEFAULT
+                    createdAt: 2026-01-15T09:30:00.000Z
+                    updatedAt: 2026-01-15T09:30:00.000Z
+              schema:
+                $ref: "#/components/schemas/AutomationDataPlane"
+          description: The created or updated data plane
+        "400":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 400
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: "Invalid request: a missing required field, an unknown data\
+            \ plane type, a configuration the type's plugin rejects, an id reserved\
+            \ by the node's gravitee.yml, or an attempt to change an immutable field"
+        "403":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 403
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Permission denied
+        "404":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 404
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: "An id: reference naming a data plane that does not exist in\
+            \ this environment"
+        "409":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 409
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: The id is already taken by a data plane the Automation API
+            does not manage
+      summary: Create or update a data plane
+      tags:
+      - Data Planes
+  /organizations/{orgId}/environments/{envId}/dataplanes/{dataPlaneId}:
+    delete:
+      description: Deletes an Automation-managed data plane by its id. Deleting a
+        data plane that does not exist also returns 204.
+      operationId: automationDeleteDataPlane
+      parameters:
+      - description: Identifier of the organization that owns the environment.
+        example: DEFAULT
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the environment the resource belongs to.
+        example: DEFAULT
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+      - description: Id of the data plane within the environment.
+        example: acme-eu
+        in: path
+        name: dataPlaneId
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: Data plane successfully deleted
+        "403":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 403
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Permission denied
+        "409":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 409
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: At least one domain still references the data plane
+      summary: Delete a data plane
+      tags:
+      - Data Planes
+    get:
+      description: Retrieves a single Automation-managed data plane by its id.
+      operationId: automationGetDataPlane
+      parameters:
+      - description: Identifier of the organization that owns the environment.
+        example: DEFAULT
+        in: path
+        name: orgId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the environment the resource belongs to.
+        example: DEFAULT
+        in: path
+        name: envId
+        required: true
+        schema:
+          type: string
+      - description: Id of the data plane within the environment.
+        example: acme-eu
+        in: path
+        name: dataPlaneId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                DataPlane:
+                  description: DataPlane
+                  value:
+                    id: acme-eu
+                    name: ACME EU data plane
+                    type: mongodb
+                    gatewayUrl: https://gateway-eu.example.com
+                    database: gravitee-am-acme
+                    hosts:
+                    - mongo:27017
+                    organizationId: DEFAULT
+                    environmentId: DEFAULT
+                    createdAt: 2026-01-15T09:30:00.000Z
+                    updatedAt: 2026-01-15T09:30:00.000Z
+              schema:
+                $ref: "#/components/schemas/AutomationDataPlane"
+          description: The data plane
+        "403":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 403
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: Permission denied
+        "404":
+          content:
+            application/json:
+              examples:
+                error:
+                  value:
+                    http_status: 404
+                    message: A human-readable description of the error
+              schema:
+                $ref: "#/components/schemas/Error"
+          description: "Data plane not found in this environment, or not managed by\
+            \ the Automation API"
+      summary: Get a data plane
+      tags:
+      - Data Planes
   /organizations/{orgId}/environments/{envId}/domains:
     get:
       description: Returns all security domains within the specified environment.
@@ -63,7 +377,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -137,7 +451,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -239,7 +553,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -293,7 +607,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -373,7 +687,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -448,7 +762,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -562,7 +876,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -624,7 +938,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -710,7 +1024,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -795,7 +1109,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -930,7 +1244,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -993,7 +1307,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -1088,7 +1402,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -1163,7 +1477,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -1278,7 +1592,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -1340,7 +1654,7 @@ paths:
         required: true
         schema:
           type: string
-      - description: Identifier of the environment the domain belongs to.
+      - description: Identifier of the environment the resource belongs to.
         example: DEFAULT
         in: path
         name: envId
@@ -1702,6 +2016,85 @@ components:
           description: Whether open (unauthenticated) Dynamic Client Registration
             is enabled for the domain.
       title: Client registration settings
+    AutomationDataPlane:
+      type: object
+      description: "A data plane managed by the Automation API. Data planes store\
+        \ the runtime data of the domains bound to them. The id field is the stable,\
+        \ immutable identity used for idempotent create-or-update."
+      properties:
+        configuration:
+          type: object
+          description: "Connection settings. Write-only: it can hold credentials."
+          example:
+            mongodb:
+              dbname: gravitee-am-acme
+              host: mongo
+              port: 27017
+          writeOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          description: "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
+          readOnly: true
+        database:
+          type: string
+          description: Name of the database the configuration points at. Read-only.
+          example: gravitee-am-acme
+          readOnly: true
+        environmentId:
+          type: string
+          description: Identifier of the environment the data plane belongs to. Read-only.
+          example: DEFAULT
+          readOnly: true
+        gatewayUrl:
+          type: string
+          description: Base URL of the gateway serving the domains bound to this data
+            plane.
+          example: https://gateway-eu.example.com
+        hosts:
+          type: array
+          description: "Hosts the configuration points at, as host:port. Read-only."
+          example:
+          - mongo:27017
+          items:
+            type: string
+            description: "Hosts the configuration points at, as host:port. Read-only."
+            example: "[\"mongo:27017\"]"
+            readOnly: true
+          readOnly: true
+        id:
+          type: string
+          description: "Stable, immutable identifier for the data plane within its\
+            \ environment. Lowercase alphanumeric and hyphens, starting and ending\
+            \ with an alphanumeric character. This is the value a domain's dataPlaneId\
+            \ refers to."
+          example: acme-eu
+          maxLength: 255
+          minLength: 1
+        name:
+          type: string
+          description: Human-readable name of the data plane.
+          example: ACME EU data plane
+          maxLength: 255
+          minLength: 1
+        organizationId:
+          type: string
+          description: Identifier of the organization the data plane belongs to. Read-only.
+          example: DEFAULT
+          readOnly: true
+        type:
+          type: string
+          description: "Data plane plugin type identifier, matching the dataplane-am-<type>\
+            \ plugin. Immutable after creation."
+          example: mongodb
+        updatedAt:
+          type: string
+          format: date-time
+          description: "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only."
+          readOnly: true
+      required:
+      - id
+      title: Data plane
     AutomationDomain:
       type: object
       description: "A security domain managed by the Automation API. The key field\
@@ -1726,9 +2119,9 @@ components:
         dataPlaneId:
           type: string
           description: "Identifier of the data plane this domain is connected to.\
-            \ Optional at creation, resolved from the environment's data planes when\
-            \ omitted, and immutable afterwards; included in the desired-state document\
-            \ but never re-applied on update."
+            \ Optional at creation and resolved from the environment's data planes\
+            \ when omitted. Immutable afterwards: an apply that names a different\
+            \ one is rejected."
           example: default
           maxLength: 255
           minLength: 0

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -16549,6 +16549,7 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
+            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -16867,6 +16868,7 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
+            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17101,6 +17103,7 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
+            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17338,6 +17341,7 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
+            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17505,6 +17509,7 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
+            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -16549,7 +16549,6 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
-            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -16868,7 +16867,6 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
-            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17103,7 +17101,6 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
-            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17341,7 +17338,6 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
-            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM
@@ -17509,7 +17505,6 @@ components:
             - ORGANIZATION_MEMBER
             - ENVIRONMENT
             - DATA_PLANE
-            - DATA_PLANE_MANAGED
             - DOMAIN
             - DOMAIN_SETTINGS
             - DOMAIN_FORM

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/EventType.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/audit/EventType.java
@@ -301,6 +301,7 @@ public interface EventType {
      * ----------
      */
     String DATA_PLANE_CREATED = "DATA_PLANE_CREATED";
+    String DATA_PLANE_UPDATED = "DATA_PLANE_UPDATED";
     String DATA_PLANE_DELETED = "DATA_PLANE_DELETED";
 
     /**

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/AutomationApiApplication.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/AutomationApiApplication.java
@@ -17,6 +17,8 @@ package io.gravitee.am.management.handlers.automation;
 
 import io.gravitee.am.management.handlers.automation.resource.CertificateResource;
 import io.gravitee.am.management.handlers.automation.resource.CertificatesResource;
+import io.gravitee.am.management.handlers.automation.resource.DataPlaneResource;
+import io.gravitee.am.management.handlers.automation.resource.DataPlanesResource;
 import io.gravitee.am.management.handlers.automation.resource.DomainResource;
 import io.gravitee.am.management.handlers.automation.resource.DomainsResource;
 import io.gravitee.am.management.handlers.automation.resource.IdentityProviderResource;
@@ -53,6 +55,8 @@ public class AutomationApiApplication extends ResourceConfig {
         register(CertificateResource.class);
         register(ReportersResource.class);
         register(ReporterResource.class);
+        register(DataPlanesResource.class);
+        register(DataPlaneResource.class);
 
         register(ObjectMapperResolver.class);
         register(ManagementExceptionMapper.class);

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDataPlaneMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDataPlaneMapper.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.mapper;
+
+import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.NewDataPlaneDefinition;
+
+/**
+ * Maps between the {@link DataPlaneDefinitionSummary} the service layer returns and the
+ * {@link AutomationDataPlane} projection.
+ *
+ * @author GraviteeSource Team
+ */
+public final class AutomationDataPlaneMapper {
+
+    private AutomationDataPlaneMapper() {
+    }
+
+    public static AutomationDataPlane toAutomationDataPlane(DataPlaneDefinitionSummary summary) {
+        AutomationDataPlane out = new AutomationDataPlane();
+        out.setId(summary.id());
+        out.setName(summary.name());
+        out.setType(summary.type());
+        out.setGatewayUrl(summary.gatewayUrl());
+        out.setDatabase(summary.database());
+        out.setHosts(summary.hosts());
+        out.setOrganizationId(summary.organizationId());
+        out.setEnvironmentId(summary.environmentId());
+        out.setCreatedAt(summary.createdAt());
+        out.setUpdatedAt(summary.updatedAt());
+        return out;
+    }
+
+    public static NewDataPlaneDefinition toNewDataPlaneDefinition(AutomationDataPlane definition, String id,
+                                                                  String organizationId, String environmentId) {
+        NewDataPlaneDefinition out = new NewDataPlaneDefinition();
+        out.setId(id);
+        out.setName(definition.getName());
+        out.setType(definition.getType());
+        out.setGatewayUrl(definition.getGatewayUrl());
+        out.setConfiguration(definition.getConfiguration());
+        out.setOrganizationId(organizationId);
+        out.setEnvironmentId(environmentId);
+        return out;
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/mapper/AutomationDomainMapper.java
@@ -182,6 +182,10 @@ public final class AutomationDomainMapper {
      * id — is honoured) and its parallel {@code *Key} field.
      */
     public static void applyTo(AutomationDomain in, Domain target, List<IdentityProvider> idps) {
+        // omitted -> keep the plane the service resolved; named -> DomainService.update refuses a move
+        if (in.getDataPlaneId() != null && !in.getDataPlaneId().isBlank()) {
+            target.setDataPlaneId(in.getDataPlaneId());
+        }
         target.setName(in.getName());
         target.setDescription(in.getDescription());
         target.setEnabled(in.isEnabled());

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDataPlane.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDataPlane.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * The Automation API representation of a data plane.
+ *
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@Schema(name = "AutomationDataPlane", title = "Data plane",
+        description = "A data plane managed by the Automation API. Data planes store the runtime data of the " +
+                "domains bound to them. The id field is the stable, immutable identity used for idempotent " +
+                "create-or-update.")
+public class AutomationDataPlane {
+
+    @NotNull
+    @Size(min = 1, max = 255)
+    @Schema(description = "Stable, immutable identifier for the data plane within its environment. Lowercase " +
+            "alphanumeric and hyphens, starting and ending with an alphanumeric character. This is the value " +
+            "a domain's dataPlaneId refers to.",
+            example = "acme-eu")
+    private String id;
+
+    @Size(min = 1, max = 255)
+    @Schema(description = "Human-readable name of the data plane.", example = "ACME EU data plane")
+    private String name;
+
+    @Schema(description = "Data plane plugin type identifier, matching the dataplane-am-<type> plugin. " +
+            "Immutable after creation.",
+            example = "mongodb")
+    private String type;
+
+    @Schema(description = "Base URL of the gateway serving the domains bound to this data plane.",
+            example = "https://gateway-eu.example.com")
+    private String gatewayUrl;
+
+    @Schema(accessMode = Schema.AccessMode.WRITE_ONLY, type = "object", implementation = Object.class,
+            description = "Connection settings. Write-only: it can hold credentials.",
+            example = "{\"mongodb\":{\"dbname\":\"gravitee-am-acme\",\"host\":\"mongo\",\"port\":27017}}")
+    private JsonNode configuration;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
+            description = "Name of the database the configuration points at. Read-only.", example = "gravitee-am-acme")
+    private String database;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
+            description = "Hosts the configuration points at, as host:port. Read-only.", example = "[\"mongo:27017\"]")
+    private List<String> hosts;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
+            description = "Identifier of the organization the data plane belongs to. Read-only.", example = "DEFAULT")
+    private String organizationId;
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
+            description = "Identifier of the environment the data plane belongs to. Read-only.", example = "DEFAULT")
+    private String environmentId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Creation timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
+    private Date createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "Last-update timestamp (ISO-8601 / RFC 3339, UTC). Read-only.")
+    private Date updatedAt;
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/model/AutomationDomain.java
@@ -113,15 +113,10 @@ public class AutomationDomain {
     @Schema(description = "Virtual hosts the domain is exposed on, overriding the default context path.")
     private List<VirtualHost> vhosts;
 
-    /**
-     * Immutable after creation. Optional on create: when omitted the data plane is resolved from the
-     * ones linked to the environment, the same way the Management API does it. It is part of the full
-     * desired-state document but is never re-applied on update.
-     */
     @Size(max = 255)
-    @Schema(description = "Identifier of the data plane this domain is connected to. Optional at creation, " +
-            "resolved from the environment's data planes when omitted, and immutable afterwards; included in the " +
-            "desired-state document but never re-applied on update.",
+    @Schema(description = "Identifier of the data plane this domain is connected to. Optional at creation and " +
+            "resolved from the environment's data planes when omitted. Immutable afterwards: an apply that names " +
+            "a different one is rejected.",
             example = "default")
     private String dataPlaneId;
 

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AutomationResourceResolver.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/AutomationResourceResolver.java
@@ -23,10 +23,13 @@ import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Reporter;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.CertificateNotFoundException;
+import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
 import io.gravitee.am.service.exception.DomainNotFoundException;
 import io.gravitee.am.service.exception.IdentityProviderNotFoundException;
 import io.gravitee.am.service.exception.ReporterNotFoundException;
@@ -44,15 +47,18 @@ public class AutomationResourceResolver {
     private final IdentityProviderService identityProviderService;
     private final CertificateService certificateService;
     private final ReporterService reporterService;
+    private final DataPlaneDefinitionService dataPlaneDefinitionService;
 
     public AutomationResourceResolver(DomainService domainService,
             IdentityProviderService identityProviderService,
             CertificateService certificateService,
-            ReporterService reporterService) {
+            ReporterService reporterService,
+            DataPlaneDefinitionService dataPlaneDefinitionService) {
         this.domainService = domainService;
         this.identityProviderService = identityProviderService;
         this.certificateService = certificateService;
         this.reporterService = reporterService;
+        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
     }
 
     // --- domains ------------------------------------------------------------
@@ -69,6 +75,24 @@ public class AutomationResourceResolver {
             case AutomationRef.KeyRef(String key) -> domainService.findById(AutomationIds.domainId(environmentId, key))
                     .filter(domain -> domain.isManagedBy(ManagedBy.AUTOMATION_API));
         };
+    }
+
+    // --- data planes --------------------------------------------------------
+
+    public Single<DataPlaneDefinitionSummary> resolveDataPlane(String environmentId, AutomationRef ref) {
+        return resolveDataPlaneMaybe(environmentId, ref)
+                .switchIfEmpty(Maybe.error(() -> new DataPlaneDefinitionNotFoundException(ref.raw())))
+                .toSingle();
+    }
+
+    public Maybe<DataPlaneDefinitionSummary> resolveDataPlaneMaybe(String environmentId, AutomationRef ref) {
+        return dataPlaneDefinitionService.findByEnvironmentId(environmentId)
+                .filter(dataPlane -> switch (ref) {
+                    case AutomationRef.IdRef(String id) -> id.equals(dataPlane.id());
+                    case AutomationRef.KeyRef(String key) -> key.equals(dataPlane.id())
+                            && ManagedBy.AUTOMATION_API == dataPlane.managedBy();
+                })
+                .firstElement();
     }
 
     // --- identity providers -------------------------------------------------

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.mapper.AutomationDataPlaneMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
+import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.reactivex.rxjava3.core.Completable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * A single data plane, addressed by the id it was provisioned under.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Data Planes")
+public class DataPlaneResource extends AbstractAutomationResource {
+
+    @Autowired
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Autowired
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @Autowired
+    private DataPlaneRegistry dataPlaneRegistry;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationGetDataPlane", summary = "Get a data plane",
+            description = "Retrieves a single Automation-managed data plane by its id.")
+    @ApiResponse(responseCode = "200", description = "The data plane",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationDataPlane.class),
+                    examples = @ExampleObject(name = "DataPlane", value = DataPlanesResource.READ_EXAMPLE)))
+    @ApiResponse(responseCode = "404", description = "Data plane not found in this environment, or not managed " +
+            "by the Automation API")
+    public void get(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("dataPlaneId") String dataPlaneId,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE, Acl.READ)
+                .andThen(resolver.resolveDataPlane(environmentId, AutomationRef.parse(dataPlaneId)))
+                .map(AutomationDataPlaneMapper::toAutomationDataPlane)
+                .subscribe(response::resume, response::resume);
+    }
+
+    @DELETE
+    @Operation(operationId = "automationDeleteDataPlane", summary = "Delete a data plane",
+            description = "Deletes an Automation-managed data plane by its id. Deleting a data plane that " +
+                    "does not exist also returns 204.")
+    @ApiResponse(responseCode = "204", description = "Data plane successfully deleted")
+    @ApiResponse(responseCode = "409", description = "At least one domain still references the data plane")
+    public void delete(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @PathParam("dataPlaneId") String dataPlaneId,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE_MANAGED, Acl.DELETE)
+                .andThen(resolver.resolveDataPlaneMaybe(environmentId, AutomationRef.parse(dataPlaneId)))
+                .flatMapCompletable(dataPlane -> dataPlaneDefinitionService.delete(dataPlane.id(), principal)
+                        .andThen(Completable.fromAction(() -> {
+                            dataPlaneRegistry.unregister(dataPlane.id());
+                            provisionedDataPlaneLoader.forget(dataPlane.id());
+                        })))
+                .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
@@ -19,10 +19,7 @@ import io.gravitee.am.management.handlers.automation.mapper.AutomationDataPlaneM
 import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
 import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.permissions.Permission;
-import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
-import io.gravitee.am.service.DataPlaneDefinitionService;
-import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
-import io.reactivex.rxjava3.core.Completable;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -48,13 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DataPlaneResource extends AbstractAutomationResource {
 
     @Autowired
-    private DataPlaneDefinitionService dataPlaneDefinitionService;
-
-    @Autowired
-    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
-
-    @Autowired
-    private DataPlaneRegistry dataPlaneRegistry;
+    private DataPlaneProvisioningService dataPlaneProvisioningService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -94,11 +85,7 @@ public class DataPlaneResource extends AbstractAutomationResource {
         final var principal = getAuthenticatedUser();
         checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE, Acl.DELETE)
                 .andThen(resolver.resolveDataPlaneMaybe(environmentId, AutomationRef.parse(dataPlaneId)))
-                .flatMapCompletable(dataPlane -> dataPlaneDefinitionService.delete(dataPlane.id(), principal)
-                        .andThen(Completable.fromAction(() -> {
-                            dataPlaneRegistry.unregister(dataPlane.id());
-                            provisionedDataPlaneLoader.forget(dataPlane.id());
-                        })))
+                .flatMapCompletable(dataPlane -> dataPlaneProvisioningService.deprovision(dataPlane.id(), principal))
                 .subscribe(() -> response.resume(Response.noContent().build()), response::resume);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResource.java
@@ -92,7 +92,7 @@ public class DataPlaneResource extends AbstractAutomationResource {
             @Suspended final AsyncResponse response) {
 
         final var principal = getAuthenticatedUser();
-        checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE_MANAGED, Acl.DELETE)
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE, Acl.DELETE)
                 .andThen(resolver.resolveDataPlaneMaybe(environmentId, AutomationRef.parse(dataPlaneId)))
                 .flatMapCompletable(dataPlane -> dataPlaneDefinitionService.delete(dataPlane.id(), principal)
                         .andThen(Completable.fromAction(() -> {

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.management.handlers.automation.mapper.AutomationDataPlaneMapper;
+import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
+import io.gravitee.am.model.Acl;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.model.permissions.Permission;
+import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.reactivex.rxjava3.core.Single;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Data planes managed under an environment.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Data Planes")
+public class DataPlanesResource extends AbstractAutomationResource {
+
+    static final String READ_EXAMPLE =
+            "{\"id\":\"acme-eu\",\"name\":\"ACME EU data plane\",\"type\":\"mongodb\",\"gatewayUrl\":\"https://gateway-eu.example.com\","
+                    + "\"database\":\"gravitee-am-acme\",\"hosts\":[\"mongo:27017\"],\"organizationId\":\"DEFAULT\","
+                    + "\"environmentId\":\"DEFAULT\",\"createdAt\":\"2026-01-15T09:30:00.000Z\",\"updatedAt\":\"2026-01-15T09:30:00.000Z\"}";
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Autowired
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Autowired
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationListDataPlanes", summary = "List an environment's data planes",
+            description = "Returns all data planes managed by the Automation API in the environment. Data " +
+                    "planes provisioned outside the Automation API are not returned.")
+    @ApiResponse(responseCode = "200", description = "List of data planes",
+            content = @Content(mediaType = "application/json",
+                    array = @ArraySchema(schema = @Schema(implementation = AutomationDataPlane.class)),
+                    examples = @ExampleObject(name = "DataPlaneList", value = "[" + READ_EXAMPLE + "]")))
+    public void list(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE, Acl.LIST)
+                .andThen(dataPlaneDefinitionService.findByEnvironmentId(environmentId)
+                        .filter(dataPlane -> ManagedBy.AUTOMATION_API == dataPlane.managedBy())
+                        .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(nullToEmpty(o1.id()), nullToEmpty(o2.id())))
+                        .map(AutomationDataPlaneMapper::toAutomationDataPlane)
+                        .toList())
+                .subscribe(response::resume, response::resume);
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "automationCreateOrUpdateDataPlane",
+            summary = "Create or update a data plane",
+            description = "Idempotent create-or-update. Uses the id field in the body to identify the data " +
+                    "plane within the environment. The type is immutable, and the organization and " +
+                    "environment come from the path. An id: reference updates a data plane the Automation " +
+                    "API does not manage, and cannot create one.")
+    @ApiResponse(responseCode = "200", description = "The created or updated data plane",
+            content = @Content(mediaType = "application/json",
+                    schema = @Schema(implementation = AutomationDataPlane.class),
+                    examples = @ExampleObject(name = "DataPlane", value = READ_EXAMPLE)))
+    @ApiResponse(responseCode = "400", description = "Invalid request: a missing required field, an unknown " +
+            "data plane type, a configuration the type's plugin rejects, an id reserved by the node's " +
+            "gravitee.yml, or an attempt to change an immutable field")
+    @ApiResponse(responseCode = "404", description = "An id: reference naming a data plane that does not exist " +
+            "in this environment")
+    @ApiResponse(responseCode = "409", description = "The id is already taken by a data plane the Automation " +
+            "API does not manage")
+    public void createOrUpdate(
+            @PathParam("orgId") String organizationId,
+            @PathParam("envId") String environmentId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Desired state of the data plane.",
+                    required = true,
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AutomationDataPlane.class),
+                            examples = {
+                                    @ExampleObject(name = "DataPlane", description = "A MongoDB data plane",
+                                            value = "{\"id\":\"acme-eu\",\"name\":\"ACME EU data plane\"," +
+                                                    "\"type\":\"mongodb\",\"gatewayUrl\":\"https://gateway-eu.example.com\"," +
+                                                    "\"configuration\":{\"mongodb\":{\"dbname\":\"gravitee-am-acme\"," +
+                                                    "\"host\":\"mongo\",\"port\":27017}}}")
+                            }))
+            @Valid @NotNull AutomationDataPlane definition,
+            @Suspended final AsyncResponse response) {
+
+        final var principal = getAuthenticatedUser();
+        final AutomationRef ref = AutomationRef.parse(definition.getId());
+
+        // The ACL is chosen from a non-erroring lookup so the permission gate runs before any
+        // existence is revealed (404 for an unknown id: reference, 409 for a taken id).
+        resolver.resolveDataPlaneMaybe(environmentId, ref)
+                .map(Optional::of)
+                .defaultIfEmpty(Optional.empty())
+                .flatMap(match -> {
+                    Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
+                    return checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE_MANAGED, requiredAcl)
+                            .andThen(Single.defer(() -> match
+                                    .map(existing -> updateExisting(existing, definition, organizationId, environmentId, principal))
+                                    .orElseGet(() -> createNew(ref, definition, organizationId, environmentId, principal))));
+                })
+                // this node registers the change itself; the others pick it up from the sync event
+                .flatMap(dataPlane -> provisionedDataPlaneLoader.reload(dataPlane.getId()).toSingleDefault(dataPlane))
+                .subscribe(response::resume, response::resume);
+    }
+
+    private Single<AutomationDataPlane> updateExisting(DataPlaneDefinitionSummary existing, AutomationDataPlane definition,
+            String organizationId, String environmentId, User principal) {
+        return dataPlaneDefinitionService.update(existing.id(),
+                        AutomationDataPlaneMapper.toNewDataPlaneDefinition(definition, existing.id(), organizationId, environmentId),
+                        principal)
+                .map(AutomationDataPlaneMapper::toAutomationDataPlane);
+    }
+
+    private Single<AutomationDataPlane> createNew(AutomationRef ref, AutomationDataPlane definition,
+            String organizationId, String environmentId, User principal) {
+        if (ref.isId()) {
+            return Single.error(new DataPlaneDefinitionNotFoundException(ref.raw()));
+        }
+        return dataPlaneDefinitionService.create(
+                        AutomationDataPlaneMapper.toNewDataPlaneDefinition(definition, ref.raw(), organizationId, environmentId),
+                        ManagedBy.AUTOMATION_API, principal)
+                .map(AutomationDataPlaneMapper::toAutomationDataPlane);
+    }
+
+    @Path("/{dataPlaneId}")
+    public DataPlaneResource getDataPlaneResource() {
+        return resourceContext.getResource(DataPlaneResource.class);
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
@@ -144,7 +144,7 @@ public class DataPlanesResource extends AbstractAutomationResource {
                 .defaultIfEmpty(Optional.empty())
                 .flatMap(match -> {
                     Acl requiredAcl = match.isPresent() ? Acl.UPDATE : Acl.CREATE;
-                    return checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE_MANAGED, requiredAcl)
+                    return checkAnyPermission(principal, organizationId, environmentId, Permission.DATA_PLANE, requiredAcl)
                             .andThen(Single.defer(() -> match
                                     .map(existing -> updateExisting(existing, definition, organizationId, environmentId, principal))
                                     .orElseGet(() -> createNew(ref, definition, organizationId, environmentId, principal))));

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResource.java
@@ -22,7 +22,7 @@ import io.gravitee.am.model.Acl;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.permissions.Permission;
 import io.gravitee.am.service.DataPlaneDefinitionService;
-import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.reactivex.rxjava3.core.Single;
@@ -70,7 +70,7 @@ public class DataPlanesResource extends AbstractAutomationResource {
     private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     @Autowired
-    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+    private DataPlaneProvisioningService dataPlaneProvisioningService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -149,14 +149,12 @@ public class DataPlanesResource extends AbstractAutomationResource {
                                     .map(existing -> updateExisting(existing, definition, organizationId, environmentId, principal))
                                     .orElseGet(() -> createNew(ref, definition, organizationId, environmentId, principal))));
                 })
-                // this node registers the change itself; the others pick it up from the sync event
-                .flatMap(dataPlane -> provisionedDataPlaneLoader.reload(dataPlane.getId()).toSingleDefault(dataPlane))
                 .subscribe(response::resume, response::resume);
     }
 
     private Single<AutomationDataPlane> updateExisting(DataPlaneDefinitionSummary existing, AutomationDataPlane definition,
             String organizationId, String environmentId, User principal) {
-        return dataPlaneDefinitionService.update(existing.id(),
+        return dataPlaneProvisioningService.reprovision(existing.id(),
                         AutomationDataPlaneMapper.toNewDataPlaneDefinition(definition, existing.id(), organizationId, environmentId),
                         principal)
                 .map(AutomationDataPlaneMapper::toAutomationDataPlane);
@@ -167,7 +165,7 @@ public class DataPlanesResource extends AbstractAutomationResource {
         if (ref.isId()) {
             return Single.error(new DataPlaneDefinitionNotFoundException(ref.raw()));
         }
-        return dataPlaneDefinitionService.create(
+        return dataPlaneProvisioningService.provision(
                         AutomationDataPlaneMapper.toNewDataPlaneDefinition(definition, ref.raw(), organizationId, environmentId),
                         ManagedBy.AUTOMATION_API, principal)
                 .map(AutomationDataPlaneMapper::toAutomationDataPlane);

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/resource/OrganizationResource.java
@@ -35,4 +35,9 @@ public class OrganizationResource {
     public DomainsResource getDomainsResource() {
         return resourceContext.getResource(DomainsResource.class);
     }
+
+    @Path("/environments/{envId}/dataplanes")
+    public DataPlanesResource getDataPlanesResource() {
+        return resourceContext.getResource(DataPlanesResource.class);
+    }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/AutomationConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/spring/AutomationConfiguration.java
@@ -19,6 +19,7 @@ import io.gravitee.am.management.handlers.automation.resource.AutomationResource
 import io.gravitee.am.management.handlers.automation.spring.security.AutomationSecurityConfiguration;
 import io.gravitee.am.management.service.DomainService;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.ReporterService;
 import org.springframework.context.annotation.Bean;
@@ -48,7 +49,9 @@ public class AutomationConfiguration {
     public AutomationResourceResolver automationResourceResolver(DomainService domainService,
             IdentityProviderService identityProviderService,
             CertificateService certificateService,
-            ReporterService reporterService) {
-        return new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService);
+            ReporterService reporterService,
+            DataPlaneDefinitionService dataPlaneDefinitionService) {
+        return new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService,
+                dataPlaneDefinitionService);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/main/java/io/gravitee/am/management/handlers/automation/swagger/AutomationApiDefinition.java
@@ -72,7 +72,7 @@ public class AutomationApiDefinition implements ReaderListener {
      */
     public static final String DEFAULT_AUTOMATION_ENTRYPOINT = "/automation";
 
-    private static final Set<String> AUTOMATION_TAGS = Set.of("Domains", "Identity Providers", "Certificates", "Reporters");
+    private static final Set<String> AUTOMATION_TAGS = Set.of("Domains", "Identity Providers", "Certificates", "Reporters", "Data Planes");
 
     private static final String ERROR_SCHEMA = "Error";
 
@@ -84,7 +84,8 @@ public class AutomationApiDefinition implements ReaderListener {
                     "configuration. Create, read, update, and delete domains, and reach their sub-resources.",
             "Identity Providers", "Identity providers configured under a domain to authenticate users.",
             "Certificates", "Certificates configured under a domain to sign and verify tokens.",
-            "Reporters", "Reporters configured under a domain to persist audit events to a backend.");
+            "Reporters", "Reporters configured under a domain to persist audit events to a backend.",
+            "Data Planes", "Data planes configured under an environment to store the runtime data of its domains.");
 
     /**
      * Descriptions and examples for the shared path parameters, keyed by parameter name. Injected onto every
@@ -92,12 +93,13 @@ public class AutomationApiDefinition implements ReaderListener {
      */
     private static final Map<String, String[]> PATH_PARAM_DOCS = Map.of(
             "orgId", new String[]{"Identifier of the organization that owns the environment.", "DEFAULT"},
-            "envId", new String[]{"Identifier of the environment the domain belongs to.", "DEFAULT"},
+            "envId", new String[]{"Identifier of the environment the resource belongs to.", "DEFAULT"},
             "domainKey", new String[]{"Key of the domain: its stable, immutable Automation identifier within the " +
                     "environment.", "example-domain"},
             "certKey", new String[]{"Key of the certificate within the domain.", "signing-cert"},
             "identityKey", new String[]{"Key of the identity within the domain.", "corporate-ldap"},
-            "reporterKey", new String[]{"Key of the reporter within the domain.", "audit-kafka"});
+            "reporterKey", new String[]{"Key of the reporter within the domain.", "audit-kafka"},
+            "dataPlaneId", new String[]{"Id of the data plane within the environment.", "acme-eu"});
 
     @Override
     public void beforeScan(OpenApiReader openApiReader, OpenAPI openAPI) {

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -38,6 +38,7 @@ import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.idp.SystemClusterIdpPolicy;
 import io.reactivex.rxjava3.core.Completable;
@@ -141,10 +142,10 @@ public abstract class AutomationJerseySpringTest {
         // (e.g. "delete was never called") scoped to the test at hand.
         clearInvocations(permissionService, domainService, certificateService, identityProviderService,
                 defaultIdentityProviderService, reporterService, dataPlaneRegistry);
-        // Fully reset: data plane tests stub findByEnvironmentId per case. Every write path calls the
-        // loader's reload, so it is re-stubbed here.
+        // Fully reset: data plane tests stub findByEnvironmentId per case. Every write path activates
+        // the data plane on the loader, so that is re-stubbed here.
         reset(dataPlaneDefinitionService, provisionedDataPlaneLoader);
-        when(provisionedDataPlaneLoader.reload(anyString())).thenReturn(Completable.complete());
+        when(provisionedDataPlaneLoader.activate(anyString())).thenReturn(Completable.complete());
         reset(trustDomainService);
         when(trustDomainService.findByReference(any(), any())).thenReturn(Flowable.empty());
         // Fully reset the validation mocks (not just their invocations): tests add throwing/erroring stubs
@@ -244,6 +245,12 @@ public abstract class AutomationJerseySpringTest {
         @Bean
         public DataPlaneRegistry dataPlaneRegistry() {
             return mock(DataPlaneRegistry.class);
+        }
+
+        @Bean
+        public DataPlaneProvisioningService dataPlaneProvisioningService(DataPlaneDefinitionService dataPlaneDefinitionService,
+                ProvisionedDataPlaneLoader provisionedDataPlaneLoader) {
+            return new DataPlaneProvisioningService(dataPlaneDefinitionService, provisionedDataPlaneLoader);
         }
 
         @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/AutomationJerseySpringTest.java
@@ -32,10 +32,13 @@ import io.gravitee.am.management.service.PermissionService;
 import io.gravitee.am.management.service.ReporterPluginService;
 import io.gravitee.am.management.service.permissions.PermissionAcls;
 import io.gravitee.am.model.Organization;
+import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.PluginConfigurationValidationService;
 import io.gravitee.am.service.ReporterService;
+import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.idp.SystemClusterIdpPolicy;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -122,13 +125,26 @@ public abstract class AutomationJerseySpringTest {
     @Autowired
     protected TrustDomainService trustDomainService;
 
+    @Autowired
+    protected DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Autowired
+    protected ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    @Autowired
+    protected DataPlaneRegistry dataPlaneRegistry;
+
     @BeforeEach
     public void init() {
         // The service mocks are Spring singletons shared across the cached context, so clear any
         // invocations recorded by a previous test before each one runs — this keeps verify(...) checks
         // (e.g. "delete was never called") scoped to the test at hand.
         clearInvocations(permissionService, domainService, certificateService, identityProviderService,
-                defaultIdentityProviderService, reporterService);
+                defaultIdentityProviderService, reporterService, dataPlaneRegistry);
+        // Fully reset: data plane tests stub findByEnvironmentId per case. Every write path calls the
+        // loader's reload, so it is re-stubbed here.
+        reset(dataPlaneDefinitionService, provisionedDataPlaneLoader);
+        when(provisionedDataPlaneLoader.reload(anyString())).thenReturn(Completable.complete());
         reset(trustDomainService);
         when(trustDomainService.findByReference(any(), any())).thenReturn(Flowable.empty());
         // Fully reset the validation mocks (not just their invocations): tests add throwing/erroring stubs
@@ -216,11 +232,28 @@ public abstract class AutomationJerseySpringTest {
         }
 
         @Bean
+        public DataPlaneDefinitionService dataPlaneDefinitionService() {
+            return mock(DataPlaneDefinitionService.class);
+        }
+
+        @Bean
+        public ProvisionedDataPlaneLoader provisionedDataPlaneLoader() {
+            return mock(ProvisionedDataPlaneLoader.class);
+        }
+
+        @Bean
+        public DataPlaneRegistry dataPlaneRegistry() {
+            return mock(DataPlaneRegistry.class);
+        }
+
+        @Bean
         public AutomationResourceResolver automationResourceResolver(DomainService domainService,
                 IdentityProviderService identityProviderService,
                 CertificateService certificateService,
-                ReporterService reporterService) {
-            return new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService);
+                ReporterService reporterService,
+                DataPlaneDefinitionService dataPlaneDefinitionService) {
+            return new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService,
+                    dataPlaneDefinitionService);
         }
     }
 
@@ -244,6 +277,11 @@ public abstract class AutomationJerseySpringTest {
     /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/certificates}. */
     protected final WebTarget certificatesTarget(String domainKey) {
         return domainsTarget().path(domainKey).path("certificates");
+    }
+
+    /** {@code /organizations/{orgId}/environments/{envId}/dataplanes}. */
+    protected final WebTarget dataPlanesTarget() {
+        return orgTarget().path("environments").path(ENV_ID).path("dataplanes");
     }
 
     /** {@code /organizations/{orgId}/environments/{envId}/domains/{domainKey}/reporters}. */

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/AutomationResourceResolverTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/AutomationResourceResolverTest.java
@@ -24,6 +24,7 @@ import io.gravitee.am.model.Reference;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.Reporter;
 import io.gravitee.am.service.CertificateService;
+import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.IdentityProviderService;
 import io.gravitee.am.service.ReporterService;
 import io.gravitee.am.service.exception.CertificateNotFoundException;
@@ -56,6 +57,7 @@ class AutomationResourceResolverTest {
     private IdentityProviderService identityProviderService;
     private CertificateService certificateService;
     private ReporterService reporterService;
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
     private AutomationResourceResolver resolver;
 
     private Domain domain() {
@@ -70,7 +72,9 @@ class AutomationResourceResolverTest {
         identityProviderService = mock(IdentityProviderService.class);
         certificateService = mock(CertificateService.class);
         reporterService = mock(ReporterService.class);
-        resolver = new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService);
+        dataPlaneDefinitionService = mock(DataPlaneDefinitionService.class);
+        resolver = new AutomationResourceResolver(domainService, identityProviderService, certificateService, reporterService,
+                dataPlaneDefinitionService);
     }
 
     // --- domains (scoped by environment) ------------------------------------

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResourceTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.service.exception.DataPlaneInUseByDomainsException;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DataPlaneResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DATA_PLANE_ID = "acme-eu";
+
+    private DataPlaneDefinitionSummary summary(String id, ManagedBy managedBy) {
+        return new DataPlaneDefinitionSummary(id, "Data plane " + id, "mongodb", "https://gw.example.com",
+                ORG_ID, ENV_ID, "gravitee-am-" + id, List.of("mongo:27017"), managedBy, new Date(), new Date());
+    }
+
+    private void givenEnvironmentHolds(DataPlaneDefinitionSummary... summaries) {
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENV_ID)).thenReturn(Flowable.fromArray(summaries));
+    }
+
+    private Response getRequest(String reference) {
+        return dataPlanesTarget().path(reference).request().get();
+    }
+
+    private Response deleteRequest(String reference) {
+        return dataPlanesTarget().path(reference).request().delete();
+    }
+
+    @Test
+    void get_returns_a_data_plane_the_automation_api_manages() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+
+        Response response = getRequest(DATA_PLANE_ID);
+
+        assertEquals(200, response.getStatus());
+        AutomationDataPlane body = readEntity(response, AutomationDataPlane.class);
+        assertEquals(DATA_PLANE_ID, body.getId());
+        assertEquals("gravitee-am-" + DATA_PLANE_ID, body.getDatabase());
+        assertNull(body.getConfiguration());
+    }
+
+    @Test
+    void get_returns_404_when_the_data_plane_is_absent() {
+        givenEnvironmentHolds();
+
+        assertEquals(404, getRequest(DATA_PLANE_ID).getStatus());
+    }
+
+    @Test
+    void get_returns_404_when_the_data_plane_is_not_automation_managed() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.NONE));
+
+        assertEquals(404, getRequest(DATA_PLANE_ID).getStatus());
+    }
+
+    @Test
+    void get_reaches_a_data_plane_it_does_not_manage_by_id_reference() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.NONE));
+
+        Response response = getRequest("id:" + DATA_PLANE_ID);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(DATA_PLANE_ID, readEntity(response, AutomationDataPlane.class).getId());
+    }
+
+    @Test
+    void get_returns_403_when_the_permission_is_denied() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        denyPermission();
+
+        assertEquals(403, getRequest(DATA_PLANE_ID).getStatus());
+    }
+
+    @Test
+    void delete_removes_the_data_plane_and_stops_serving_it() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        when(dataPlaneDefinitionService.delete(anyString(), any())).thenReturn(Completable.complete());
+
+        Response response = deleteRequest(DATA_PLANE_ID);
+
+        assertEquals(204, response.getStatus());
+        verify(dataPlaneDefinitionService).delete(eq(DATA_PLANE_ID), any());
+        verify(dataPlaneRegistry).unregister(DATA_PLANE_ID);
+        verify(provisionedDataPlaneLoader).forget(DATA_PLANE_ID);
+    }
+
+    @Test
+    void delete_returns_204_when_the_data_plane_is_absent() {
+        givenEnvironmentHolds();
+
+        assertEquals(204, deleteRequest(DATA_PLANE_ID).getStatus());
+        verify(dataPlaneDefinitionService, never()).delete(anyString(), any());
+    }
+
+    @Test
+    void delete_returns_204_when_the_data_plane_is_not_automation_managed() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.NONE));
+
+        assertEquals(204, deleteRequest(DATA_PLANE_ID).getStatus());
+        verify(dataPlaneDefinitionService, never()).delete(anyString(), any());
+    }
+
+    @Test
+    void delete_returns_409_and_keeps_serving_it_while_a_domain_references_it() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        when(dataPlaneDefinitionService.delete(anyString(), any()))
+                .thenReturn(Completable.error(new DataPlaneInUseByDomainsException(DATA_PLANE_ID)));
+
+        Response response = deleteRequest(DATA_PLANE_ID);
+
+        assertEquals(409, response.getStatus());
+        verify(dataPlaneRegistry, never()).unregister(anyString());
+        verify(provisionedDataPlaneLoader, never()).forget(anyString());
+    }
+
+    @Test
+    void delete_returns_403_before_anything_is_removed() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        denyPermission();
+
+        Response response = deleteRequest(DATA_PLANE_ID);
+
+        assertEquals(403, response.getStatus());
+        verify(dataPlaneDefinitionService, never()).delete(anyString(), any());
+        verify(dataPlaneRegistry, never()).unregister(anyString());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlaneResourceTest.java
@@ -116,8 +116,7 @@ class DataPlaneResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(204, response.getStatus());
         verify(dataPlaneDefinitionService).delete(eq(DATA_PLANE_ID), any());
-        verify(dataPlaneRegistry).unregister(DATA_PLANE_ID);
-        verify(provisionedDataPlaneLoader).forget(DATA_PLANE_ID);
+        verify(provisionedDataPlaneLoader).deactivate(DATA_PLANE_ID);
     }
 
     @Test
@@ -145,8 +144,7 @@ class DataPlaneResourceTest extends AutomationJerseySpringTest {
         Response response = deleteRequest(DATA_PLANE_ID);
 
         assertEquals(409, response.getStatus());
-        verify(dataPlaneRegistry, never()).unregister(anyString());
-        verify(provisionedDataPlaneLoader, never()).forget(anyString());
+        verify(provisionedDataPlaneLoader, never()).deactivate(anyString());
     }
 
     @Test
@@ -158,6 +156,6 @@ class DataPlaneResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(403, response.getStatus());
         verify(dataPlaneDefinitionService, never()).delete(anyString(), any());
-        verify(dataPlaneRegistry, never()).unregister(anyString());
+        verify(provisionedDataPlaneLoader, never()).deactivate(anyString());
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResourceTest.java
@@ -135,7 +135,7 @@ class DataPlanesResourceTest extends AutomationJerseySpringTest {
 
         put(dataPlanesTarget(), definition(DATA_PLANE_ID));
 
-        verify(provisionedDataPlaneLoader).reload(DATA_PLANE_ID);
+        verify(provisionedDataPlaneLoader).activate(DATA_PLANE_ID);
     }
 
     @Test
@@ -217,7 +217,7 @@ class DataPlanesResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(403, response.getStatus());
         verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
-        verify(provisionedDataPlaneLoader, never()).reload(anyString());
+        verify(provisionedDataPlaneLoader, never()).activate(anyString());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DataPlanesResourceTest.java
@@ -1,0 +1,233 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.management.handlers.automation.resource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.am.management.handlers.automation.AutomationJerseySpringTest;
+import io.gravitee.am.management.handlers.automation.model.AutomationDataPlane;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.service.exception.DataPlaneDefinitionAlreadyExistsException;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.NewDataPlaneDefinition;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+class DataPlanesResourceTest extends AutomationJerseySpringTest {
+
+    private static final String DATA_PLANE_ID = "acme-eu";
+    private static final String SECRET = "sup3r-s3cret";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private DataPlaneDefinitionSummary summary(String id, ManagedBy managedBy) {
+        return new DataPlaneDefinitionSummary(id, "Data plane " + id, "mongodb", "https://gw.example.com",
+                ORG_ID, ENV_ID, "gravitee-am-" + id, List.of("mongo:27017"), managedBy, new Date(), new Date());
+    }
+
+    private AutomationDataPlane definition(String id) {
+        AutomationDataPlane definition = new AutomationDataPlane();
+        definition.setId(id);
+        definition.setName("Data plane " + id);
+        definition.setType("mongodb");
+        definition.setGatewayUrl("https://gw.example.com");
+        definition.setConfiguration(readTree("{\"mongodb\":{\"dbname\":\"gravitee-am-acme\",\"host\":\"mongo\","
+                + "\"port\":27017,\"username\":\"am-user\",\"password\":\"" + SECRET + "\"}}"));
+        return definition;
+    }
+
+    private com.fasterxml.jackson.databind.JsonNode readTree(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private void givenEnvironmentHolds(DataPlaneDefinitionSummary... summaries) {
+        when(dataPlaneDefinitionService.findByEnvironmentId(ENV_ID)).thenReturn(Flowable.fromArray(summaries));
+    }
+
+    @Test
+    void list_returns_only_the_data_planes_the_automation_api_manages() {
+        givenEnvironmentHolds(summary("acme-eu", ManagedBy.AUTOMATION_API),
+                summary("legacy", ManagedBy.NONE),
+                summary("acme-us", ManagedBy.AUTOMATION_API));
+
+        Response response = dataPlanesTarget().request().get();
+
+        assertEquals(200, response.getStatus());
+        List<AutomationDataPlane> body = readListEntity(response, AutomationDataPlane.class);
+        assertEquals(List.of("acme-eu", "acme-us"), body.stream().map(AutomationDataPlane::getId).toList());
+    }
+
+    @Test
+    void list_never_returns_the_connection_settings() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+
+        String body = readEntity(dataPlanesTarget().request().get(), String.class);
+
+        assertFalse(body.contains("configuration"), body);
+        assertFalse(body.contains(SECRET), body);
+    }
+
+    @Test
+    void list_returns_403_when_the_permission_is_denied() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        denyPermission();
+
+        assertEquals(403, dataPlanesTarget().request().get().getStatus());
+    }
+
+    @Test
+    void put_creates_a_data_plane_the_automation_api_owns() {
+        givenEnvironmentHolds();
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
+                .thenReturn(Single.just(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        assertEquals(200, response.getStatus());
+        ArgumentCaptor<NewDataPlaneDefinition> captor = ArgumentCaptor.forClass(NewDataPlaneDefinition.class);
+        verify(dataPlaneDefinitionService).create(captor.capture(), eq(ManagedBy.AUTOMATION_API), any());
+        assertEquals(DATA_PLANE_ID, captor.getValue().getId());
+        assertEquals(ORG_ID, captor.getValue().getOrganizationId());
+        assertEquals(ENV_ID, captor.getValue().getEnvironmentId());
+    }
+
+    @Test
+    void put_registers_the_new_data_plane_on_this_node() {
+        givenEnvironmentHolds();
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
+                .thenReturn(Single.just(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API)));
+
+        put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        verify(provisionedDataPlaneLoader).reload(DATA_PLANE_ID);
+    }
+
+    @Test
+    void put_never_returns_the_connection_settings() {
+        givenEnvironmentHolds();
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
+                .thenReturn(Single.just(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API)));
+
+        String body = readEntity(put(dataPlanesTarget(), definition(DATA_PLANE_ID)), String.class);
+
+        assertFalse(body.contains("configuration"), body);
+        assertFalse(body.contains(SECRET), body);
+    }
+
+    @Test
+    void put_returns_409_when_the_id_belongs_to_a_data_plane_it_does_not_manage() {
+        // not automation-managed, so the resolver skips it and the create path refuses the taken id
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.NONE));
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
+                .thenReturn(Single.error(new DataPlaneDefinitionAlreadyExistsException(DATA_PLANE_ID)));
+
+        Response response = put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        assertEquals(409, response.getStatus());
+    }
+
+    @Test
+    void put_rejects_an_id_that_is_not_a_valid_key() {
+        givenEnvironmentHolds();
+
+        Response response = put(dataPlanesTarget(), definition("Not A Key"));
+
+        assertEquals(400, response.getStatus());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    void put_updates_a_data_plane_it_already_manages() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        when(dataPlaneDefinitionService.update(anyString(), any(), any()))
+                .thenReturn(Single.just(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API)));
+
+        Response response = put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        assertEquals(200, response.getStatus());
+        verify(dataPlaneDefinitionService).update(eq(DATA_PLANE_ID), any(), any());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    void put_by_id_reference_updates_a_data_plane_it_does_not_manage() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.NONE));
+        when(dataPlaneDefinitionService.update(anyString(), any(), any()))
+                .thenReturn(Single.just(summary(DATA_PLANE_ID, ManagedBy.NONE)));
+
+        Response response = put(dataPlanesTarget(), definition("id:" + DATA_PLANE_ID));
+
+        assertEquals(200, response.getStatus());
+        verify(dataPlaneDefinitionService).update(eq(DATA_PLANE_ID), any(), any());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    void put_by_id_reference_returns_404_when_nothing_exists_to_update() {
+        givenEnvironmentHolds();
+
+        Response response = put(dataPlanesTarget(), definition("id:" + DATA_PLANE_ID));
+
+        assertEquals(404, response.getStatus());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
+    }
+
+    @Test
+    void put_returns_403_before_anything_is_created() {
+        givenEnvironmentHolds();
+        denyPermission();
+
+        Response response = put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        assertEquals(403, response.getStatus());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
+        verify(provisionedDataPlaneLoader, never()).reload(anyString());
+    }
+
+    @Test
+    void put_returns_403_before_anything_is_updated() {
+        givenEnvironmentHolds(summary(DATA_PLANE_ID, ManagedBy.AUTOMATION_API));
+        denyPermission();
+
+        Response response = put(dataPlanesTarget(), definition(DATA_PLANE_ID));
+
+        assertEquals(403, response.getStatus());
+        verify(dataPlaneDefinitionService, never()).update(anyString(), any(), any());
+    }
+}

--- a/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-automation/gravitee-am-management-api-automation-rest/src/test/java/io/gravitee/am/management/handlers/automation/resource/DomainsResourceTest.java
@@ -42,6 +42,8 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.when;
 
 /**
@@ -105,6 +107,36 @@ class DomainsResourceTest extends AutomationJerseySpringTest {
 
         assertEquals(200, response.getStatus());
         assertEquals("customer-auth", readEntity(response, AutomationDomain.class).getAutomationKey());
+    }
+
+    @Test
+    void put_carries_a_named_data_plane_through_to_the_service() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
+        AutomationDomain definition = definition("customer-auth");
+        definition.setDataPlaneId("somewhere-else");
+
+        put(domainsTarget(), definition);
+
+        verify(domainService).update(eq(domainId), argThat(d -> "somewhere-else".equals(d.getDataPlaneId())), eq(false));
+    }
+
+    @Test
+    void put_leaves_the_resolved_data_plane_alone_when_the_payload_omits_it() {
+        String domainId = AutomationIds.domainId(ENV_ID, "customer-auth");
+        Domain existing = domain(domainId, "customer-auth");
+        when(domainService.findById(eq(domainId))).thenReturn(Maybe.just(existing));
+        when(identityProviderService.findAll(eq(ReferenceType.DOMAIN), anyString())).thenReturn(Flowable.empty());
+        when(domainService.update(eq(domainId), any(Domain.class), eq(false))).thenReturn(Single.just(existing));
+        AutomationDomain definition = definition("customer-auth");
+        definition.setDataPlaneId(null);
+
+        put(domainsTarget(), definition);
+
+        verify(domainService).update(eq(domainId), argThat(d -> "default".equals(d.getDataPlaneId())), eq(false));
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.handlers.internalapi.endpoints;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
@@ -73,7 +74,7 @@ public class CreateDataPlaneEndpoint extends AbstractInternalApiEndpoint {
             return;
         }
 
-        dataPlaneDefinitionService.create(payload)
+         dataPlaneDefinitionService.create(payload, ManagedBy.NONE, null)
                 .flatMap(summary -> provisionedDataPlaneLoader.register(summary.id()).andThen(Single.just(summary)))
                 .subscribe(
                         summary -> respond(context, HttpStatusCode.CREATED_201, summary),

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpoint.java
@@ -19,12 +19,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.gravitee.am.model.ManagedBy;
-import io.gravitee.am.service.DataPlaneDefinitionService;
-import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
-import io.reactivex.rxjava3.core.Single;
 import io.vertx.ext.web.RoutingContext;
 import lombok.CustomLog;
 
@@ -37,15 +35,12 @@ import lombok.CustomLog;
 @CustomLog
 public class CreateDataPlaneEndpoint extends AbstractInternalApiEndpoint {
 
-    private final DataPlaneDefinitionService dataPlaneDefinitionService;
-    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+    private final DataPlaneProvisioningService dataPlaneProvisioningService;
 
-    public CreateDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
-                                   ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+    public CreateDataPlaneEndpoint(DataPlaneProvisioningService dataPlaneProvisioningService,
                                    ObjectMapper objectMapper) {
         super(objectMapper);
-        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
-        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
+        this.dataPlaneProvisioningService = dataPlaneProvisioningService;
     }
 
     @Override
@@ -74,8 +69,7 @@ public class CreateDataPlaneEndpoint extends AbstractInternalApiEndpoint {
             return;
         }
 
-         dataPlaneDefinitionService.create(payload, ManagedBy.NONE, null)
-                .flatMap(summary -> provisionedDataPlaneLoader.register(summary.id()).andThen(Single.just(summary)))
+        dataPlaneProvisioningService.provision(payload, ManagedBy.NONE, null)
                 .subscribe(
                         summary -> respond(context, HttpStatusCode.CREATED_201, summary),
                         throwable -> respondFailure(context, throwable, "Unable to create the data plane definition"));

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
@@ -16,9 +16,7 @@
 package io.gravitee.am.management.handlers.internalapi.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
-import io.gravitee.am.service.DataPlaneDefinitionService;
-import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.vertx.ext.web.RoutingContext;
@@ -30,18 +28,12 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
 
     static final String PARAM_ID = "id";
 
-    private final DataPlaneDefinitionService dataPlaneDefinitionService;
-    private final DataPlaneRegistry dataPlaneRegistry;
-    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+    private final DataPlaneProvisioningService dataPlaneProvisioningService;
 
-    public DeleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
-                                   DataPlaneRegistry dataPlaneRegistry,
-                                   ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+    public DeleteDataPlaneEndpoint(DataPlaneProvisioningService dataPlaneProvisioningService,
                                    ObjectMapper objectMapper) {
         super(objectMapper);
-        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
-        this.dataPlaneRegistry = dataPlaneRegistry;
-        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
+        this.dataPlaneProvisioningService = dataPlaneProvisioningService;
     }
 
     @Override
@@ -58,15 +50,11 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
     public void handle(RoutingContext context) {
         String id = context.pathParam(PARAM_ID);
 
-        dataPlaneDefinitionService.delete(id, null)
+        dataPlaneProvisioningService.deprovision(id, null)
                 .subscribe(
-                        () -> {
-                            dataPlaneRegistry.unregister(id);
-                            provisionedDataPlaneLoader.forget(id);
-                            context.response()
-                                    .setStatusCode(HttpStatusCode.NO_CONTENT_204)
-                                    .end();
-                        },
+                        () -> context.response()
+                                .setStatusCode(HttpStatusCode.NO_CONTENT_204)
+                                .end(),
                         throwable -> respondFailure(context, throwable, "Unable to delete the data plane definition"));
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpoint.java
@@ -58,7 +58,7 @@ public class DeleteDataPlaneEndpoint extends AbstractInternalApiEndpoint {
     public void handle(RoutingContext context) {
         String id = context.pathParam(PARAM_ID);
 
-        dataPlaneDefinitionService.delete(id)
+        dataPlaneDefinitionService.delete(id, null)
                 .subscribe(
                         () -> {
                             dataPlaneRegistry.unregister(id);

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/main/java/io/gravitee/am/management/handlers/internalapi/spring/InternalApiConfiguration.java
@@ -21,9 +21,8 @@ import io.gravitee.am.management.handlers.internalapi.endpoints.DeleteDataPlaneE
 import io.gravitee.am.management.handlers.internalapi.endpoints.GetDataPlaneEndpoint;
 import io.gravitee.am.management.handlers.internalapi.InternalApiService;
 import io.gravitee.am.management.handlers.internalapi.endpoints.ListDataPlanesEndpoint;
-import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.DataPlaneDefinitionService;
-import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -37,10 +36,9 @@ import org.springframework.context.annotation.Configuration;
 public class InternalApiConfiguration {
 
     @Bean
-    public CreateDataPlaneEndpoint createDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
-                                                           ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+    public CreateDataPlaneEndpoint createDataPlaneEndpoint(DataPlaneProvisioningService dataPlaneProvisioningService,
                                                            ObjectMapper objectMapper) {
-        return new CreateDataPlaneEndpoint(dataPlaneDefinitionService, provisionedDataPlaneLoader, objectMapper);
+        return new CreateDataPlaneEndpoint(dataPlaneProvisioningService, objectMapper);
     }
 
     @Bean
@@ -54,11 +52,9 @@ public class InternalApiConfiguration {
     }
 
     @Bean
-    public DeleteDataPlaneEndpoint deleteDataPlaneEndpoint(DataPlaneDefinitionService dataPlaneDefinitionService,
-                                                           DataPlaneRegistry dataPlaneRegistry,
-                                                           ProvisionedDataPlaneLoader provisionedDataPlaneLoader,
+    public DeleteDataPlaneEndpoint deleteDataPlaneEndpoint(DataPlaneProvisioningService dataPlaneProvisioningService,
                                                            ObjectMapper objectMapper) {
-        return new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, dataPlaneRegistry, provisionedDataPlaneLoader, objectMapper);
+        return new DeleteDataPlaneEndpoint(dataPlaneProvisioningService, objectMapper);
     }
 
     @Bean

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
@@ -17,6 +17,7 @@ package io.gravitee.am.management.handlers.internalapi.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.internalapi.endpoints.CreateDataPlaneEndpoint;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.exception.DataPlaneDefinitionAlreadyExistsException;
@@ -43,6 +44,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -107,7 +110,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldReturn201WithTheCreatedDefinition() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.just(summary()));
+        when(dataPlaneDefinitionService.create(any(), any(), any())).thenReturn(Single.just(summary()));
 
         endpoint.handle(routingContext);
 
@@ -118,7 +121,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldNotEchoTheSubmittedCredentialsBack() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.just(summary()));
+        when(dataPlaneDefinitionService.create(any(), any(), any())).thenReturn(Single.just(summary()));
 
         endpoint.handle(routingContext);
 
@@ -132,12 +135,12 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldPassTheDeserialisedPayloadToTheService() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.just(summary()));
+        when(dataPlaneDefinitionService.create(any(), any(), any())).thenReturn(Single.just(summary()));
 
         endpoint.handle(routingContext);
 
         ArgumentCaptor<NewDataPlaneDefinition> captor = ArgumentCaptor.forClass(NewDataPlaneDefinition.class);
-        verify(dataPlaneDefinitionService).create(captor.capture());
+        verify(dataPlaneDefinitionService).create(captor.capture(), eq(ManagedBy.NONE), isNull());
 
         NewDataPlaneDefinition payload = captor.getValue();
         assertThat(payload.getId()).isEqualTo("dp-acme");
@@ -149,7 +152,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldRegisterTheProvisionedDataPlaneSoItIsUsableWithoutARestart() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.just(summary()));
+        when(dataPlaneDefinitionService.create(any(), any(), any())).thenReturn(Single.just(summary()));
 
         endpoint.handle(routingContext);
 
@@ -160,7 +163,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldNotRegisterADefinitionThatWasNotPersisted() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any()))
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
                 .thenReturn(Single.error(new DataPlaneDefinitionAlreadyExistsException("dp-acme")));
 
         endpoint.handle(routingContext);
@@ -175,7 +178,7 @@ class CreateDataPlaneEndpointTest {
         endpoint.handle(routingContext);
 
         verify(response).setStatusCode(400);
-        verify(dataPlaneDefinitionService, never()).create(any());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
     }
 
     @Test
@@ -187,7 +190,7 @@ class CreateDataPlaneEndpointTest {
         endpoint.handle(routingContext);
 
         verify(response).setStatusCode(400);
-        verify(dataPlaneDefinitionService, never()).create(any());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
         assertThat(responseBody()).contains("unknown field [gatewayURL]");
     }
 
@@ -210,13 +213,13 @@ class CreateDataPlaneEndpointTest {
         endpoint.handle(routingContext);
 
         verify(response).setStatusCode(400);
-        verify(dataPlaneDefinitionService, never()).create(any());
+        verify(dataPlaneDefinitionService, never()).create(any(), any(), any());
     }
 
     @Test
     void shouldReturn400WhenTheServiceRejectsTheDefinition() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any()))
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
                 .thenReturn(Single.error(new InvalidParameterException("configuration.mongodb requires either 'uri' or 'dbname'")));
 
         endpoint.handle(routingContext);
@@ -228,7 +231,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldReturn409OnADuplicateId() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any()))
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
                 .thenReturn(Single.error(new DataPlaneDefinitionAlreadyExistsException("dp-acme")));
 
         endpoint.handle(routingContext);
@@ -240,7 +243,7 @@ class CreateDataPlaneEndpointTest {
     @Test
     void shouldReturn500OnAnUnexpectedFailure() {
         when(requestBody.asString()).thenReturn(PAYLOAD);
-        when(dataPlaneDefinitionService.create(any())).thenReturn(Single.error(new IllegalStateException("boom")));
+        when(dataPlaneDefinitionService.create(any(), any(), any())).thenReturn(Single.error(new IllegalStateException("boom")));
 
         endpoint.handle(routingContext);
 
@@ -264,6 +267,7 @@ class CreateDataPlaneEndpointTest {
                 "DEFAULT",
                 "gravitee-am-acme",
                 List.of("mongo:27017"),
+                ManagedBy.NONE,
                 new Date(),
                 new Date());
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/CreateDataPlaneEndpointTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.internalapi.endpoints.CreateDataPlaneEndpoint;
 import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.exception.DataPlaneDefinitionAlreadyExistsException;
 import io.gravitee.am.service.exception.InvalidParameterException;
@@ -97,8 +98,9 @@ class CreateDataPlaneEndpointTest {
         response = mock(HttpServerResponse.class, RETURNS_SELF);
         when(routingContext.body()).thenReturn(requestBody);
         when(routingContext.response()).thenReturn(response);
-        when(provisionedDataPlaneLoader.register(any())).thenReturn(Completable.complete());
-        endpoint = new CreateDataPlaneEndpoint(dataPlaneDefinitionService, provisionedDataPlaneLoader, new ObjectMapper());
+        when(provisionedDataPlaneLoader.activate(any())).thenReturn(Completable.complete());
+        endpoint = new CreateDataPlaneEndpoint(
+                new DataPlaneProvisioningService(dataPlaneDefinitionService, provisionedDataPlaneLoader), new ObjectMapper());
     }
 
     @Test
@@ -156,7 +158,7 @@ class CreateDataPlaneEndpointTest {
 
         endpoint.handle(routingContext);
 
-        verify(provisionedDataPlaneLoader).register("dp-acme");
+        verify(provisionedDataPlaneLoader).activate("dp-acme");
         verify(response).setStatusCode(201);
     }
 
@@ -168,7 +170,7 @@ class CreateDataPlaneEndpointTest {
 
         endpoint.handle(routingContext);
 
-        verify(provisionedDataPlaneLoader, never()).register(any());
+        verify(provisionedDataPlaneLoader, never()).activate(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
@@ -16,8 +16,8 @@
 package io.gravitee.am.management.handlers.internalapi.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.am.plugins.dataplane.core.DataPlaneRegistry;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
 import io.gravitee.am.service.exception.DataPlaneInUseByDomainsException;
@@ -53,9 +53,6 @@ class DeleteDataPlaneEndpointTest {
     private DataPlaneDefinitionService dataPlaneDefinitionService;
 
     @Mock
-    private DataPlaneRegistry dataPlaneRegistry;
-
-    @Mock
     private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
 
     @Mock
@@ -69,7 +66,8 @@ class DeleteDataPlaneEndpointTest {
     void setUp() {
         response = mock(HttpServerResponse.class, RETURNS_SELF);
         when(routingContext.response()).thenReturn(response);
-        endpoint = new DeleteDataPlaneEndpoint(dataPlaneDefinitionService, dataPlaneRegistry, provisionedDataPlaneLoader, new ObjectMapper());
+        endpoint = new DeleteDataPlaneEndpoint(
+                new DataPlaneProvisioningService(dataPlaneDefinitionService, provisionedDataPlaneLoader), new ObjectMapper());
     }
 
     @Test
@@ -96,8 +94,7 @@ class DeleteDataPlaneEndpointTest {
 
         endpoint.handle(routingContext);
 
-        verify(dataPlaneRegistry).unregister("dp-acme");
-        verify(provisionedDataPlaneLoader).forget("dp-acme");
+        verify(provisionedDataPlaneLoader).deactivate("dp-acme");
     }
 
     @Test
@@ -108,8 +105,7 @@ class DeleteDataPlaneEndpointTest {
 
         endpoint.handle(routingContext);
 
-        verify(dataPlaneRegistry, never()).unregister(any());
-        verify(provisionedDataPlaneLoader, never()).forget(any());
+        verify(provisionedDataPlaneLoader, never()).deactivate(any());
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/DeleteDataPlaneEndpointTest.java
@@ -81,7 +81,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldReturn204OnDeletion() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
-        when(dataPlaneDefinitionService.delete("dp-acme")).thenReturn(Completable.complete());
+        when(dataPlaneDefinitionService.delete("dp-acme", null)).thenReturn(Completable.complete());
 
         endpoint.handle(routingContext);
 
@@ -92,7 +92,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldStopServingTheDataPlaneOnThisNode() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
-        when(dataPlaneDefinitionService.delete("dp-acme")).thenReturn(Completable.complete());
+        when(dataPlaneDefinitionService.delete("dp-acme", null)).thenReturn(Completable.complete());
 
         endpoint.handle(routingContext);
 
@@ -103,7 +103,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldKeepServingTheDataPlaneWhenTheDeletionIsRefused() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
-        when(dataPlaneDefinitionService.delete("dp-acme"))
+        when(dataPlaneDefinitionService.delete("dp-acme", null))
                 .thenReturn(Completable.error(new DataPlaneInUseByDomainsException("dp-acme")));
 
         endpoint.handle(routingContext);
@@ -115,7 +115,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldReturn404WhenTheDefinitionDoesNotExist() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-missing");
-        when(dataPlaneDefinitionService.delete("dp-missing"))
+        when(dataPlaneDefinitionService.delete("dp-missing", null))
                 .thenReturn(Completable.error(new DataPlaneDefinitionNotFoundException("dp-missing")));
 
         endpoint.handle(routingContext);
@@ -127,7 +127,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldReturn409WhenADomainStillUsesTheDataPlane() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
-        when(dataPlaneDefinitionService.delete("dp-acme"))
+        when(dataPlaneDefinitionService.delete("dp-acme", null))
                 .thenReturn(Completable.error(new DataPlaneInUseByDomainsException("dp-acme")));
 
         endpoint.handle(routingContext);
@@ -139,7 +139,7 @@ class DeleteDataPlaneEndpointTest {
     @Test
     void shouldReturn500OnAnUnexpectedFailure() {
         when(routingContext.pathParam(DeleteDataPlaneEndpoint.PARAM_ID)).thenReturn("dp-acme");
-        when(dataPlaneDefinitionService.delete("dp-acme")).thenReturn(Completable.error(new IllegalStateException("boom")));
+        when(dataPlaneDefinitionService.delete("dp-acme", null)).thenReturn(Completable.error(new IllegalStateException("boom")));
 
         endpoint.handle(routingContext);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/GetDataPlaneEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/GetDataPlaneEndpointTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.internalapi.endpoints.GetDataPlaneEndpoint;
 import io.gravitee.am.service.DataPlaneDefinitionService;
 import io.gravitee.am.service.exception.DataPlaneDefinitionNotFoundException;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.common.http.HttpMethod;
 import io.reactivex.rxjava3.core.Single;
@@ -138,6 +139,7 @@ class GetDataPlaneEndpointTest {
                 "DEFAULT",
                 "gravitee-am-acme",
                 List.of("mongo:27017"),
+                ManagedBy.NONE,
                 new Date(),
                 new Date());
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/ListDataPlanesEndpointTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-internal/src/test/java/io/gravitee/am/management/handlers/internalapi/endpoints/ListDataPlanesEndpointTest.java
@@ -18,6 +18,7 @@ package io.gravitee.am.management.handlers.internalapi.endpoints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.am.management.handlers.internalapi.endpoints.ListDataPlanesEndpoint;
 import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.common.http.HttpMethod;
 import io.reactivex.rxjava3.core.Flowable;
@@ -133,6 +134,7 @@ class ListDataPlanesEndpointTest {
                 environmentId,
                 "gravitee-am-acme",
                 List.of("mongo:27017"),
+                ManagedBy.NONE,
                 new Date(),
                 new Date());
     }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManager.java
@@ -101,7 +101,6 @@ public class ProvisionedDataPlaneManager extends AbstractService<ProvisionedData
     }
 
     private void undeploy(String dataPlaneId) {
-        dataPlaneRegistry.unregister(dataPlaneId);
-        provisionedDataPlaneLoader.forget(dataPlaneId);
+        provisionedDataPlaneLoader.deactivate(dataPlaneId);
     }
 }

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DefaultRoleUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/DefaultRoleUpgrader.java
@@ -36,7 +36,7 @@ public class DefaultRoleUpgrader implements Upgrader {
     private final RoleService roleService;
 
     // bump every time system roles are modified
-    private static final String VERSION = "4_13_0_a";
+    private static final String VERSION = "4_13_0_b";
 
     @Override
     public boolean upgrade() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/OrganizationRolesUpgrader.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/upgrades/OrganizationRolesUpgrader.java
@@ -40,7 +40,7 @@ public class OrganizationRolesUpgrader implements Upgrader {
 
     // Bump this VERSION every time the default-role permission sets are modified in RoleServiceImpl#buildDefaultRoles
     // so existing installations pick up newly added permissions.
-    private static final String VERSION = "4_13_0_a";
+    private static final String VERSION = "4_13_0_b";
 
     @Override
     public boolean upgrade() {

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/DomainServiceTest.java
@@ -114,6 +114,7 @@ import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.impl.I18nDictionaryService;
 import io.gravitee.am.service.impl.PasswordHistoryService;
 import io.gravitee.am.service.model.AutomationNewDomain;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDomain;
 import io.gravitee.am.service.model.NewSystemScope;
@@ -748,7 +749,7 @@ public class DomainServiceTest {
 
     private DataPlaneDefinitionSummary dpSummary(String id) {
         return new DataPlaneDefinitionSummary(
-                id, id, "mongodb", null, ORGANIZATION_ID, ENVIRONMENT_ID, null, List.of(), null, null);
+                id, id, "mongodb", null, ORGANIZATION_ID, ENVIRONMENT_ID, null, List.of(), ManagedBy.NONE, null, null);
     }
 
     @Test

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/test/java/io/gravitee/am/management/service/impl/ProvisionedDataPlaneManagerTest.java
@@ -167,8 +167,7 @@ class ProvisionedDataPlaneManagerTest {
     void shouldStopServingTheDataPlaneOnUndeploy() {
         manager.onEvent(event(DataPlaneEvent.UNDEPLOY, "dp-1"));
 
-        verify(dataPlaneRegistry).unregister("dp-1");
-        verify(provisionedDataPlaneLoader).forget("dp-1");
+        verify(provisionedDataPlaneLoader).deactivate("dp-1");
         verify(dataPlaneDefinitionRepository, never()).findById(any());
     }
 
@@ -178,8 +177,7 @@ class ProvisionedDataPlaneManagerTest {
 
         manager.onEvent(event(DataPlaneEvent.DEPLOY, "dp-1"));
 
-        verify(dataPlaneRegistry).unregister("dp-1");
-        verify(provisionedDataPlaneLoader).forget("dp-1");
+        verify(provisionedDataPlaneLoader).deactivate("dp-1");
         verify(dataPlaneRegistry, never()).registerProvisioned(any());
     }
 

--- a/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-standalone/gravitee-am-management-api-standalone-container/src/main/java/io/gravitee/am/management/standalone/spring/StandaloneConfiguration.java
@@ -52,6 +52,8 @@ import io.gravitee.am.plugins.reporter.spring.ReporterSpringConfiguration;
 import io.gravitee.am.plugins.resource.spring.ResourceSpringConfiguration;
 import io.gravitee.am.repository.ManagementRepositoryScopeProvider;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
+import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.dataplane.DataPlaneProvisioningService;
 import io.gravitee.am.service.dataplane.ProvisionedDataPlaneLoader;
 import io.gravitee.am.service.secrets.SecretsConfiguration;
 import io.gravitee.am.service.spring.ServiceConfiguration;
@@ -177,6 +179,12 @@ public class StandaloneConfiguration {
                                                                 @Lazy DataPlaneDefinitionRepository dataPlaneDefinitionRepository,
                                                                 ConfigurableEnvironment environment) {
         return new ProvisionedDataPlaneLoader(configurationLoader, dataPlaneDefinitionRepository, environment);
+    }
+
+    @Bean
+    public DataPlaneProvisioningService dataPlaneProvisioningService(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                                                    ProvisionedDataPlaneLoader provisionedDataPlaneLoader) {
+        return new DataPlaneProvisioningService(dataPlaneDefinitionService, provisionedDataPlaneLoader);
     }
 
     @Bean

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/DataPlaneDefinition.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/DataPlaneDefinition.java
@@ -27,7 +27,7 @@ import java.util.Date;
  * @author GraviteeSource Team
  */
 @Data
-public class DataPlaneDefinition {
+public class DataPlaneDefinition implements Managed {
 
     private String id;
 
@@ -45,6 +45,8 @@ public class DataPlaneDefinition {
     /** Stored verbatim, can hold credentials, hence excluded from {@code toString()}. */
     @ToString.Exclude
     private String configuration;
+
+    private ManagedBy managedBy;
 
     private Date createdAt;
 

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
@@ -52,6 +52,7 @@ public enum Permission {
     ENVIRONMENT(ReferenceType.PLATFORM, ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
 
     DATA_PLANE(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
+    DATA_PLANE_MANAGED(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
 
     DOMAIN(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN),
     DOMAIN_SETTINGS(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN),

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/permissions/Permission.java
@@ -52,7 +52,6 @@ public enum Permission {
     ENVIRONMENT(ReferenceType.PLATFORM, ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
 
     DATA_PLANE(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
-    DATA_PLANE_MANAGED(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT),
 
     DOMAIN(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN),
     DOMAIN_SETTINGS(ReferenceType.ORGANIZATION, ReferenceType.ENVIRONMENT, ReferenceType.DOMAIN),

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDataPlaneDefinitionRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/JdbcDataPlaneDefinitionRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.jdbc.management.api;
 
 import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.repository.jdbc.management.AbstractJdbcRepository;
 import io.gravitee.am.repository.jdbc.management.api.model.JdbcDataPlaneDefinition;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
@@ -53,6 +54,7 @@ public class JdbcDataPlaneDefinitionRepository extends AbstractJdbcRepository im
     private static final String COL_ORGANIZATION_ID = "organization_id";
     private static final String COL_ENVIRONMENT_ID = "environment_id";
     private static final String COL_CONFIGURATION = "configuration";
+    private static final String COL_MANAGED_BY = "managed_by";
     private static final String COL_CREATED_AT = "created_at";
     private static final String COL_UPDATED_AT = "updated_at";
 
@@ -64,6 +66,7 @@ public class JdbcDataPlaneDefinitionRepository extends AbstractJdbcRepository im
             COL_ORGANIZATION_ID,
             COL_ENVIRONMENT_ID,
             COL_CONFIGURATION,
+            COL_MANAGED_BY,
             COL_CREATED_AT,
             COL_UPDATED_AT);
 
@@ -144,6 +147,7 @@ public class JdbcDataPlaneDefinitionRepository extends AbstractJdbcRepository im
         spec = addQuotedField(spec, COL_ORGANIZATION_ID, item.getOrganizationId(), String.class);
         spec = addQuotedField(spec, COL_ENVIRONMENT_ID, item.getEnvironmentId(), String.class);
         spec = addQuotedField(spec, COL_CONFIGURATION, item.getConfiguration(), String.class);
+        spec = addQuotedField(spec, COL_MANAGED_BY, item.getManagedBy() != null ? item.getManagedBy().name() : null, String.class);
         spec = addQuotedField(spec, COL_CREATED_AT, dateConverter.convertTo(item.getCreatedAt(), null), LocalDateTime.class);
         spec = addQuotedField(spec, COL_UPDATED_AT, dateConverter.convertTo(item.getUpdatedAt(), null), LocalDateTime.class);
         return spec;
@@ -161,6 +165,7 @@ public class JdbcDataPlaneDefinitionRepository extends AbstractJdbcRepository im
         definition.setOrganizationId(entity.getOrganizationId());
         definition.setEnvironmentId(entity.getEnvironmentId());
         definition.setConfiguration(entity.getConfiguration());
+        definition.setManagedBy(entity.getManagedBy() != null ? ManagedBy.valueOf(entity.getManagedBy()) : null);
         definition.setCreatedAt(dateConverter.convertFrom(entity.getCreatedAt(), null));
         definition.setUpdatedAt(dateConverter.convertFrom(entity.getUpdatedAt(), null));
         return definition;

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcDataPlaneDefinition.java
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/java/io/gravitee/am/repository/jdbc/management/api/model/JdbcDataPlaneDefinition.java
@@ -45,6 +45,9 @@ public class JdbcDataPlaneDefinition {
 
     private String configuration;
 
+    @Column("managed_by")
+    private String managedBy;
+
     @Column("created_at")
     private LocalDateTime createdAt;
 
@@ -97,6 +100,14 @@ public class JdbcDataPlaneDefinition {
 
     public void setEnvironmentId(String environmentId) {
         this.environmentId = environmentId;
+    }
+
+    public String getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(String managedBy) {
+        this.managedBy = managedBy;
     }
 
     public String getConfiguration() {

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-dataplanes-add-managed-by.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/changelogs/v4_13_0/4.13.0-dataplanes-add-managed-by.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.13.0-add-managed-by-to-dataplanes
+      author: GraviteeSource Team
+      preConditions:
+        onFail: MARK_RAN
+        not:
+          - columnExists:
+              tableName: dataplanes
+              columnName: managed_by
+      changes:
+        #############################
+        # dataplanes #
+        ############################
+        - addColumn:
+            tableName: dataplanes
+            columns:
+              - column:
+                  name: managed_by
+                  type: varchar(64)
+                  constraints:
+                    nullable: true

--- a/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/src/main/resources/liquibase/management-master.yml
@@ -245,3 +245,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_13_0/4.13.0-reporters-add-attribute-mapping-event-types.yml
   - include:
       - file: liquibase/changelogs/v4_13_0/4.13.0-trusted-domains-table.yml
+  - include:
+      - file: liquibase/changelogs/v4_13_0/4.13.0-dataplanes-add-managed-by.yml

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDataPlaneDefinitionRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDataPlaneDefinitionRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.am.repository.mongodb.management;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.repository.management.api.DataPlaneDefinitionRepository;
 import io.gravitee.am.repository.mongodb.management.internal.model.DataPlaneDefinitionMongo;
 import io.reactivex.rxjava3.core.Completable;
@@ -107,6 +108,7 @@ public class MongoDataPlaneDefinitionRepository extends AbstractManagementMongoR
         definition.setOrganizationId(entity.getOrganizationId());
         definition.setEnvironmentId(entity.getEnvironmentId());
         definition.setConfiguration(entity.getConfiguration());
+        definition.setManagedBy(entity.getManagedBy() != null ? ManagedBy.valueOf(entity.getManagedBy()) : null);
         definition.setCreatedAt(entity.getCreatedAt());
         definition.setUpdatedAt(entity.getUpdatedAt());
         return definition;
@@ -124,6 +126,7 @@ public class MongoDataPlaneDefinitionRepository extends AbstractManagementMongoR
         entity.setOrganizationId(definition.getOrganizationId());
         entity.setEnvironmentId(definition.getEnvironmentId());
         entity.setConfiguration(definition.getConfiguration());
+        entity.setManagedBy(definition.getManagedBy() != null ? definition.getManagedBy().name() : null);
         entity.setCreatedAt(definition.getCreatedAt());
         entity.setUpdatedAt(definition.getUpdatedAt());
         return entity;

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/DataPlaneDefinitionMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/DataPlaneDefinitionMongo.java
@@ -38,6 +38,8 @@ public class DataPlaneDefinitionMongo extends Auditable {
 
     private String configuration;
 
+    private String managedBy;
+
     public String getId() {
         return id;
     }
@@ -84,6 +86,14 @@ public class DataPlaneDefinitionMongo extends Auditable {
 
     public void setEnvironmentId(String environmentId) {
         this.environmentId = environmentId;
+    }
+
+    public String getManagedBy() {
+        return managedBy;
+    }
+
+    public void setManagedBy(String managedBy) {
+        this.managedBy = managedBy;
     }
 
     public String getConfiguration() {

--- a/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DataPlaneDefinitionRepositoryTest.java
+++ b/gravitee-am-repository/gravitee-am-repository-tests/src/test/java/io/gravitee/am/repository/management/api/DataPlaneDefinitionRepositoryTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.repository.management.api;
 
 import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.repository.management.AbstractManagementTest;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Test;
@@ -50,6 +51,7 @@ public class DataPlaneDefinitionRepositoryTest extends AbstractManagementTest {
         definition.setOrganizationId("DEFAULT");
         definition.setEnvironmentId(environmentId);
         definition.setConfiguration(MONGO_CONFIGURATION);
+        definition.setManagedBy(ManagedBy.AUTOMATION_API);
         definition.setCreatedAt(new Date());
         definition.setUpdatedAt(new Date());
         return definition;
@@ -194,5 +196,21 @@ public class DataPlaneDefinitionRepositoryTest extends AbstractManagementTest {
         obs.assertNoErrors();
 
         assertNull(dataPlaneDefinitionRepository.findById("dp-delete").blockingGet());
+    }
+
+    @Test
+    public void testManagedByRoundTrip() {
+        dataPlaneDefinitionRepository.create(build("dp-managed", "env-managed")).blockingGet();
+
+        DataPlaneDefinition stored = dataPlaneDefinitionRepository.findById("dp-managed").blockingGet();
+        assertEquals(ManagedBy.AUTOMATION_API, stored.getManagedBy());
+
+        stored.setManagedBy(ManagedBy.NONE);
+        TestObserver<DataPlaneDefinition> obs = dataPlaneDefinitionRepository.update(stored).test();
+        obs.awaitDone(10, TimeUnit.SECONDS);
+
+        obs.assertComplete();
+        obs.assertNoErrors();
+        obs.assertValue(d -> ManagedBy.NONE == d.getManagedBy());
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/DataPlaneDefinitionService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/DataPlaneDefinitionService.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.service;
 
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
 import io.gravitee.am.service.model.NewDataPlaneDefinition;
 import io.reactivex.rxjava3.core.Completable;
@@ -29,7 +31,13 @@ import io.reactivex.rxjava3.core.Single;
  */
 public interface DataPlaneDefinitionService {
 
-    Single<DataPlaneDefinitionSummary> create(NewDataPlaneDefinition newDataPlaneDefinition);
+    Single<DataPlaneDefinitionSummary> create(NewDataPlaneDefinition newDataPlaneDefinition, ManagedBy managedBy, User principal);
+
+    /**
+     * Replaces the mutable fields of an existing definition. A change to type, organization or
+     * environment is refused; ownership is left as it was.
+     */
+    Single<DataPlaneDefinitionSummary> update(String id, NewDataPlaneDefinition newDataPlaneDefinition, User principal);
 
     Flowable<DataPlaneDefinitionSummary> findAll();
 
@@ -40,5 +48,5 @@ public interface DataPlaneDefinitionService {
     /**
      * Deletes a definition, refused while any domain still points at it.
      */
-    Completable delete(String id);
+    Completable delete(String id, User principal);
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DataPlaneProvisioningService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/DataPlaneProvisioningService.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.dataplane;
+
+import io.gravitee.am.identityprovider.api.User;
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.NewDataPlaneDefinition;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * Changes a data plane definition and, on the node serving the request, the registry that runs it.
+ * The other nodes pick the change up from the sync event the definition change publishes.
+ *
+ * @author GraviteeSource Team
+ */
+public class DataPlaneProvisioningService {
+
+    private final DataPlaneDefinitionService dataPlaneDefinitionService;
+    private final ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    public DataPlaneProvisioningService(DataPlaneDefinitionService dataPlaneDefinitionService,
+                                        ProvisionedDataPlaneLoader provisionedDataPlaneLoader) {
+        this.dataPlaneDefinitionService = dataPlaneDefinitionService;
+        this.provisionedDataPlaneLoader = provisionedDataPlaneLoader;
+    }
+
+    public Single<DataPlaneDefinitionSummary> provision(NewDataPlaneDefinition definition, ManagedBy managedBy, User principal) {
+        return dataPlaneDefinitionService.create(definition, managedBy, principal)
+                .flatMap(summary -> provisionedDataPlaneLoader.activate(summary.id()).toSingleDefault(summary));
+    }
+
+    public Single<DataPlaneDefinitionSummary> reprovision(String id, NewDataPlaneDefinition definition, User principal) {
+        return dataPlaneDefinitionService.update(id, definition, principal)
+                .flatMap(summary -> provisionedDataPlaneLoader.activate(summary.id()).toSingleDefault(summary));
+    }
+
+    public Completable deprovision(String id, User principal) {
+        return dataPlaneDefinitionService.delete(id, principal)
+                .andThen(Completable.fromAction(() -> provisionedDataPlaneLoader.deactivate(id)));
+    }
+}

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -103,6 +103,21 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                 .onErrorComplete();
     }
 
+    /**
+     * Re-registers a definition whose stored configuration changed.
+     */
+    public Completable reload(String dataPlaneId) {
+        if (storageRef.get() == null) {
+            return Completable.complete();
+        }
+        var registry = registryRef.get();
+        if (registry != null) {
+            registry.unregister(dataPlaneId);
+        }
+        forget(dataPlaneId);
+        return register(dataPlaneId);
+    }
+
     private void activate(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
         // only the provisioned definitions reach here, which is what keeps the gravitee.yml ones exempt
         var registry = registryRef.get();

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoader.java
@@ -85,7 +85,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
                 .blockingForEach(definition -> activate(definition, storage));
     }
 
-    public Completable register(String dataPlaneId) {
+    Completable register(String dataPlaneId) {
         var storage = storageRef.get();
 
         // nothing is lost when the registry has not started yet: load publishes its consumer before
@@ -104,18 +104,26 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
     }
 
     /**
-     * Re-registers a definition whose stored configuration changed.
+     * Makes this node serve the stored definition, dropping whatever it served under that id first.
      */
-    public Completable reload(String dataPlaneId) {
+    public Completable activate(String dataPlaneId) {
         if (storageRef.get() == null) {
             return Completable.complete();
         }
+        deactivate(dataPlaneId);
+        return register(dataPlaneId);
+    }
+
+    /**
+     * Stops this node serving the data plane: its provider is closed and the id is left free for
+     * whatever claims it next.
+     */
+    public void deactivate(String dataPlaneId) {
         var registry = registryRef.get();
         if (registry != null) {
             registry.unregister(dataPlaneId);
         }
         forget(dataPlaneId);
-        return register(dataPlaneId);
     }
 
     private void activate(DataPlaneDefinition definition, Consumer<DataPlaneDescription> storage) {
@@ -145,7 +153,7 @@ public class ProvisionedDataPlaneLoader implements DataPlaneLoader {
         }
     }
 
-    public void forget(String dataPlaneId) {
+    void forget(String dataPlaneId) {
         registered.remove(dataPlaneId);
         properties.keySet().removeIf(key -> key.startsWith(PROPERTIES_BASE + "." + dataPlaneId + "."));
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/DataPlaneDefinitionServiceImpl.java
@@ -21,8 +21,10 @@ import io.gravitee.am.common.audit.EventType;
 import io.gravitee.am.common.event.Action;
 import io.gravitee.am.common.event.Type;
 import io.gravitee.am.dataplane.api.DataPlaneDescription;
+import io.gravitee.am.identityprovider.api.User;
 import io.gravitee.am.model.DataPlaneDefinition;
 import io.gravitee.am.model.Environment;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.model.ReferenceType;
 import io.gravitee.am.model.common.event.Event;
@@ -58,6 +60,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -108,7 +111,7 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     }
 
     @Override
-    public Single<DataPlaneDefinitionSummary> create(NewDataPlaneDefinition newDataPlaneDefinition) {
+    public Single<DataPlaneDefinitionSummary> create(NewDataPlaneDefinition newDataPlaneDefinition, ManagedBy managedBy, User principal) {
         log.debug("Create data plane definition {}", newDataPlaneDefinition);
 
         return Single.fromCallable(() -> validate(newDataPlaneDefinition))
@@ -116,16 +119,55 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                         .flatMap(resolved -> checkIdIsFree(resolved)
                                 .andThen(Single.defer(() -> {
                                     var now = new Date();
+                                    resolved.setManagedBy(managedBy);
                                     resolved.setCreatedAt(now);
                                     resolved.setUpdatedAt(now);
                                     return dataPlaneDefinitionRepository.create(resolved)
                                             .onErrorResumeNext(throwable -> conflictThatLostTheRace(resolved, throwable));
                                 }))
                                 .map(this::toSummary))
-                        .doOnError(throwable -> reportCreated(toSummary(definition), throwable)))
-                .doOnSuccess(summary -> reportCreated(summary, null))
+                        .doOnError(throwable -> reportCreated(toSummary(definition), principal, throwable)))
+                .doOnSuccess(summary -> reportCreated(summary, principal, null))
                 // after the audit: a failed event must not report the creation itself as failed
                 .flatMap(summary -> publishEvent(summary, Action.CREATE).toSingleDefault(summary));
+    }
+
+    @Override
+    public Single<DataPlaneDefinitionSummary> update(String id, NewDataPlaneDefinition newDataPlaneDefinition, User principal) {
+        log.debug("Update data plane definition {}", id);
+
+        return dataPlaneDefinitionRepository.findById(id)
+                .switchIfEmpty(Single.error(() -> new DataPlaneDefinitionNotFoundException(id)))
+                .flatMap(existing -> {
+                    // applyTo mutates the stored definition, so the audit's old value is taken first
+                    var before = toSummary(existing);
+                    return Single.fromCallable(() -> validate(newDataPlaneDefinition))
+                            .flatMap(candidate -> resolveReferences(newDataPlaneDefinition, candidate))
+                            .map(resolved -> applyTo(existing, resolved))
+                            .flatMap(dataPlaneDefinitionRepository::update)
+                            .map(this::toSummary)
+                            .doOnSuccess(updated -> reportUpdated(before, updated, principal, null))
+                            .doOnError(throwable -> reportUpdated(before, before, principal, throwable));
+                })
+                .flatMap(summary -> publishEvent(summary, Action.UPDATE).toSingleDefault(summary));
+    }
+
+    private DataPlaneDefinition applyTo(DataPlaneDefinition existing, DataPlaneDefinition resolved) {
+        rejectChange("type", existing.getType(), resolved.getType(), existing.getId());
+        rejectChange("organizationId", existing.getOrganizationId(), resolved.getOrganizationId(), existing.getId());
+        rejectChange("environmentId", existing.getEnvironmentId(), resolved.getEnvironmentId(), existing.getId());
+
+        existing.setName(resolved.getName());
+        existing.setGatewayUrl(resolved.getGatewayUrl());
+        existing.setConfiguration(resolved.getConfiguration());
+        existing.setUpdatedAt(new Date());
+        return existing;
+    }
+
+    private static void rejectChange(String field, String current, String candidate, String id) {
+        if (!Objects.equals(current, candidate)) {
+            throw new InvalidParameterException("Once a data plane is created, '" + field + "' cannot be changed [" + id + "]");
+        }
     }
 
     private Completable publishEvent(DataPlaneDefinitionSummary summary, Action action) {
@@ -135,10 +177,20 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
         });
     }
 
-    private void reportCreated(DataPlaneDefinitionSummary summary, Throwable throwable) {
+    private void reportCreated(DataPlaneDefinitionSummary summary, User principal, Throwable throwable) {
         auditService.report(AuditBuilder.builder(DataPlaneDefinitionAuditBuilder.class)
                 .type(EventType.DATA_PLANE_CREATED)
                 .dataPlane(summary)
+                .principal(principal)
+                .throwable(throwable));
+    }
+
+    private void reportUpdated(DataPlaneDefinitionSummary before, DataPlaneDefinitionSummary after, User principal, Throwable throwable) {
+        auditService.report(AuditBuilder.builder(DataPlaneDefinitionAuditBuilder.class)
+                .type(EventType.DATA_PLANE_UPDATED)
+                .dataPlane(after)
+                .oldValue(before)
+                .principal(principal)
                 .throwable(throwable));
     }
 
@@ -163,15 +215,15 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
     }
 
     @Override
-    public Completable delete(String id) {
+    public Completable delete(String id, User principal) {
         log.debug("Delete data plane definition {}", id);
         return dataPlaneDefinitionRepository.findById(id)
                 .map(this::toSummary)
                 .switchIfEmpty(Single.error(() -> new DataPlaneDefinitionNotFoundException(id)))
                 .flatMapCompletable(summary -> checkNoDomainUsesIt(id)
                         .andThen(Completable.defer(() -> dataPlaneDefinitionRepository.delete(id)))
-                        .doOnComplete(() -> reportDeleted(summary, null))
-                        .doOnError(throwable -> reportDeleted(summary, throwable))
+                        .doOnComplete(() -> reportDeleted(summary, principal, null))
+                        .doOnError(throwable -> reportDeleted(summary, principal, throwable))
                         .andThen(publishEvent(summary, Action.DELETE)));
     }
 
@@ -182,10 +234,11 @@ public class DataPlaneDefinitionServiceImpl implements DataPlaneDefinitionServic
                         : Completable.complete());
     }
 
-    private void reportDeleted(DataPlaneDefinitionSummary summary, Throwable throwable) {
+    private void reportDeleted(DataPlaneDefinitionSummary summary, User principal, Throwable throwable) {
         auditService.report(AuditBuilder.builder(DataPlaneDefinitionAuditBuilder.class)
                 .type(EventType.DATA_PLANE_DELETED)
                 .dataPlane(summary)
+                .principal(principal)
                 .throwable(throwable));
     }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
@@ -442,13 +442,9 @@ public class RoleServiceImpl implements RoleService {
         organizationPrimaryOwnerPermissions.put(Permission.ORGANIZATION_AUDIT, Acl.of(READ, LIST));
         organizationPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
         organizationPrimaryOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
-        organizationPrimaryOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
-        organizationPrimaryOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
 
         environmentPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
-        environmentPrimaryOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
-        environmentPrimaryOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         domainPrimaryOwnerPermissions.put(Permission.DOMAIN, Acl.of(READ, UPDATE, DELETE));
         domainPrimaryOwnerPermissions.put(Permission.DOMAIN_SETTINGS, Acl.of(READ, UPDATE, DELETE));
@@ -485,12 +481,8 @@ public class RoleServiceImpl implements RoleService {
         organizationOwnerPermissions.put(Permission.ORGANIZATION_AUDIT, Acl.of(READ, LIST));
         organizationOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
         organizationOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
-        organizationOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
-        organizationOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         environmentOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
-        environmentOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
-        environmentOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         domainOwnerPermissions.put(Permission.DOMAIN, Acl.of(READ, UPDATE));
         domainOwnerPermissions.put(Permission.DOMAIN_SETTINGS, Acl.of(READ, UPDATE));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/RoleServiceImpl.java
@@ -443,10 +443,12 @@ public class RoleServiceImpl implements RoleService {
         organizationPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
         organizationPrimaryOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
         organizationPrimaryOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
+        organizationPrimaryOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
 
         environmentPrimaryOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
         environmentPrimaryOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
+        environmentPrimaryOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         domainPrimaryOwnerPermissions.put(Permission.DOMAIN, Acl.of(READ, UPDATE, DELETE));
         domainPrimaryOwnerPermissions.put(Permission.DOMAIN_SETTINGS, Acl.of(READ, UPDATE, DELETE));
@@ -484,9 +486,11 @@ public class RoleServiceImpl implements RoleService {
         organizationOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ, LIST));
         organizationOwnerPermissions.put(Permission.LICENSE_NOTIFICATION, Acl.of(READ));
         organizationOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
+        organizationOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         environmentOwnerPermissions.put(Permission.ENVIRONMENT, Acl.of(READ));
         environmentOwnerPermissions.put(Permission.DATA_PLANE, Acl.of(READ, LIST));
+        environmentOwnerPermissions.remove(Permission.DATA_PLANE_MANAGED);
 
         domainOwnerPermissions.put(Permission.DOMAIN, Acl.of(READ, UPDATE));
         domainOwnerPermissions.put(Permission.DOMAIN_SETTINGS, Acl.of(READ, UPDATE));

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/DataPlaneDefinitionSummary.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/DataPlaneDefinitionSummary.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.service.model;
 
 import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.service.dataplane.config.DataPlaneConnectionSummary;
 
 import java.util.Date;
@@ -37,6 +38,7 @@ public record DataPlaneDefinitionSummary(
         String environmentId,
         String database,
         List<String> hosts,
+        ManagedBy managedBy,
         Date createdAt,
         Date updatedAt) {
 
@@ -50,6 +52,7 @@ public record DataPlaneDefinitionSummary(
                 definition.getEnvironmentId(),
                 connection.database(),
                 connection.hosts(),
+                definition.getManagedBy(),
                 definition.getCreatedAt(),
                 definition.getUpdatedAt());
     }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/DataPlaneDefinitionServiceTest.java
@@ -30,6 +30,7 @@ import io.gravitee.am.service.exception.TechnicalManagementException;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.dataplane.api.DataPlane;
 import io.gravitee.am.model.DataPlaneDefinition;
+import io.gravitee.am.model.ManagedBy;
 import io.gravitee.am.model.Environment;
 import io.gravitee.am.model.Organization;
 import io.gravitee.am.plugins.dataplane.core.DataPlanePluginManager;
@@ -84,6 +85,7 @@ import static org.mockito.Mockito.when;
 class DataPlaneDefinitionServiceTest {
 
     private static final String MONGO_CONFIGURATION = "{\"mongodb\": {\"dbname\": \"gravitee-am-acme\", \"host\": \"mongo\", \"port\": 27017}}";
+    private static final String JDBC_CONFIGURATION = "{\"jdbc\": {\"uri\": \"r2dbc:postgresql://pg:5432/gravitee-am-acme\"}}";
     private static final String MONGO_CONFIGURATION_WITH_SECRETS =
             "{\"mongodb\": {\"dbname\": \"gravitee-am-acme\", \"host\": \"mongo\", \"port\": 27017, \"username\": \"am-user\", \"password\": \"sup3r-s3cret\"}}";
 
@@ -144,7 +146,7 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldCreateWithDefaultOrganizationAndEnvironment() {
-        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload()).test();
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload(), ManagedBy.NONE, null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertComplete();
@@ -169,7 +171,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition payload = payload();
         payload.setConfiguration(readTree(MONGO_CONFIGURATION_WITH_SECRETS));
 
-        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload).test();
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload, ManagedBy.NONE, null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertValue(summary -> "dp-acme".equals(summary.id()));
@@ -183,7 +185,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition payload = payload();
         payload.setOrganizationId("org-1");
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         Audit audit = capturedAudit();
         assertThat(audit.getType()).isEqualTo(EventType.DATA_PLANE_CREATED);
@@ -199,7 +201,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition payload = payload();
         payload.setConfiguration(readTree(MONGO_CONFIGURATION_WITH_SECRETS));
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(capturedAudit().toString()).doesNotContain("sup3r-s3cret", "am-user", "configuration");
     }
@@ -208,7 +210,7 @@ class DataPlaneDefinitionServiceTest {
     void shouldReportAFailedAuditWhenThePersistFails() {
         doReturn(Single.error(new TechnicalManagementException("boom"))).when(dataPlaneDefinitionRepository).create(any());
 
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS)
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS)
                 .assertError(TechnicalManagementException.class);
 
         Audit audit = capturedAudit();
@@ -222,7 +224,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition payload = payload();
         payload.setId(null);
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS)
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS)
                 .assertError(InvalidParameterException.class);
 
         verify(auditService, never()).report(any());
@@ -240,7 +242,7 @@ class DataPlaneDefinitionServiceTest {
         payload.setOrganizationId("org-1");
         payload.setEnvironmentId("env-1");
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
         verify(dataPlaneDefinitionRepository).create(captor.capture());
@@ -251,7 +253,7 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldStoreTheConfigurationVerbatim() {
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS);
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS);
 
         ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
         verify(dataPlaneDefinitionRepository).create(captor.capture());
@@ -323,7 +325,7 @@ class DataPlaneDefinitionServiceTest {
     void shouldAcceptAConfigurationThatMatchesThePluginSchema() {
         registerMongoSchema();
 
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
     }
 
     @Test
@@ -340,7 +342,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition payload = payload();
         payload.setConfiguration(readTree("{\"mongodb\": {\"dbname\": \"acme\", \"host\": \"mongo\", \"port\": \"twenty-seven-thousand\"}}"));
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
     }
 
     private void registerMongoSchema() {
@@ -406,7 +408,7 @@ class DataPlaneDefinitionServiceTest {
         payload.setOrganizationHrid("acme");
         payload.setEnvironmentHrid("prod");
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
         verify(dataPlaneDefinitionRepository).create(captor.capture());
@@ -422,7 +424,7 @@ class DataPlaneDefinitionServiceTest {
         payload.setEnvironmentId("env-1");
         payload.setEnvironmentHrid("ignored-env");
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
         verify(dataPlaneDefinitionRepository).create(captor.capture());
@@ -439,7 +441,7 @@ class DataPlaneDefinitionServiceTest {
         payload.setOrganizationId("org-1");
         payload.setEnvironmentHrid("prod");
 
-        service.create(payload).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload, ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
         verify(dataPlaneDefinitionRepository).create(captor.capture());
@@ -495,7 +497,7 @@ class DataPlaneDefinitionServiceTest {
         NewDataPlaneDefinition second = payload();
         second.setId("dp-acme-2");
 
-        TestObserver<DataPlaneDefinitionSummary> observer = service.create(second).test();
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(second, ManagedBy.NONE, null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertComplete();
@@ -583,7 +585,7 @@ class DataPlaneDefinitionServiceTest {
         doReturn(Single.error(new TechnicalManagementException("duplicate key")))
                 .when(dataPlaneDefinitionRepository).create(any());
 
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS)
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS)
                 .assertError(DataPlaneDefinitionAlreadyExistsException.class);
     }
 
@@ -591,7 +593,7 @@ class DataPlaneDefinitionServiceTest {
     void shouldDeleteAndReportAnAudit() {
         when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
 
-        TestObserver<Void> observer = service.delete("dp-acme").test();
+        TestObserver<Void> observer = service.delete("dp-acme", null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertComplete();
@@ -607,7 +609,7 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldFailDeletingAnUnknownDefinition() {
-        TestObserver<Void> observer = service.delete("dp-missing").test();
+        TestObserver<Void> observer = service.delete("dp-missing", null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertError(DataPlaneDefinitionNotFoundException.class);
@@ -620,7 +622,7 @@ class DataPlaneDefinitionServiceTest {
         when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
         when(domainRepository.existsByDataPlaneId("dp-acme")).thenReturn(Single.just(true));
 
-        TestObserver<Void> observer = service.delete("dp-acme").test();
+        TestObserver<Void> observer = service.delete("dp-acme", null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertError(DataPlaneInUseByDomainsException.class);
@@ -637,14 +639,14 @@ class DataPlaneDefinitionServiceTest {
         withSecrets.setConfiguration(MONGO_CONFIGURATION_WITH_SECRETS);
         when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(withSecrets));
 
-        service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS);
+        service.delete("dp-acme", null).test().awaitDone(10, TimeUnit.SECONDS);
 
         assertThat(capturedAudit().toString()).doesNotContain("sup3r-s3cret", "am-user", "configuration");
     }
 
     @Test
     void shouldPublishADeployEventOnCreate() {
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         Payload payload = capturedEvent(Type.DATA_PLANE).getPayload();
         assertThat(payload.getId()).isEqualTo("dp-acme");
@@ -657,7 +659,7 @@ class DataPlaneDefinitionServiceTest {
     void shouldPublishAnUndeployEventOnDelete() {
         when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
 
-        service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+        service.delete("dp-acme", null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
 
         Payload payload = capturedEvent(Type.DATA_PLANE).getPayload();
         assertThat(payload.getId()).isEqualTo("dp-acme");
@@ -668,7 +670,7 @@ class DataPlaneDefinitionServiceTest {
 
     @Test
     void shouldNotScopeTheEventToASingleDataPlane() {
-        service.create(payload()).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+        service.create(payload(), ManagedBy.NONE, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
 
         Event event = capturedEvent(Type.DATA_PLANE);
         assertThat(event.getDataPlaneId()).isNull();
@@ -679,7 +681,7 @@ class DataPlaneDefinitionServiceTest {
     void shouldFailTheCreationWhenTheEventCannotBeWritten() {
         doReturn(Single.error(new TechnicalManagementException("events are down"))).when(eventService).create(any());
 
-        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload()).test();
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload(), ManagedBy.NONE, null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertError(TechnicalManagementException.class);
@@ -692,7 +694,7 @@ class DataPlaneDefinitionServiceTest {
         when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(definition("dp-acme", "env-1")));
         when(domainRepository.existsByDataPlaneId("dp-acme")).thenReturn(Single.just(true));
 
-        service.delete("dp-acme").test().awaitDone(10, TimeUnit.SECONDS)
+        service.delete("dp-acme", null).test().awaitDone(10, TimeUnit.SECONDS)
                 .assertError(DataPlaneInUseByDomainsException.class);
 
         verify(eventService, never()).create(any());
@@ -707,7 +709,7 @@ class DataPlaneDefinitionServiceTest {
     }
 
     private void assertRejected(NewDataPlaneDefinition payload, Class<? extends Throwable> type, String messageFragment) {
-        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload).test();
+        TestObserver<DataPlaneDefinitionSummary> observer = service.create(payload, ManagedBy.NONE, null).test();
         observer.awaitDone(10, TimeUnit.SECONDS);
 
         observer.assertError(type);
@@ -735,6 +737,191 @@ class DataPlaneDefinitionServiceTest {
         Environment environment = new Environment();
         environment.setId(id);
         return environment;
+    }
+
+    @Test
+    void shouldStampTheOwnerItIsCreatedWith() {
+        service.create(payload(), ManagedBy.AUTOMATION_API, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(capturedCreate().getManagedBy()).isEqualTo(ManagedBy.AUTOMATION_API);
+    }
+
+    @Test
+    void shouldUpdateTheMutableFields() {
+        DataPlaneDefinition stored = storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setName("Renamed");
+        payload.setGatewayUrl("https://gw-renamed.example.com");
+        payload.setConfiguration(readTree(MONGO_CONFIGURATION_WITH_SECRETS));
+
+        TestObserver<DataPlaneDefinitionSummary> observer = service.update("dp-acme", payload, null).test();
+        observer.awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+        observer.assertValue(summary -> "Renamed".equals(summary.name())
+                && "https://gw-renamed.example.com".equals(summary.gatewayUrl()));
+        assertThat(readTree(stored.getConfiguration())).isEqualTo(readTree(MONGO_CONFIGURATION_WITH_SECRETS));
+    }
+
+    @Test
+    void shouldLeaveOwnershipAloneOnUpdate() {
+        DataPlaneDefinition stored = storedDefinition();
+        stored.setManagedBy(ManagedBy.NONE);
+
+        service.update("dp-acme", payload(), null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(stored.getManagedBy()).isEqualTo(ManagedBy.NONE);
+    }
+
+    @Test
+    void shouldKeepTheCreationTimestampAndMoveTheUpdateOne() {
+        DataPlaneDefinition stored = storedDefinition();
+        Date createdAt = new Date(1_000_000L);
+        stored.setCreatedAt(createdAt);
+        stored.setUpdatedAt(createdAt);
+
+        service.update("dp-acme", payload(), null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(stored.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(stored.getUpdatedAt()).isAfter(createdAt);
+    }
+
+    @Test
+    void shouldRejectAnUnknownIdOnUpdate() {
+        service.update("dp-missing", payload(), null).test().awaitDone(10, TimeUnit.SECONDS)
+                .assertError(DataPlaneDefinitionNotFoundException.class);
+    }
+
+    @Test
+    void shouldRejectATypeChange() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setType("jdbc");
+        payload.setConfiguration(readTree(JDBC_CONFIGURATION));
+
+        assertUpdateRejected(payload, "'type' cannot be changed");
+    }
+
+    @Test
+    void shouldRejectAnEnvironmentChange() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setEnvironmentId("env-other");
+
+        assertUpdateRejected(payload, "'environmentId' cannot be changed");
+    }
+
+    @Test
+    void shouldRejectAnOrganizationChange() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setOrganizationId("org-other");
+
+        assertUpdateRejected(payload, "'organizationId' cannot be changed");
+    }
+
+    @Test
+    void shouldRejectAnIdReservedByTheConfigurationOnUpdate() {
+        storedDefinition();
+        when(configurationLoader.isDeclared("dp-acme")).thenReturn(true);
+
+        assertUpdateRejected(payload(), "reserved for a data plane declared in the gravitee.yml");
+    }
+
+    @Test
+    void shouldRejectAConfigurationTheTypeDoesNotAcceptOnUpdate() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setConfiguration(readTree("{\"mongodb\": {\"host\": \"mongo\"}}"));
+
+        assertUpdateRejected(payload, "dbname");
+    }
+
+    @Test
+    void shouldReportAnUpdateAudit() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setName("Renamed");
+
+        service.update("dp-acme", payload, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        Audit audit = capturedAudit();
+        assertThat(audit.getType()).isEqualTo(EventType.DATA_PLANE_UPDATED);
+        assertThat(audit.getTarget().getId()).isEqualTo("dp-acme");
+        assertThat(audit.getTarget().getType()).isEqualTo(EntityType.DATA_PLANE);
+        assertThat(audit.getOutcome().getStatus()).isEqualTo(Status.SUCCESS);
+    }
+
+    @Test
+    void shouldKeepCredentialsOutOfTheUpdateAudit() {
+        storedDefinition();
+        NewDataPlaneDefinition payload = payload();
+        payload.setConfiguration(readTree(MONGO_CONFIGURATION_WITH_SECRETS));
+
+        service.update("dp-acme", payload, null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        assertThat(capturedAudit().toString()).doesNotContain("sup3r-s3cret", "am-user", "configuration");
+    }
+
+    @Test
+    void shouldReportAFailedUpdateAudit() {
+        storedDefinition();
+        doReturn(Single.error(new TechnicalManagementException("boom"))).when(dataPlaneDefinitionRepository).update(any());
+
+        service.update("dp-acme", payload(), null).test().awaitDone(10, TimeUnit.SECONDS)
+                .assertError(TechnicalManagementException.class);
+
+        Audit audit = capturedAudit();
+        assertThat(audit.getType()).isEqualTo(EventType.DATA_PLANE_UPDATED);
+        assertThat(audit.getOutcome().getStatus()).isEqualTo(Status.FAILURE);
+    }
+
+    @Test
+    void shouldPublishAnUpdateEvent() {
+        storedDefinition();
+
+        service.update("dp-acme", payload(), null).test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        Payload eventPayload = capturedEvent(Type.DATA_PLANE).getPayload();
+        assertThat(eventPayload.getAction()).isEqualTo(Action.UPDATE);
+        assertThat(eventPayload.getId()).isEqualTo("dp-acme");
+        assertThat(eventPayload.getReferenceType()).isEqualTo(ReferenceType.ENVIRONMENT);
+        assertThat(eventPayload.getReferenceId()).isEqualTo(Environment.DEFAULT);
+    }
+
+    @Test
+    void shouldNotFailTheUpdateWhenTheEventCannotBePublished() {
+        storedDefinition();
+        doReturn(Single.error(new TechnicalManagementException("events are down"))).when(eventService).create(any());
+
+        service.update("dp-acme", payload(), null).test().awaitDone(10, TimeUnit.SECONDS)
+                .assertError(TechnicalManagementException.class);
+
+        // the audit still records the update: only the propagation failed
+        assertThat(capturedAudit().getOutcome().getStatus()).isEqualTo(Status.SUCCESS);
+    }
+
+    /** Puts a definition in the repository under the id {@link #payload()} uses, and returns it. */
+    private DataPlaneDefinition storedDefinition() {
+        DataPlaneDefinition stored = definition("dp-acme", Environment.DEFAULT);
+        stored.setManagedBy(ManagedBy.AUTOMATION_API);
+        when(dataPlaneDefinitionRepository.findById("dp-acme")).thenReturn(Maybe.just(stored));
+        when(dataPlaneDefinitionRepository.update(any())).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+        return stored;
+    }
+
+    private DataPlaneDefinition capturedCreate() {
+        ArgumentCaptor<DataPlaneDefinition> captor = ArgumentCaptor.forClass(DataPlaneDefinition.class);
+        verify(dataPlaneDefinitionRepository).create(captor.capture());
+        return captor.getValue();
+    }
+
+    private void assertUpdateRejected(NewDataPlaneDefinition payload, String messageFragment) {
+        TestObserver<DataPlaneDefinitionSummary> observer = service.update("dp-acme", payload, null).test();
+        observer.awaitDone(10, TimeUnit.SECONDS);
+
+        observer.assertError(InvalidParameterException.class);
+        observer.assertError(error -> error.getMessage().contains(messageFragment));
+        verify(dataPlaneDefinitionRepository, never()).update(any());
     }
 
     private DataPlaneDefinition definition(String id, String environmentId) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
@@ -41,22 +41,28 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -465,5 +471,50 @@ public class RoleServiceTest {
         testObserver.assertNoErrors();
 
         verify(roleRepository, times(1)).delete("my-role");
+    }
+
+    @Test
+    public void shouldNotGrantDataPlaneManagedToAnySystemRole() {
+        assertNoRoleGrantsDataPlaneManaged(seededRoles(roleService::createOrUpdateSystemRoles));
+    }
+
+    @Test
+    public void shouldNotGrantDataPlaneManagedToAnyDefaultRole() {
+        assertNoRoleGrantsDataPlaneManaged(seededRoles(() -> roleService.createDefaultRoles(ORGANIZATION_ID)));
+    }
+
+    @Test
+    public void shouldStillGrantReadOnlyDataPlaneToTheOwnerRoles() {
+        List<Role> roles = new ArrayList<>(seededRoles(roleService::createOrUpdateSystemRoles));
+        roles.addAll(seededRoles(() -> roleService.createDefaultRoles(ORGANIZATION_ID)));
+
+        List<Role> withDataPlane = roles.stream()
+                .filter(role -> role.getPermissionAcls().containsKey(Permission.DATA_PLANE))
+                .toList();
+
+        assertFalse("no role was seeded with the DATA_PLANE permission", withDataPlane.isEmpty());
+        withDataPlane.forEach(role ->
+                assertEquals("unexpected DATA_PLANE acls on " + role.getName(),
+                        Set.of(Acl.READ, Acl.LIST), role.getPermissionAcls().get(Permission.DATA_PLANE)));
+    }
+
+    /** Runs a seeding call against an empty repository and returns the roles it created. */
+    private List<Role> seededRoles(Supplier<Completable> seeding) {
+        when(roleRepository.findByNameAndAssignableType(any(), any(), anyString(), any())).thenReturn(Maybe.empty());
+        when(roleRepository.create(any(Role.class))).thenAnswer(invocation -> Single.just(invocation.getArgument(0)));
+        when(eventService.create(any(Event.class))).thenReturn(Single.just(new Event()));
+
+        seeding.get().test().awaitDone(10, TimeUnit.SECONDS).assertComplete();
+
+        ArgumentCaptor<Role> created = ArgumentCaptor.forClass(Role.class);
+        verify(roleRepository, atLeastOnce()).create(created.capture());
+        return created.getAllValues();
+    }
+
+    private static void assertNoRoleGrantsDataPlaneManaged(List<Role> roles) {
+        assertFalse("no role was seeded", roles.isEmpty());
+        roles.forEach(role -> assertFalse(
+                role.getName() + " must not carry DATA_PLANE_MANAGED",
+                role.getPermissionAcls().containsKey(Permission.DATA_PLANE_MANAGED)));
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/RoleServiceTest.java
@@ -474,26 +474,30 @@ public class RoleServiceTest {
     }
 
     @Test
-    public void shouldNotGrantDataPlaneManagedToAnySystemRole() {
-        assertNoRoleGrantsDataPlaneManaged(seededRoles(roleService::createOrUpdateSystemRoles));
-    }
-
-    @Test
-    public void shouldNotGrantDataPlaneManagedToAnyDefaultRole() {
-        assertNoRoleGrantsDataPlaneManaged(seededRoles(() -> roleService.createDefaultRoles(ORGANIZATION_ID)));
-    }
-
-    @Test
-    public void shouldStillGrantReadOnlyDataPlaneToTheOwnerRoles() {
+    public void shouldGrantEveryDataPlaneAclToTheOwnerRoles() {
         List<Role> roles = new ArrayList<>(seededRoles(roleService::createOrUpdateSystemRoles));
         roles.addAll(seededRoles(() -> roleService.createDefaultRoles(ORGANIZATION_ID)));
 
-        List<Role> withDataPlane = roles.stream()
+        List<Role> owners = roles.stream()
+                .filter(role -> role.getName().endsWith("_OWNER"))
                 .filter(role -> role.getPermissionAcls().containsKey(Permission.DATA_PLANE))
                 .toList();
 
-        assertFalse("no role was seeded with the DATA_PLANE permission", withDataPlane.isEmpty());
-        withDataPlane.forEach(role ->
+        assertFalse("no owner role was seeded with the DATA_PLANE permission", owners.isEmpty());
+        owners.forEach(role ->
+                assertEquals("unexpected DATA_PLANE acls on " + role.getName(),
+                        Acl.all(), role.getPermissionAcls().get(Permission.DATA_PLANE)));
+    }
+
+    @Test
+    public void shouldKeepDataPlaneReadOnlyForTheUserRoles() {
+        List<Role> users = seededRoles(() -> roleService.createDefaultRoles(ORGANIZATION_ID)).stream()
+                .filter(role -> role.getName().endsWith("_USER"))
+                .filter(role -> role.getPermissionAcls().containsKey(Permission.DATA_PLANE))
+                .toList();
+
+        assertFalse("no user role was seeded with the DATA_PLANE permission", users.isEmpty());
+        users.forEach(role ->
                 assertEquals("unexpected DATA_PLANE acls on " + role.getName(),
                         Set.of(Acl.READ, Acl.LIST), role.getPermissionAcls().get(Permission.DATA_PLANE)));
     }
@@ -511,10 +515,4 @@ public class RoleServiceTest {
         return created.getAllValues();
     }
 
-    private static void assertNoRoleGrantsDataPlaneManaged(List<Role> roles) {
-        assertFalse("no role was seeded", roles.isEmpty());
-        roles.forEach(role -> assertFalse(
-                role.getName() + " must not carry DATA_PLANE_MANAGED",
-                role.getPermissionAcls().containsKey(Permission.DATA_PLANE_MANAGED)));
-    }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/DataPlaneProvisioningServiceTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/DataPlaneProvisioningServiceTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.am.service.dataplane;
+
+import io.gravitee.am.model.ManagedBy;
+import io.gravitee.am.service.DataPlaneDefinitionService;
+import io.gravitee.am.service.exception.DataPlaneInUseByDomainsException;
+import io.gravitee.am.service.model.DataPlaneDefinitionSummary;
+import io.gravitee.am.service.model.NewDataPlaneDefinition;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class DataPlaneProvisioningServiceTest {
+
+    private static final String DATA_PLANE_ID = "dp-acme";
+
+    @Mock
+    private DataPlaneDefinitionService dataPlaneDefinitionService;
+
+    @Mock
+    private ProvisionedDataPlaneLoader provisionedDataPlaneLoader;
+
+    private DataPlaneProvisioningService provisioningService() {
+        return new DataPlaneProvisioningService(dataPlaneDefinitionService, provisionedDataPlaneLoader);
+    }
+
+    @Test
+    void should_serve_a_provisioned_data_plane_on_this_node() {
+        var definition = new NewDataPlaneDefinition();
+        when(dataPlaneDefinitionService.create(definition, ManagedBy.NONE, null)).thenReturn(Single.just(summary()));
+        when(provisionedDataPlaneLoader.activate(DATA_PLANE_ID)).thenReturn(Completable.complete());
+
+        provisioningService().provision(definition, ManagedBy.NONE, null).test()
+                .assertValue(summary -> DATA_PLANE_ID.equals(summary.id()));
+
+        InOrder inOrder = inOrder(dataPlaneDefinitionService, provisionedDataPlaneLoader);
+        inOrder.verify(dataPlaneDefinitionService).create(definition, ManagedBy.NONE, null);
+        inOrder.verify(provisionedDataPlaneLoader).activate(DATA_PLANE_ID);
+    }
+
+    @Test
+    void should_not_serve_a_data_plane_that_was_not_stored() {
+        var definition = new NewDataPlaneDefinition();
+        when(dataPlaneDefinitionService.create(any(), any(), any()))
+                .thenReturn(Single.error(new IllegalStateException("connection lost")));
+
+        provisioningService().provision(definition, ManagedBy.NONE, null).test()
+                .assertError(IllegalStateException.class);
+
+        verify(provisionedDataPlaneLoader, never()).activate(anyString());
+    }
+
+    @Test
+    void should_rebuild_the_provider_of_a_reprovisioned_data_plane() {
+        var definition = new NewDataPlaneDefinition();
+        when(dataPlaneDefinitionService.update(DATA_PLANE_ID, definition, null)).thenReturn(Single.just(summary()));
+        when(provisionedDataPlaneLoader.activate(DATA_PLANE_ID)).thenReturn(Completable.complete());
+
+        provisioningService().reprovision(DATA_PLANE_ID, definition, null).test()
+                .assertValue(summary -> DATA_PLANE_ID.equals(summary.id()));
+
+        InOrder inOrder = inOrder(dataPlaneDefinitionService, provisionedDataPlaneLoader);
+        inOrder.verify(dataPlaneDefinitionService).update(DATA_PLANE_ID, definition, null);
+        inOrder.verify(provisionedDataPlaneLoader).activate(DATA_PLANE_ID);
+    }
+
+    @Test
+    void should_keep_serving_a_data_plane_whose_new_configuration_was_refused() {
+        when(dataPlaneDefinitionService.update(anyString(), any(), any()))
+                .thenReturn(Single.error(new IllegalStateException("connection lost")));
+
+        provisioningService().reprovision(DATA_PLANE_ID, new NewDataPlaneDefinition(), null).test()
+                .assertError(IllegalStateException.class);
+
+        verify(provisionedDataPlaneLoader, never()).activate(anyString());
+    }
+
+    @Test
+    void should_stop_serving_a_deprovisioned_data_plane_on_this_node() {
+        when(dataPlaneDefinitionService.delete(DATA_PLANE_ID, null)).thenReturn(Completable.complete());
+
+        provisioningService().deprovision(DATA_PLANE_ID, null).test().assertComplete();
+
+        InOrder inOrder = inOrder(dataPlaneDefinitionService, provisionedDataPlaneLoader);
+        inOrder.verify(dataPlaneDefinitionService).delete(DATA_PLANE_ID, null);
+        inOrder.verify(provisionedDataPlaneLoader).deactivate(DATA_PLANE_ID);
+    }
+
+    @Test
+    void should_keep_serving_a_data_plane_whose_deletion_was_refused() {
+        when(dataPlaneDefinitionService.delete(anyString(), any()))
+                .thenReturn(Completable.error(new DataPlaneInUseByDomainsException(DATA_PLANE_ID)));
+
+        provisioningService().deprovision(DATA_PLANE_ID, null).test()
+                .assertError(DataPlaneInUseByDomainsException.class);
+
+        verify(provisionedDataPlaneLoader, never()).deactivate(anyString());
+    }
+
+    private static DataPlaneDefinitionSummary summary() {
+        return new DataPlaneDefinitionSummary(DATA_PLANE_ID, "ACME", "mongodb", "https://gateway", "org", "env",
+                "gravitee-am", List.of("mongo:27017"), ManagedBy.NONE, null, null);
+    }
+}

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -474,7 +474,7 @@ class ProvisionedDataPlaneLoaderTest {
         loader.load(loaded::add);
         clearInvocations(registry);
 
-        loader.reload("dp-1").test().assertComplete();
+        loader.activate("dp-1").test().assertComplete();
 
         InOrder inOrder = inOrder(registry);
         inOrder.verify(registry).unregister("dp-1");
@@ -493,17 +493,46 @@ class ProvisionedDataPlaneLoaderTest {
         loader.setRegistry(registry);
         loader.load(loaded::add);
 
-        loader.reload("dp-2").test().assertComplete();
+        loader.activate("dp-2").test().assertComplete();
 
         verify(registry).registerProvisioned(argThat(description -> "dp-2".equals(description.id())));
     }
 
     @Test
-    void should_ignore_a_reload_that_arrives_before_the_registry_has_started() {
+    void should_ignore_an_activation_that_arrives_before_the_registry_has_started() {
         var loader = loader();
 
-        loader.reload("dp-1").test().assertComplete();
+        loader.activate("dp-1").test().assertComplete();
 
         verify(dataPlaneDefinitionRepository, never()).findById(anyString());
+    }
+
+    @Test
+    void should_stop_serving_a_deactivated_definition() {
+        var registry = mock(DataPlaneRegistry.class);
+        var definition = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://gone:27017/db\"}}");
+        definition.setUpdatedAt(new Date(1_000L));
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(definition));
+        var loader = loader();
+        loader.setRegistry(registry);
+        loader.load(loaded::add);
+
+        loader.deactivate("dp-1");
+
+        verify(registry).unregister("dp-1");
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isNull();
+        assertThat(loader.isServing(definition)).isFalse();
+    }
+
+    @Test
+    void should_deactivate_a_definition_before_the_registry_has_been_wired_in() {
+        when(dataPlaneDefinitionRepository.findAll())
+                .thenReturn(Flowable.just(definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://gone:27017/db\"}}")));
+        var loader = loader();
+        loader.load(loaded::add);
+
+        loader.deactivate("dp-1");
+
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isNull();
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/dataplane/ProvisionedDataPlaneLoaderTest.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -36,8 +37,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -454,5 +458,52 @@ class ProvisionedDataPlaneLoaderTest {
         loader.forget("dp-1");
 
         assertThat(loader.isServing(definition)).isFalse();
+    }
+
+    @Test
+    void should_swap_the_provider_of_a_definition_this_node_already_serves() {
+        var registry = mock(DataPlaneRegistry.class);
+        var original = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://old:27017/db\"}}");
+        original.setUpdatedAt(new Date(1_000L));
+        var changed = definition("dp-1", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://new:27017/db\"}}");
+        changed.setUpdatedAt(new Date(2_000L));
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.just(original));
+        when(dataPlaneDefinitionRepository.findById("dp-1")).thenReturn(Maybe.just(changed));
+        var loader = loader();
+        loader.setRegistry(registry);
+        loader.load(loaded::add);
+        clearInvocations(registry);
+
+        loader.reload("dp-1").test().assertComplete();
+
+        InOrder inOrder = inOrder(registry);
+        inOrder.verify(registry).unregister("dp-1");
+        inOrder.verify(registry).registerProvisioned(argThat(description -> "dp-1".equals(description.id())));
+        assertThat(environment.getProperty("dataPlanes.provisioned.dp-1.mongodb.uri")).isEqualTo("mongodb://new:27017/db");
+        assertThat(loader.isServing(changed)).isTrue();
+    }
+
+    @Test
+    void should_register_a_definition_this_node_does_not_serve_yet() {
+        var registry = mock(DataPlaneRegistry.class);
+        var definition = definition("dp-2", "mongodb", "{\"mongodb\":{\"uri\":\"mongodb://h:27017/db\"}}");
+        when(dataPlaneDefinitionRepository.findAll()).thenReturn(Flowable.empty());
+        when(dataPlaneDefinitionRepository.findById("dp-2")).thenReturn(Maybe.just(definition));
+        var loader = loader();
+        loader.setRegistry(registry);
+        loader.load(loaded::add);
+
+        loader.reload("dp-2").test().assertComplete();
+
+        verify(registry).registerProvisioned(argThat(description -> "dp-2".equals(description.id())));
+    }
+
+    @Test
+    void should_ignore_a_reload_that_arrives_before_the_registry_has_started() {
+        var loader = loader();
+
+        loader.reload("dp-1").test().assertComplete();
+
+        verify(dataPlaneDefinitionRepository, never()).findById(anyString());
     }
 }

--- a/gravitee-am-test/api/commands/management/dataplane-provisioning-commands.ts
+++ b/gravitee-am-test/api/commands/management/dataplane-provisioning-commands.ts
@@ -33,6 +33,7 @@ export type DataPlaneSummary = {
   environmentId: string;
   database?: string;
   hosts: string[];
+  managedBy?: string;
   createdAt: number;
   updatedAt: number;
 };

--- a/gravitee-am-test/specs/management/automation/dataplanes.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/dataplanes.jest.spec.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  AutomationDataPlaneFixture,
+  READ_FIELDS,
+  SECRET_PASSWORD,
+  SECRET_USERNAME,
+  connectablePayload,
+  dataPlanePayload,
+  jdbcPayload,
+  setupAutomationDataPlaneFixture,
+} from './fixtures/automation-dataplane-fixture';
+import { createDomain, safeDeleteDomain } from '@management-commands/domain-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+
+setup(200000);
+
+let fixture: AutomationDataPlaneFixture;
+
+beforeAll(async () => {
+  fixture = await setupAutomationDataPlaneFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+const expectNoCredentials = (response: { text?: string; body: unknown }) => {
+  const raw = response.text ?? JSON.stringify(response.body);
+  expect(raw).not.toContain(SECRET_PASSWORD);
+  expect(raw).not.toContain(SECRET_USERNAME);
+  expect(raw).not.toContain('configuration');
+};
+
+describe('Automation API data planes - the permission is granted to no built-in role', () => {
+  it('should refuse a write from the admin, who is ORGANIZATION_PRIMARY_OWNER', async () => {
+    const id = fixture.reserveId('dp-denied');
+
+    const response = await fixture.adminClient.putDataPlane(dataPlanePayload(id));
+
+    // the Automation API answers a denied permission with a bare 403 and no body
+    expect(response.status).toBe(403);
+  });
+
+  it('should refuse a delete from the admin', async () => {
+    const id = fixture.reserveId('dp-admin-del');
+    expect((await fixture.client.putDataPlane(dataPlanePayload(id))).status).toBe(200);
+
+    const response = await fixture.adminClient.deleteDataPlane(id);
+
+    expect(response.status).toBe(403);
+    expect((await fixture.client.getDataPlane(id)).status).toBe(200);
+  });
+
+  it('should still let the admin read data planes', async () => {
+    const id = fixture.reserveId('dp-admin-read');
+    expect((await fixture.client.putDataPlane(dataPlanePayload(id))).status).toBe(200);
+
+    // reads use the pre-existing data_plane permission, which the built-in roles do have
+    expect((await fixture.adminClient.listDataPlanes()).status).toBe(200);
+    expect((await fixture.adminClient.getDataPlane(id)).status).toBe(200);
+  });
+
+  it('should accept a write from a custom role carrying the permission', async () => {
+    const id = fixture.reserveId('dp-granted');
+
+    const response = await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual(id);
+  });
+});
+
+describe('Automation API data planes - create, read and replay', () => {
+  it('should return the connection summary and never the settings', async () => {
+    const id = fixture.reserveId('dp-summary');
+
+    const created = await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    expect(created.status).toBe(200);
+    expect(created.body.database).toEqual('gravitee-am-e2e-dataplane');
+    expect(created.body.hosts).toEqual([expect.any(String)]);
+    expect(Object.keys(created.body).sort()).toEqual(expect.arrayContaining(['id', 'database', 'hosts']));
+    expect(Object.keys(created.body).every((field) => READ_FIELDS.includes(field))).toBe(true);
+    expectNoCredentials(created);
+  });
+
+  it('should not leak the settings on a read or a list either', async () => {
+    const id = fixture.reserveId('dp-noleak');
+    await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    expectNoCredentials(await fixture.client.getDataPlane(id));
+    expectNoCredentials(await fixture.client.listDataPlanes());
+  });
+
+  it('should list the data plane it created', async () => {
+    const id = fixture.reserveId('dp-listed');
+    await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    const response = await fixture.client.listDataPlanes();
+
+    expect(response.status).toBe(200);
+    expect(response.body.map((dataPlane) => dataPlane.id)).toContain(id);
+  });
+
+  it('should replay the same definition without changing what it created', async () => {
+    const id = fixture.reserveId('dp-replay');
+    const first = await fixture.client.putDataPlane(dataPlanePayload(id));
+    expect(first.status).toBe(200);
+
+    const second = await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    expect(second.status).toBe(200);
+    expect(second.body.createdAt).toEqual(first.body.createdAt);
+    expect(new Date(second.body.updatedAt).getTime()).toBeGreaterThanOrEqual(new Date(first.body.updatedAt).getTime());
+  });
+
+  it('should return 404 for a data plane that does not exist', async () => {
+    const response = await fixture.client.getDataPlane('dp-never-provisioned');
+
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('Automation API data planes - update', () => {
+  it('should apply a new name and gateway url', async () => {
+    const id = fixture.reserveId('dp-renamed');
+    await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    const updated = await fixture.client.putDataPlane(
+      dataPlanePayload(id, { name: 'Renamed data plane', gatewayUrl: 'https://gateway-renamed.example.com' }),
+    );
+
+    expect(updated.status).toBe(200);
+    const read = await fixture.client.getDataPlane(id);
+    expect(read.body.name).toEqual('Renamed data plane');
+    expect(read.body.gatewayUrl).toEqual('https://gateway-renamed.example.com');
+  });
+
+  it('should refuse a type change', async () => {
+    const id = fixture.reserveId('dp-retyped');
+    await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    const response = await fixture.client.putDataPlane(jdbcPayload(id));
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain("'type' cannot be changed");
+  });
+
+  it('should refuse an id reserved by the gravitee.yml', async () => {
+    const response = await fixture.client.putDataPlane(dataPlanePayload('default'));
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain('reserved');
+  });
+});
+
+describe('Automation API data planes - a domain keeps the plane it was created on', () => {
+  it('should refuse an apply that moves a domain to another data plane', async () => {
+    const id = fixture.reserveId('dp-pinned');
+    expect((await fixture.client.putDataPlane(connectablePayload(id))).status).toBe(200);
+
+    const domainKey = uniqueName(`dp-pinned-domain-${process.pid}`, true).toLowerCase();
+    const domain = { key: domainKey, name: domainKey, path: `/${domainKey}`, dataPlaneId: id };
+    expect((await fixture.adminClient.putDomain(domain)).status).toBe(200);
+
+    try {
+      const moved = await fixture.adminClient.putDomain({ ...domain, dataPlaneId: 'default' });
+
+      expect(moved.status).toBe(400);
+      expect(moved.body.message).toContain('[dataPlaneId] cannot be changed');
+      expect((await fixture.adminClient.putDomain(domain)).status).toBe(200);
+    } finally {
+      await fixture.adminClient.deleteDomain(domainKey);
+    }
+  });
+});
+
+describe('Automation API data planes - delete', () => {
+  it('should refuse to delete a data plane a domain still references', async () => {
+    const id = fixture.reserveId('dp-bound');
+    expect((await fixture.client.putDataPlane(connectablePayload(id))).status).toBe(200);
+
+    // binding only succeeds if the write registered the data plane on the node serving this request
+    const domain = await createDomain(fixture.adminToken, uniqueName('dp-bound-domain', true), 'Bound to a data plane', id);
+    expect(domain.dataPlaneId).toEqual(id);
+
+    const refused = await fixture.client.deleteDataPlane(id);
+    expect(refused.status).toBe(409);
+
+    await safeDeleteDomain(domain.id, fixture.adminToken);
+
+    const accepted = await fixture.client.deleteDataPlane(id);
+    expect(accepted.status).toBe(204);
+  });
+
+  it('should return 204 when deleting a data plane that does not exist', async () => {
+    const response = await fixture.client.deleteDataPlane('dp-never-provisioned');
+
+    expect(response.status).toBe(204);
+  });
+
+  it('should make the data plane unreadable once deleted', async () => {
+    const id = fixture.reserveId('dp-gone');
+    await fixture.client.putDataPlane(dataPlanePayload(id));
+
+    expect((await fixture.client.deleteDataPlane(id)).status).toBe(204);
+    expect((await fixture.client.getDataPlane(id)).status).toBe(404);
+  });
+});

--- a/gravitee-am-test/specs/management/automation/dataplanes.jest.spec.ts
+++ b/gravitee-am-test/specs/management/automation/dataplanes.jest.spec.ts
@@ -50,45 +50,6 @@ const expectNoCredentials = (response: { text?: string; body: unknown }) => {
   expect(raw).not.toContain('configuration');
 };
 
-describe('Automation API data planes - the permission is granted to no built-in role', () => {
-  it('should refuse a write from the admin, who is ORGANIZATION_PRIMARY_OWNER', async () => {
-    const id = fixture.reserveId('dp-denied');
-
-    const response = await fixture.adminClient.putDataPlane(dataPlanePayload(id));
-
-    // the Automation API answers a denied permission with a bare 403 and no body
-    expect(response.status).toBe(403);
-  });
-
-  it('should refuse a delete from the admin', async () => {
-    const id = fixture.reserveId('dp-admin-del');
-    expect((await fixture.client.putDataPlane(dataPlanePayload(id))).status).toBe(200);
-
-    const response = await fixture.adminClient.deleteDataPlane(id);
-
-    expect(response.status).toBe(403);
-    expect((await fixture.client.getDataPlane(id)).status).toBe(200);
-  });
-
-  it('should still let the admin read data planes', async () => {
-    const id = fixture.reserveId('dp-admin-read');
-    expect((await fixture.client.putDataPlane(dataPlanePayload(id))).status).toBe(200);
-
-    // reads use the pre-existing data_plane permission, which the built-in roles do have
-    expect((await fixture.adminClient.listDataPlanes()).status).toBe(200);
-    expect((await fixture.adminClient.getDataPlane(id)).status).toBe(200);
-  });
-
-  it('should accept a write from a custom role carrying the permission', async () => {
-    const id = fixture.reserveId('dp-granted');
-
-    const response = await fixture.client.putDataPlane(dataPlanePayload(id));
-
-    expect(response.status).toBe(200);
-    expect(response.body.id).toEqual(id);
-  });
-});
-
 describe('Automation API data planes - create, read and replay', () => {
   it('should return the connection summary and never the settings', async () => {
     const id = fixture.reserveId('dp-summary');
@@ -180,16 +141,16 @@ describe('Automation API data planes - a domain keeps the plane it was created o
 
     const domainKey = uniqueName(`dp-pinned-domain-${process.pid}`, true).toLowerCase();
     const domain = { key: domainKey, name: domainKey, path: `/${domainKey}`, dataPlaneId: id };
-    expect((await fixture.adminClient.putDomain(domain)).status).toBe(200);
+    expect((await fixture.client.putDomain(domain)).status).toBe(200);
 
     try {
-      const moved = await fixture.adminClient.putDomain({ ...domain, dataPlaneId: 'default' });
+      const moved = await fixture.client.putDomain({ ...domain, dataPlaneId: 'default' });
 
       expect(moved.status).toBe(400);
       expect(moved.body.message).toContain('[dataPlaneId] cannot be changed');
-      expect((await fixture.adminClient.putDomain(domain)).status).toBe(200);
+      expect((await fixture.client.putDomain(domain)).status).toBe(200);
     } finally {
-      await fixture.adminClient.deleteDomain(domainKey);
+      await fixture.client.deleteDomain(domainKey);
     }
   });
 });

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-client.ts
@@ -17,8 +17,7 @@ import { performDelete, performGet, performPut } from '@gateway-commands/oauth-o
 
 export const automationUrl = (): string => `${process.env.AM_MANAGEMENT_URL}/automation`;
 
-export const envPath = (): string =>
-  `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}`;
+export const envPath = (): string => `/organizations/${process.env.AM_DEF_ORG_ID}/environments/${process.env.AM_DEF_ENV_ID}`;
 
 export const jsonHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
   'Content-Type': 'application/json',
@@ -110,6 +109,24 @@ export class AutomationClient {
 
   deleteReporter(domainKey: string, reporterKey: string) {
     return performDelete(automationUrl(), `${envPath()}/domains/${domainKey}/reporters/${reporterKey}`, this.headers());
+  }
+
+  // ---- Data planes (under an environment) --------------------------------
+
+  listDataPlanes() {
+    return performGet(automationUrl(), `${envPath()}/dataplanes`, this.headers());
+  }
+
+  putDataPlane(definition: object) {
+    return performPut(automationUrl(), `${envPath()}/dataplanes`, definition, this.headers());
+  }
+
+  getDataPlane(reference: string) {
+    return performGet(automationUrl(), `${envPath()}/dataplanes/${reference}`, this.headers());
+  }
+
+  deleteDataPlane(reference: string) {
+    return performDelete(automationUrl(), `${envPath()}/dataplanes/${reference}`, this.headers());
   }
 
   // ---- Generic escape hatches (auth + path) -----------------------------

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-dataplane-fixture.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-dataplane-fixture.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import { expect } from '@jest/globals';
-import { requestAccessToken, requestAdminAccessToken } from '@management-commands/token-management-commands';
-import { createOrganisationUser, deleteOrganisationUser } from '@management-commands/organisation-user-commands';
-import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
-import { addOrganizationMembership, userMembership } from '@management-commands/membership-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { uniqueName } from '@utils-commands/misc';
 import { JWT_FORMAT } from '@specs-utils/jwt-format';
 import { Fixture } from '../../../test-fixture';
@@ -110,25 +107,11 @@ export const connectablePayload = (id: string) =>
       };
 
 export interface AutomationDataPlaneFixture extends Fixture {
-  /** Admin JWT. The admin is ORGANIZATION_PRIMARY_OWNER. */
   adminToken: string;
-  adminClient: AutomationClient;
-  /** Client acting as a user holding the custom data-plane role. */
   client: AutomationClient;
   /** Mints a unique id and registers it for cleanup. */
   reserveId: (prefix?: string) => string;
 }
-
-/** Flattened permissions the Automation API's data plane endpoints require. */
-export const DATA_PLANE_PERMISSIONS = [
-  'data_plane_managed_create',
-  'data_plane_managed_update',
-  'data_plane_managed_delete',
-  'data_plane_read',
-  'data_plane_list',
-];
-
-const PASSWORD = 'DataPl@neP@ssw0rd1!';
 
 /**
  * Ids are tracked per fixture instance, never swept from the environment: jest runs spec files on
@@ -138,64 +121,21 @@ export const setupAutomationDataPlaneFixture = async (): Promise<AutomationDataP
   const adminToken = await requestAdminAccessToken();
   expect(adminToken).toMatch(JWT_FORMAT);
 
+  const client = new AutomationClient(adminToken);
   const reserved: string[] = [];
-  let roleId: string | undefined;
-  let userId: string | undefined;
 
-  try {
-    const role = await createCustomOrganizationRole(
-      adminToken,
-      uniqueName('dataplane-operator', true),
-      'ORGANIZATION',
-      DATA_PLANE_PERMISSIONS,
-    );
-    roleId = role.id;
-
-    const username = uniqueName(`dpop-${process.pid}`, true).toLowerCase();
-    const user = await createOrganisationUser(adminToken, {
-      firstName: 'DataPlane',
-      lastName: 'Operator',
-      email: `${username}@test.com`,
-      username,
-      password: PASSWORD,
-      preRegistration: false,
-    });
-    userId = user.id;
-    await addOrganizationMembership(adminToken, userMembership(user.id, role.id));
-
-    const operatorToken = await requestAccessToken(username, PASSWORD);
-    expect(operatorToken).toMatch(JWT_FORMAT);
-
-    const client = new AutomationClient(operatorToken);
-
-    return {
-      adminToken,
-      adminClient: new AutomationClient(adminToken),
-      client,
-      reserveId: (prefix = 'dp-auto') => {
-        const id = uniqueName(`${prefix}-${process.pid}`, true).toLowerCase();
-        reserved.push(id);
-        return id;
-      },
-      cleanUp: async () => {
-        for (const id of reserved) {
-          await client.deleteDataPlane(id).catch(() => undefined);
-        }
-        if (userId) {
-          await deleteOrganisationUser(adminToken, userId).catch(() => undefined);
-        }
-        if (roleId) {
-          await deleteOrganizationRole(adminToken, roleId).catch(() => undefined);
-        }
-      },
-    };
-  } catch (error) {
-    if (userId) {
-      await deleteOrganisationUser(adminToken, userId).catch(() => undefined);
-    }
-    if (roleId) {
-      await deleteOrganizationRole(adminToken, roleId).catch(() => undefined);
-    }
-    throw error;
-  }
+  return {
+    adminToken,
+    client,
+    reserveId: (prefix = 'dp-auto') => {
+      const id = uniqueName(`${prefix}-${process.pid}`, true).toLowerCase();
+      reserved.push(id);
+      return id;
+    },
+    cleanUp: async () => {
+      for (const id of reserved) {
+        await client.deleteDataPlane(id).catch(() => undefined);
+      }
+    },
+  };
 };

--- a/gravitee-am-test/specs/management/automation/fixtures/automation-dataplane-fixture.ts
+++ b/gravitee-am-test/specs/management/automation/fixtures/automation-dataplane-fixture.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { requestAccessToken, requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createOrganisationUser, deleteOrganisationUser } from '@management-commands/organisation-user-commands';
+import { createCustomOrganizationRole, deleteOrganizationRole } from '@management-commands/role-management-commands';
+import { addOrganizationMembership, userMembership } from '@management-commands/membership-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { JWT_FORMAT } from '@specs-utils/jwt-format';
+import { Fixture } from '../../../test-fixture';
+import { AutomationClient } from './automation-client';
+
+const mongoUri = new URL(process.env.AM_INTERNAL_MONGODB_URI ?? process.env.AM_MONGODB_URI);
+const MONGO_HOST = mongoUri.hostname;
+const MONGO_PORT = Number(mongoUri.port);
+const JDBC_HOST = process.env.AM_INTERNAL_POSTGRES_HOST ?? process.env.AM_POSTGRES_HOST;
+const JDBC_PORT = 5432;
+
+export const SECRET_USERNAME = 'am-e2e-user';
+export const SECRET_PASSWORD = 'sup3r-s3cret-e2e';
+
+/** Every field a read is allowed to return. Anything else is a leak, `configuration` above all. */
+export const READ_FIELDS = [
+  'id',
+  'name',
+  'type',
+  'gatewayUrl',
+  'database',
+  'hosts',
+  'organizationId',
+  'environmentId',
+  'createdAt',
+  'updatedAt',
+];
+
+/** Provisioning validates the shape only, so the fake credentials double as the leak assertions' needles. */
+export const dataPlanePayload = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  name: 'E2E automation data plane',
+  type: 'mongodb',
+  gatewayUrl: process.env.AM_GATEWAY_URL,
+  configuration: {
+    mongodb: {
+      dbname: 'gravitee-am-e2e-dataplane',
+      host: MONGO_HOST,
+      port: MONGO_PORT,
+      username: SECRET_USERNAME,
+      password: SECRET_PASSWORD,
+    },
+  },
+  ...overrides,
+});
+
+/** The other type, for the immutable-`type` case. */
+export const jdbcPayload = (id: string) => ({
+  id,
+  name: 'E2E automation data plane',
+  type: 'jdbc',
+  configuration: {
+    jdbc: {
+      driver: 'postgresql',
+      host: JDBC_HOST,
+      port: JDBC_PORT,
+      database: 'gravitee-am-e2e-dataplane',
+      username: SECRET_USERNAME,
+      password: SECRET_PASSWORD,
+    },
+  },
+});
+
+/**
+ * A data plane whose store the management API can actually reach, so the registry verifies it and a
+ * domain can be bound to it.
+ */
+export const connectablePayload = (id: string) =>
+  process.env.REPOSITORY_TYPE === 'jdbc'
+    ? {
+        id,
+        name: 'E2E connectable automation data plane',
+        type: 'jdbc',
+        configuration: {
+          jdbc: {
+            driver: 'postgresql',
+            host: JDBC_HOST,
+            port: JDBC_PORT,
+            database: 'postgres',
+            username: 'postgres',
+            password: 'postgres',
+          },
+        },
+      }
+    : {
+        id,
+        name: 'E2E connectable automation data plane',
+        type: 'mongodb',
+        configuration: { mongodb: { dbname: 'gravitee-am', host: MONGO_HOST, port: MONGO_PORT } },
+      };
+
+export interface AutomationDataPlaneFixture extends Fixture {
+  /** Admin JWT. The admin is ORGANIZATION_PRIMARY_OWNER. */
+  adminToken: string;
+  adminClient: AutomationClient;
+  /** Client acting as a user holding the custom data-plane role. */
+  client: AutomationClient;
+  /** Mints a unique id and registers it for cleanup. */
+  reserveId: (prefix?: string) => string;
+}
+
+/** Flattened permissions the Automation API's data plane endpoints require. */
+export const DATA_PLANE_PERMISSIONS = [
+  'data_plane_managed_create',
+  'data_plane_managed_update',
+  'data_plane_managed_delete',
+  'data_plane_read',
+  'data_plane_list',
+];
+
+const PASSWORD = 'DataPl@neP@ssw0rd1!';
+
+/**
+ * Ids are tracked per fixture instance, never swept from the environment: jest runs spec files on
+ * separate workers, and a sweep would delete data planes another worker is still bound to.
+ */
+export const setupAutomationDataPlaneFixture = async (): Promise<AutomationDataPlaneFixture> => {
+  const adminToken = await requestAdminAccessToken();
+  expect(adminToken).toMatch(JWT_FORMAT);
+
+  const reserved: string[] = [];
+  let roleId: string | undefined;
+  let userId: string | undefined;
+
+  try {
+    const role = await createCustomOrganizationRole(
+      adminToken,
+      uniqueName('dataplane-operator', true),
+      'ORGANIZATION',
+      DATA_PLANE_PERMISSIONS,
+    );
+    roleId = role.id;
+
+    const username = uniqueName(`dpop-${process.pid}`, true).toLowerCase();
+    const user = await createOrganisationUser(adminToken, {
+      firstName: 'DataPlane',
+      lastName: 'Operator',
+      email: `${username}@test.com`,
+      username,
+      password: PASSWORD,
+      preRegistration: false,
+    });
+    userId = user.id;
+    await addOrganizationMembership(adminToken, userMembership(user.id, role.id));
+
+    const operatorToken = await requestAccessToken(username, PASSWORD);
+    expect(operatorToken).toMatch(JWT_FORMAT);
+
+    const client = new AutomationClient(operatorToken);
+
+    return {
+      adminToken,
+      adminClient: new AutomationClient(adminToken),
+      client,
+      reserveId: (prefix = 'dp-auto') => {
+        const id = uniqueName(`${prefix}-${process.pid}`, true).toLowerCase();
+        reserved.push(id);
+        return id;
+      },
+      cleanUp: async () => {
+        for (const id of reserved) {
+          await client.deleteDataPlane(id).catch(() => undefined);
+        }
+        if (userId) {
+          await deleteOrganisationUser(adminToken, userId).catch(() => undefined);
+        }
+        if (roleId) {
+          await deleteOrganizationRole(adminToken, roleId).catch(() => undefined);
+        }
+      },
+    };
+  } catch (error) {
+    if (userId) {
+      await deleteOrganisationUser(adminToken, userId).catch(() => undefined);
+    }
+    if (roleId) {
+      await deleteOrganizationRole(adminToken, roleId).catch(() => undefined);
+    }
+    throw error;
+  }
+};

--- a/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
+++ b/gravitee-am-test/specs/management/internal-api/fixtures/dataplane-provisioning-fixture.ts
@@ -305,6 +305,7 @@ export const ALLOWED_SUMMARY_FIELDS = [
   'environmentId',
   'database',
   'hosts',
+  'managedBy',
   'createdAt',
   'updatedAt',
 ];


### PR DESCRIPTION
## :id: Reference related issue. 
[AM-7639](https://gravitee.atlassian.net/browse/AM-7639)

## :pencil2: A description of the changes proposed in the pull request
Expose data planes in automation API. Endpoints:
- `GET /organizations/{orgId}/environments/{envId}/dataplanes`
- `PUT /organizations/{orgId}/environments/{envId}/dataplanes`
- `GET /organizations/{orgId}/environments/{envId}/dataplanes/{dataPlaneId}`
- `DELETE /organizations/{orgId}/environments/{envId}/dataplanes/{dataPlaneId}`

Data planes are referenced by `id` (not `key`) to align with existing records; data planes not managed by the automation API can still be referenced using the brownfield `id:` prefix scheme.

Writes and deletes are guarded by `DATA_PLANE` permission alongside reads. An upgrader aligns persisted owner roles.

Data planes can now be updated. This introduces a new `DATA_PLANE_UPDATED` event type.

Domain creation remains gated on referenced data planes being loaded into the management API node. This means data planes must be provisioned in advance (and allowed time to sync if using API across multiple nodes).

## :memo: Test scenarios 
See jira.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 

[AM-7639]: https://gravitee.atlassian.net/browse/AM-7639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ