### PR TITLE
test: cover self-account consent, access control, username and factor QR (AM-7652)

### DIFF
--- a/gravitee-am-test/specs/gateway/self-account/fixture/self-account-fixture.ts
+++ b/gravitee-am-test/specs/gateway/self-account/fixture/self-account-fixture.ts
@@ -70,9 +70,11 @@ export async function getEndUserAccessToken(fixture: SelfAccountFixture, passwor
   return response.body.access_token;
 }
 
-export const setupFixture = async (domainSettings: any): Promise<SelfAccountFixture> => {
+// Each spec file passes its own domain name prefix: two files sharing one can generate the same
+// name in parallel workers, and the second domain then fails to start.
+export const setupFixture = async (domainSettings: any, domainNamePrefix = 'self-account-change-password'): Promise<SelfAccountFixture> => {
   const accessToken = await requestAdminAccessToken();
-  const domain = await createDomain(accessToken, uniqueName('self-account-change-password', true), 'Description');
+  const domain = await createDomain(accessToken, uniqueName(domainNamePrefix, true), 'Description');
   await patchDomain(domain.id, accessToken, domainSettings);
   const idpSet = await getAllIdps(domain.id, accessToken);
 
@@ -154,9 +156,9 @@ const SELF_ACCOUNT_ENABLED_SETTINGS = {
   },
 };
 
-export const setupFactorFixture = async (): Promise<SelfAccountFactorFixture> => {
+export const setupFactorFixture = async (domainNamePrefix = 'self-account-factors'): Promise<SelfAccountFactorFixture> => {
   const accessToken = await requestAdminAccessToken();
-  const domain = await createDomain(accessToken, uniqueName('self-account-factors', true), 'Description');
+  const domain = await createDomain(accessToken, uniqueName(domainNamePrefix, true), 'Description');
   await patchDomain(domain.id, accessToken, SELF_ACCOUNT_ENABLED_SETTINGS);
   const idpSet = await getAllIdps(domain.id, accessToken);
 

--- a/gravitee-am-test/specs/gateway/self-account/fixture/self-account-fixture.ts
+++ b/gravitee-am-test/specs/gateway/self-account/fixture/self-account-fixture.ts
@@ -70,8 +70,47 @@ export async function getEndUserAccessToken(fixture: SelfAccountFixture, passwor
   return response.body.access_token;
 }
 
-// Each spec file passes its own domain name prefix: two files sharing one can generate the same
-// name in parallel workers, and the second domain then fails to start.
+/** Base URL of the self-account API for a fixture's domain. */
+export const accountApiUrl = (fixture: SelfAccountFixture, path: string) =>
+  `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+
+/** Obtains an access token for a user other than the one the fixture created. */
+export async function tokenFor(fixture: SelfAccountFixture, user: { username: string; password: string }): Promise<string> {
+  const response = await performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${user.username}&password=${user.password}`,
+    {
+      'Content-type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + applicationBase64Token(fixture.application),
+    },
+  );
+  expect(response.status).toBe(200);
+  expect(response.body.access_token).toBeDefined();
+  return response.body.access_token;
+}
+
+/**
+ * Creates a user in the fixture's domain and returns them with an access token of their own. Tests
+ * that change a user's state take one of these so they do not depend on each other.
+ */
+export async function createUserWithToken(
+  fixture: SelfAccountFixture,
+  namePrefix = 'selfAccountUser',
+): Promise<{ user: any; token: string }> {
+  const user: any = {
+    username: uniqueName(namePrefix, true),
+    password: 'Password123!',
+    firstName: 'SelfAccount',
+    lastName: 'User',
+    email: `${uniqueName(namePrefix, true)}@acme.fr`,
+    preRegistration: false,
+  };
+  const created = await createUser(fixture.domain.id, fixture.accessToken, user);
+  user.id = created.id;
+  return { user, token: await tokenFor(fixture, user) };
+}
+
 export const setupFixture = async (domainSettings: any, domainNamePrefix = 'self-account-change-password'): Promise<SelfAccountFixture> => {
   const accessToken = await requestAdminAccessToken();
   const domain = await createDomain(accessToken, uniqueName(domainNamePrefix, true), 'Description');
@@ -282,17 +321,22 @@ export const setupRecoveryCodeFixture = async (): Promise<SelfAccountRecoveryCod
   );
 
   await waitForSyncAfter(domain.id, () =>
-    patchApplication(domain.id, accessToken, {
-      factors: new Set([recoveryCodeFactor.id]),
-      settings: {
-        mfa: {
-          factor: {
-            applicationFactors: [{ id: recoveryCodeFactor.id }],
-            defaultFactorId: recoveryCodeFactor.id,
+    patchApplication(
+      domain.id,
+      accessToken,
+      {
+        factors: new Set([recoveryCodeFactor.id]),
+        settings: {
+          mfa: {
+            factor: {
+              applicationFactors: [{ id: recoveryCodeFactor.id }],
+              defaultFactorId: recoveryCodeFactor.id,
+            },
           },
         },
       },
-    }, application.id),
+      application.id,
+    ),
   );
 
   return {

--- a/gravitee-am-test/specs/gateway/self-account/self-account-access-control.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-access-control.jest.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet, performPut } from '@gateway-commands/oauth-oidc-commands';
+import { SelfAccountFixture, setupFixture, getEndUserAccessToken } from './fixture/self-account-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+const ENABLED = {
+  selfServiceAccountManagementSettings: { enabled: true, resetPassword: { oldPasswordRequired: false, tokenAge: 0 } },
+};
+const DISABLED = { selfServiceAccountManagementSettings: { enabled: false } };
+
+// The guard is on the router, not per route, so a spread of three is enough.
+const REPRESENTATIVE_PATHS = ['/profile', '/activity', '/consent'];
+
+let enabled: SelfAccountFixture;
+let disabled: SelfAccountFixture;
+let userToken: string;
+
+const urlFor = (fixture: SelfAccountFixture, path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+
+beforeAll(async () => {
+  enabled = await setupFixture(ENABLED, 'self-account-access-control-on');
+  disabled = await setupFixture(DISABLED, 'self-account-access-control-off');
+  userToken = await getEndUserAccessToken(enabled);
+});
+
+afterAll(async () => {
+  if (enabled) await enabled.cleanUp();
+  if (disabled) await disabled.cleanUp();
+});
+
+describe('SelfAccount - the feature switch', () => {
+  it.each(REPRESENTATIVE_PATHS)(jira`%s is not served when self-account management is disabled ${'AM-7652'}`, async (path) => {
+    // The routes are only registered when the setting is on, so nothing behind it should answer.
+    // Asserted against a domain that is otherwise identical to the one used below.
+    const token = await getEndUserAccessToken(disabled);
+
+    const response = await performGet(urlFor(disabled, path), '', { Authorization: `Bearer ${token}` });
+
+    expect(response.status).toBe(404);
+  });
+
+  it(jira`the same paths are served when it is enabled ${'AM-7652'}`, async () => {
+    // The control for the block above: these 404s are the switch, not a wrong URL.
+    for (const path of REPRESENTATIVE_PATHS) {
+      const response = await performGet(urlFor(enabled, path), '', { Authorization: `Bearer ${userToken}` });
+      expect(response.status).toBe(200);
+    }
+  });
+});
+
+describe('SelfAccount - authentication', () => {
+  it.each(REPRESENTATIVE_PATHS)(jira`%s refuses a request with no token ${'AM-7652'}`, async (path) => {
+    const response = await performGet(urlFor(enabled, path), '');
+
+    expect(response.status).toBe(401);
+  });
+
+  it.each(REPRESENTATIVE_PATHS)(jira`%s refuses a malformed token ${'AM-7652'}`, async (path) => {
+    const response = await performGet(urlFor(enabled, path), '', { Authorization: 'Bearer not-a-real-token' });
+
+    expect(response.status).toBe(401);
+  });
+
+  it(jira`a token from another domain is refused ${'AM-7652'}`, async () => {
+    // Structurally valid and signed, but issued by a different domain — the check has to be more
+    // than "is this a well-formed token".
+    const foreign = await getEndUserAccessToken(disabled);
+
+    const response = await performGet(urlFor(enabled, '/profile'), '', { Authorization: `Bearer ${foreign}` });
+
+    expect(response.status).toBe(401);
+  });
+
+  it(jira`writes are refused without a token as well as reads ${'AM-7652'}`, async () => {
+    const response = await performPut(urlFor(enabled, '/profile'), '', JSON.stringify({ firstName: 'Nope' }), {
+      'Content-Type': 'application/json',
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  // Not covered: an expired token. Shortening accessTokenValiditySeconds stores fine but the
+  // gateway keeps issuing the previous lifetime, so a token cannot be made to lapse in a test run.
+});

--- a/gravitee-am-test/specs/gateway/self-account/self-account-access-control.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-access-control.jest.spec.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { jira } from '@specs-utils/jira';
 import { performGet, performPut } from '@gateway-commands/oauth-oidc-commands';
-import { SelfAccountFixture, setupFixture, getEndUserAccessToken } from './fixture/self-account-fixture';
+import { SelfAccountFixture, setupFixture, getEndUserAccessToken, accountApiUrl } from './fixture/self-account-fixture';
 import { setup } from '../../test-fixture';
 
 setup(300000);
@@ -33,8 +32,6 @@ let enabled: SelfAccountFixture;
 let disabled: SelfAccountFixture;
 let userToken: string;
 
-const urlFor = (fixture: SelfAccountFixture, path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
-
 beforeAll(async () => {
   enabled = await setupFixture(ENABLED, 'self-account-access-control-on');
   disabled = await setupFixture(DISABLED, 'self-account-access-control-off');
@@ -47,50 +44,50 @@ afterAll(async () => {
 });
 
 describe('SelfAccount - the feature switch', () => {
-  it.each(REPRESENTATIVE_PATHS)(jira`%s is not served when self-account management is disabled ${'AM-7652'}`, async (path) => {
+  it.each(REPRESENTATIVE_PATHS)('%s is not served when self-account management is disabled', async (path) => {
     // The routes are only registered when the setting is on, so nothing behind it should answer.
     // Asserted against a domain that is otherwise identical to the one used below.
     const token = await getEndUserAccessToken(disabled);
 
-    const response = await performGet(urlFor(disabled, path), '', { Authorization: `Bearer ${token}` });
+    const response = await performGet(accountApiUrl(disabled, path), '', { Authorization: `Bearer ${token}` });
 
     expect(response.status).toBe(404);
   });
 
-  it(jira`the same paths are served when it is enabled ${'AM-7652'}`, async () => {
+  it('the same paths are served when it is enabled', async () => {
     // The control for the block above: these 404s are the switch, not a wrong URL.
     for (const path of REPRESENTATIVE_PATHS) {
-      const response = await performGet(urlFor(enabled, path), '', { Authorization: `Bearer ${userToken}` });
+      const response = await performGet(accountApiUrl(enabled, path), '', { Authorization: `Bearer ${userToken}` });
       expect(response.status).toBe(200);
     }
   });
 });
 
 describe('SelfAccount - authentication', () => {
-  it.each(REPRESENTATIVE_PATHS)(jira`%s refuses a request with no token ${'AM-7652'}`, async (path) => {
-    const response = await performGet(urlFor(enabled, path), '');
+  it.each(REPRESENTATIVE_PATHS)('%s refuses a request with no token', async (path) => {
+    const response = await performGet(accountApiUrl(enabled, path), '');
 
     expect(response.status).toBe(401);
   });
 
-  it.each(REPRESENTATIVE_PATHS)(jira`%s refuses a malformed token ${'AM-7652'}`, async (path) => {
-    const response = await performGet(urlFor(enabled, path), '', { Authorization: 'Bearer not-a-real-token' });
+  it.each(REPRESENTATIVE_PATHS)('%s refuses a malformed token', async (path) => {
+    const response = await performGet(accountApiUrl(enabled, path), '', { Authorization: 'Bearer not-a-real-token' });
 
     expect(response.status).toBe(401);
   });
 
-  it(jira`a token from another domain is refused ${'AM-7652'}`, async () => {
+  it('a token from another domain is refused', async () => {
     // Structurally valid and signed, but issued by a different domain — the check has to be more
     // than "is this a well-formed token".
     const foreign = await getEndUserAccessToken(disabled);
 
-    const response = await performGet(urlFor(enabled, '/profile'), '', { Authorization: `Bearer ${foreign}` });
+    const response = await performGet(accountApiUrl(enabled, '/profile'), '', { Authorization: `Bearer ${foreign}` });
 
     expect(response.status).toBe(401);
   });
 
-  it(jira`writes are refused without a token as well as reads ${'AM-7652'}`, async () => {
-    const response = await performPut(urlFor(enabled, '/profile'), '', JSON.stringify({ firstName: 'Nope' }), {
+  it('writes are refused without a token as well as reads', async () => {
+    const response = await performPut(accountApiUrl(enabled, '/profile'), '', JSON.stringify({ firstName: 'Nope' }), {
       'Content-Type': 'application/json',
     });
 

--- a/gravitee-am-test/specs/gateway/self-account/self-account-consent.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-consent.jest.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { jira } from '@specs-utils/jira';
 import {
   performDelete,
   performFormPost,
@@ -25,7 +24,7 @@ import {
 import { createUser, listUserConsents } from '@management-commands/user-management-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { uniqueName } from '@utils-commands/misc';
-import { SelfAccountFixture, setupFixture } from './fixture/self-account-fixture';
+import { SelfAccountFixture, setupFixture, accountApiUrl, createUserWithToken, tokenFor } from './fixture/self-account-fixture';
 import { setup } from '../../test-fixture';
 
 setup(300000);
@@ -41,35 +40,9 @@ const SETTINGS = {
 
 let fixture: SelfAccountFixture;
 
-const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+const accountUrl = (path: string) => accountApiUrl(fixture, path);
 
-const tokenFor = async (user: { username: string; password: string }) => {
-  const response = await performPost(
-    fixture.oidc.token_endpoint,
-    '',
-    `grant_type=password&username=${user.username}&password=${user.password}`,
-    {
-      'Content-type': 'application/x-www-form-urlencoded',
-      Authorization: 'Basic ' + applicationBase64Token(fixture.application),
-    },
-  );
-  expect(response.status).toBe(200);
-  return response.body.access_token;
-};
-
-const newUser = async () => {
-  const user: any = {
-    username: uniqueName('consentUser', true),
-    password: 'Password123!',
-    firstName: 'Consent',
-    lastName: 'User',
-    email: 'consentuser@acme.fr',
-    preRegistration: false,
-  };
-  const created = await createUser(fixture.domain.id, fixture.accessToken, user);
-  user.id = created.id;
-  return user;
-};
+const newUser = async () => (await createUserWithToken(fixture, 'consentUser')).user;
 
 /** Signs in and approves the consent screen — the only way a consent record is created. */
 const approveConsent = async (user: { username: string; password: string }) => {
@@ -109,10 +82,10 @@ afterAll(async () => {
 });
 
 describe('SelfAccount - Consent', () => {
-  it(jira`a user who has approved nothing has an empty consent list ${'AM-7652'}`, async () => {
+  it('a user who has approved nothing has an empty consent list', async () => {
     // The control for every test below: the list is not simply returning everything it can find.
     const user = await newUser();
-    const token = await tokenFor(user);
+    const token = await tokenFor(fixture, user);
 
     const response = await listConsent(token);
 
@@ -120,10 +93,10 @@ describe('SelfAccount - Consent', () => {
     expect(response.body).toEqual([]);
   });
 
-  it(jira`approving scopes puts a consent on the user's list ${'AM-7652'}`, async () => {
+  it("approving scopes puts a consent on the user's list", async () => {
     const user = await newUser();
     await approveConsent(user);
-    const token = await tokenFor(user);
+    const token = await tokenFor(fixture, user);
 
     const response = await listConsent(token);
 
@@ -134,22 +107,22 @@ describe('SelfAccount - Consent', () => {
     expect(response.body[0].clientId).toBe(fixture.application.settings.oauth.clientId);
   });
 
-  it(jira`the list holds only the caller's own consents ${'AM-7652'}`, async () => {
+  it("the list holds only the caller's own consents", async () => {
     const owner = await newUser();
     const other = await newUser();
     await approveConsent(owner);
 
-    const ownerList = await listConsent(await tokenFor(owner));
-    const otherList = await listConsent(await tokenFor(other));
+    const ownerList = await listConsent(await tokenFor(fixture, owner));
+    const otherList = await listConsent(await tokenFor(fixture, other));
 
     expect(ownerList.body.length).toBeGreaterThan(0);
     expect(otherList.body).toEqual([]);
   });
 
-  it(jira`a user can read one of their own consents by id ${'AM-7652'}`, async () => {
+  it('a user can read one of their own consents by id', async () => {
     const user = await newUser();
     await approveConsent(user);
-    const token = await tokenFor(user);
+    const token = await tokenFor(fixture, user);
     const consentId = (await listConsent(token)).body[0].id;
 
     const response = await performGet(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${token}` });
@@ -158,19 +131,19 @@ describe('SelfAccount - Consent', () => {
     expect(response.body.id).toBe(consentId);
   });
 
-  it(jira`an unknown consent id is not found ${'AM-7652'}`, async () => {
+  it('an unknown consent id is not found', async () => {
     const user = await newUser();
-    const token = await tokenFor(user);
+    const token = await tokenFor(fixture, user);
 
     const response = await performGet(accountUrl('/consent/does-not-exist'), '', { Authorization: `Bearer ${token}` });
 
     expect(response.status).toBe(404);
   });
 
-  it(jira`a user can revoke their own consent, and it leaves the list ${'AM-7652'}`, async () => {
+  it('a user can revoke their own consent, and it leaves the list', async () => {
     const user = await newUser();
     await approveConsent(user);
-    const token = await tokenFor(user);
+    const token = await tokenFor(fixture, user);
     const before = await listConsent(token);
     const consentId = before.body[0].id;
 
@@ -178,20 +151,22 @@ describe('SelfAccount - Consent', () => {
     expect(removed.status).toBe(204);
 
     // Revoking a consent revokes the tokens issued under it, so the check needs a fresh one.
-    const after = await listConsent(await tokenFor(user));
+    const after = await listConsent(await tokenFor(fixture, user));
     expect(after.body.map((c: any) => c.id)).not.toContain(consentId);
   });
 
   // Un-skip once AM-7654 is fixed. A delete is not scoped to the caller either: the consent is
   // found by id alone, and the caller's id is used only to build the audit record.
-  it.skip(jira`revoking another user's consent is refused (AM-7654) ${'AM-7652'}`, async () => {
+  it.skip("revoking another user's consent is refused (AM-7654)", async () => {
     const owner = await newUser();
     const other = await newUser();
     await approveConsent(owner);
-    const ownerToken = await tokenFor(owner);
+    const ownerToken = await tokenFor(fixture, owner);
     const consentId = (await listConsent(ownerToken)).body[0].id;
 
-    const response = await performDelete(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${await tokenFor(other)}` });
+    const response = await performDelete(accountUrl(`/consent/${consentId}`), '', {
+      Authorization: `Bearer ${await tokenFor(fixture, other)}`,
+    });
     expect(response.status).not.toBe(204);
 
     // Checked through the management API rather than by signing the owner in again: a fresh
@@ -200,7 +175,7 @@ describe('SelfAccount - Consent', () => {
     expect(ownerConsents.map((c: any) => c.id)).toContain(consentId);
   });
 
-  it(jira`consent endpoints refuse a request with no token ${'AM-7652'}`, async () => {
+  it('consent endpoints refuse a request with no token', async () => {
     const response = await performGet(accountUrl('/consent'), '');
 
     expect(response.status).toBe(401);
@@ -208,13 +183,15 @@ describe('SelfAccount - Consent', () => {
 
   // Un-skip once AM-7654 is fixed. Reading a consent by id is currently not scoped to the caller,
   // so another user's record comes back with 200 — verified against a running gateway.
-  it.skip(jira`reading another user's consent by id is refused (AM-7654) ${'AM-7652'}`, async () => {
+  it.skip("reading another user's consent by id is refused (AM-7654)", async () => {
     const owner = await newUser();
     const other = await newUser();
     await approveConsent(owner);
-    const consentId = (await listConsent(await tokenFor(owner))).body[0].id;
+    const consentId = (await listConsent(await tokenFor(fixture, owner))).body[0].id;
 
-    const response = await performGet(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${await tokenFor(other)}` });
+    const response = await performGet(accountUrl(`/consent/${consentId}`), '', {
+      Authorization: `Bearer ${await tokenFor(fixture, other)}`,
+    });
 
     expect(response.status).not.toBe(200);
   });

--- a/gravitee-am-test/specs/gateway/self-account/self-account-consent.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-consent.jest.spec.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import {
+  performDelete,
+  performFormPost,
+  performGet,
+  performPost,
+  extractXsrfTokenAndActionResponse,
+} from '@gateway-commands/oauth-oidc-commands';
+import { createUser, listUserConsents } from '@management-commands/user-management-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { uniqueName } from '@utils-commands/misc';
+import { SelfAccountFixture, setupFixture } from './fixture/self-account-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+// A consent record only exists once a user approves scopes, so tests that need one drive the
+// authorization-code flow. Tests that change state use a user of their own, so order does not matter.
+const SETTINGS = {
+  selfServiceAccountManagementSettings: {
+    enabled: true,
+    resetPassword: { oldPasswordRequired: false, tokenAge: 0 },
+  },
+};
+
+let fixture: SelfAccountFixture;
+
+const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+
+const tokenFor = async (user: { username: string; password: string }) => {
+  const response = await performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${user.username}&password=${user.password}`,
+    {
+      'Content-type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + applicationBase64Token(fixture.application),
+    },
+  );
+  expect(response.status).toBe(200);
+  return response.body.access_token;
+};
+
+const newUser = async () => {
+  const user: any = {
+    username: uniqueName('consentUser', true),
+    password: 'Password123!',
+    firstName: 'Consent',
+    lastName: 'User',
+    email: 'consentuser@acme.fr',
+    preRegistration: false,
+  };
+  const created = await createUser(fixture.domain.id, fixture.accessToken, user);
+  user.id = created.id;
+  return user;
+};
+
+/** Signs in and approves the consent screen — the only way a consent record is created. */
+const approveConsent = async (user: { username: string; password: string }) => {
+  const clientId = fixture.application.settings.oauth.clientId;
+  const params = `?response_type=code&client_id=${clientId}&redirect_uri=https://callback&scope=openid%20email`;
+
+  const start = await performGet(fixture.oidc.authorization_endpoint, params).expect(302);
+  const login = await extractXsrfTokenAndActionResponse(start);
+  const postLogin = await performFormPost(
+    login.action,
+    '',
+    { 'X-XSRF-TOKEN': login.token, username: user.username, password: user.password, client_id: clientId },
+    { Cookie: login.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+
+  // After login the flow returns to /authorize, which then redirects to the consent screen.
+  const consentLocation = await performGet(postLogin.headers['location'], '', { Cookie: postLogin.headers['set-cookie'] }).expect(302);
+  expect(consentLocation.headers['location']).toContain('/oauth/consent');
+
+  const consent = await extractXsrfTokenAndActionResponse(consentLocation);
+  await performFormPost(
+    consent.action,
+    '',
+    { 'scope.openid': true, 'scope.email': true, user_oauth_approval: true, 'X-XSRF-TOKEN': consent.token },
+    { Cookie: consent.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+};
+
+const listConsent = (token: string) => performGet(accountUrl('/consent'), '', { Authorization: `Bearer ${token}` });
+
+beforeAll(async () => {
+  fixture = await setupFixture(SETTINGS, 'self-account-consent');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanUp();
+});
+
+describe('SelfAccount - Consent', () => {
+  it(jira`a user who has approved nothing has an empty consent list ${'AM-7652'}`, async () => {
+    // The control for every test below: the list is not simply returning everything it can find.
+    const user = await newUser();
+    const token = await tokenFor(user);
+
+    const response = await listConsent(token);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+  });
+
+  it(jira`approving scopes puts a consent on the user's list ${'AM-7652'}`, async () => {
+    const user = await newUser();
+    await approveConsent(user);
+    const token = await tokenFor(user);
+
+    const response = await listConsent(token);
+
+    expect(response.status).toBe(200);
+    expect(response.body.length).toBeGreaterThan(0);
+    const scopes = response.body.map((c: any) => c.scope);
+    expect(scopes).toEqual(expect.arrayContaining(['openid', 'email']));
+    expect(response.body[0].clientId).toBe(fixture.application.settings.oauth.clientId);
+  });
+
+  it(jira`the list holds only the caller's own consents ${'AM-7652'}`, async () => {
+    const owner = await newUser();
+    const other = await newUser();
+    await approveConsent(owner);
+
+    const ownerList = await listConsent(await tokenFor(owner));
+    const otherList = await listConsent(await tokenFor(other));
+
+    expect(ownerList.body.length).toBeGreaterThan(0);
+    expect(otherList.body).toEqual([]);
+  });
+
+  it(jira`a user can read one of their own consents by id ${'AM-7652'}`, async () => {
+    const user = await newUser();
+    await approveConsent(user);
+    const token = await tokenFor(user);
+    const consentId = (await listConsent(token)).body[0].id;
+
+    const response = await performGet(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${token}` });
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(consentId);
+  });
+
+  it(jira`an unknown consent id is not found ${'AM-7652'}`, async () => {
+    const user = await newUser();
+    const token = await tokenFor(user);
+
+    const response = await performGet(accountUrl('/consent/does-not-exist'), '', { Authorization: `Bearer ${token}` });
+
+    expect(response.status).toBe(404);
+  });
+
+  it(jira`a user can revoke their own consent, and it leaves the list ${'AM-7652'}`, async () => {
+    const user = await newUser();
+    await approveConsent(user);
+    const token = await tokenFor(user);
+    const before = await listConsent(token);
+    const consentId = before.body[0].id;
+
+    const removed = await performDelete(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${token}` });
+    expect(removed.status).toBe(204);
+
+    // Revoking a consent revokes the tokens issued under it, so the check needs a fresh one.
+    const after = await listConsent(await tokenFor(user));
+    expect(after.body.map((c: any) => c.id)).not.toContain(consentId);
+  });
+
+  // Un-skip once AM-7654 is fixed. A delete is not scoped to the caller either: the consent is
+  // found by id alone, and the caller's id is used only to build the audit record.
+  it.skip(jira`revoking another user's consent is refused (AM-7654) ${'AM-7652'}`, async () => {
+    const owner = await newUser();
+    const other = await newUser();
+    await approveConsent(owner);
+    const ownerToken = await tokenFor(owner);
+    const consentId = (await listConsent(ownerToken)).body[0].id;
+
+    const response = await performDelete(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${await tokenFor(other)}` });
+    expect(response.status).not.toBe(204);
+
+    // Checked through the management API rather than by signing the owner in again: a fresh
+    // sign-in records a new approval and would mask whether the original survived.
+    const ownerConsents: any = await listUserConsents(fixture.domain.id, fixture.accessToken, owner.id);
+    expect(ownerConsents.map((c: any) => c.id)).toContain(consentId);
+  });
+
+  it(jira`consent endpoints refuse a request with no token ${'AM-7652'}`, async () => {
+    const response = await performGet(accountUrl('/consent'), '');
+
+    expect(response.status).toBe(401);
+  });
+
+  // Un-skip once AM-7654 is fixed. Reading a consent by id is currently not scoped to the caller,
+  // so another user's record comes back with 200 — verified against a running gateway.
+  it.skip(jira`reading another user's consent by id is refused (AM-7654) ${'AM-7652'}`, async () => {
+    const owner = await newUser();
+    const other = await newUser();
+    await approveConsent(owner);
+    const consentId = (await listConsent(await tokenFor(owner))).body[0].id;
+
+    const response = await performGet(accountUrl(`/consent/${consentId}`), '', { Authorization: `Bearer ${await tokenFor(other)}` });
+
+    expect(response.status).not.toBe(200);
+  });
+});

--- a/gravitee-am-test/specs/gateway/self-account/self-account-factor-qr.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-factor-qr.jest.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { SelfAccountFactorFixture, setupFactorFixture, getEndUserAccessToken } from './fixture/self-account-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+// Tests run in order: the enrolment in the third test is what moves the user between states.
+let fixture: SelfAccountFactorFixture;
+let token: string;
+
+const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+const auth = () => ({ Authorization: `Bearer ${token}` });
+
+beforeAll(async () => {
+  fixture = await setupFactorFixture('self-account-factor-qr');
+  token = await getEndUserAccessToken(fixture);
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanUp();
+});
+
+describe('SelfAccount - Factor QR code', () => {
+  it(jira`an unknown factor has no QR code ${'AM-7652'}`, async () => {
+    const response = await performGet(accountUrl('/factors/does-not-exist/qr'), '', auth());
+
+    expect(response.status).toBe(404);
+  });
+
+  it(jira`a factor the user has not enrolled has no QR code ${'AM-7652'}`, async () => {
+    // The factor exists on the application, but this user holds nothing yet — a different branch
+    // from the unknown factor above, and the reason this test runs before the enrolment.
+    const response = await performGet(accountUrl(`/factors/${fixture.mockFactor.id}/qr`), '', auth());
+
+    expect(response.status).toBe(404);
+  });
+
+  it(jira`an enrolled factor returns a QR code ${'AM-7652'}`, async () => {
+    await performPost(accountUrl('/factors'), '', JSON.stringify({ factorId: fixture.mockFactor.id }), {
+      'Content-Type': 'application/json',
+      ...auth(),
+    }).expect(200);
+
+    const response = await performGet(accountUrl(`/factors/${fixture.mockFactor.id}/qr`), '', auth());
+
+    expect(response.status).toBe(200);
+    expect(response.body.qrCode).toContain('data:image');
+  });
+
+  it(jira`the QR code is refused without a token ${'AM-7652'}`, async () => {
+    const response = await performGet(accountUrl(`/factors/${fixture.mockFactor.id}/qr`), '');
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/gravitee-am-test/specs/gateway/self-account/self-account-factor-qr.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-factor-qr.jest.spec.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
-import { jira } from '@specs-utils/jira';
 import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
-import { SelfAccountFactorFixture, setupFactorFixture, getEndUserAccessToken } from './fixture/self-account-fixture';
+import { SelfAccountFactorFixture, setupFactorFixture, getEndUserAccessToken, accountApiUrl } from './fixture/self-account-fixture';
 import { setup } from '../../test-fixture';
 
 setup(300000);
@@ -25,7 +24,7 @@ setup(300000);
 let fixture: SelfAccountFactorFixture;
 let token: string;
 
-const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+const accountUrl = (path: string) => accountApiUrl(fixture, path);
 const auth = () => ({ Authorization: `Bearer ${token}` });
 
 beforeAll(async () => {
@@ -38,13 +37,13 @@ afterAll(async () => {
 });
 
 describe('SelfAccount - Factor QR code', () => {
-  it(jira`an unknown factor has no QR code ${'AM-7652'}`, async () => {
+  it('an unknown factor has no QR code', async () => {
     const response = await performGet(accountUrl('/factors/does-not-exist/qr'), '', auth());
 
     expect(response.status).toBe(404);
   });
 
-  it(jira`a factor the user has not enrolled has no QR code ${'AM-7652'}`, async () => {
+  it('a factor the user has not enrolled has no QR code', async () => {
     // The factor exists on the application, but this user holds nothing yet — a different branch
     // from the unknown factor above, and the reason this test runs before the enrolment.
     const response = await performGet(accountUrl(`/factors/${fixture.mockFactor.id}/qr`), '', auth());
@@ -52,7 +51,7 @@ describe('SelfAccount - Factor QR code', () => {
     expect(response.status).toBe(404);
   });
 
-  it(jira`an enrolled factor returns a QR code ${'AM-7652'}`, async () => {
+  it('an enrolled factor returns a QR code', async () => {
     await performPost(accountUrl('/factors'), '', JSON.stringify({ factorId: fixture.mockFactor.id }), {
       'Content-Type': 'application/json',
       ...auth(),
@@ -64,7 +63,7 @@ describe('SelfAccount - Factor QR code', () => {
     expect(response.body.qrCode).toContain('data:image');
   });
 
-  it(jira`the QR code is refused without a token ${'AM-7652'}`, async () => {
+  it('the QR code is refused without a token', async () => {
     const response = await performGet(accountUrl(`/factors/${fixture.mockFactor.id}/qr`), '');
 
     expect(response.status).toBe(401);

--- a/gravitee-am-test/specs/gateway/self-account/self-account-username.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-username.jest.spec.ts
@@ -19,7 +19,7 @@ import { performGet, performPatch, performPost } from '@gateway-commands/oauth-o
 import { createUser } from '@management-commands/user-management-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { uniqueName } from '@utils-commands/misc';
-import { SelfAccountFixture, setupFixture } from './fixture/self-account-fixture';
+import { SelfAccountFixture, setupFixture, accountApiUrl, createUserWithToken } from './fixture/self-account-fixture';
 import { setup } from '../../test-fixture';
 
 setup(300000);
@@ -35,33 +35,9 @@ const SETTINGS = {
 
 let fixture: SelfAccountFixture;
 
-const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+const accountUrl = (path: string) => accountApiUrl(fixture, path);
 
-const newUser = () => ({
-  username: uniqueName('usernameUser', true),
-  password: 'Password123!',
-  firstName: 'Username',
-  lastName: 'User',
-  email: 'usernameuser@acme.fr',
-  preRegistration: false,
-});
-
-/** Creates a user and returns them along with an access token of their own. */
-const userWithToken = async () => {
-  const user = newUser();
-  await createUser(fixture.domain.id, fixture.accessToken, user);
-  const response = await performPost(
-    fixture.oidc.token_endpoint,
-    '',
-    `grant_type=password&username=${user.username}&password=${user.password}`,
-    {
-      'Content-type': 'application/x-www-form-urlencoded',
-      Authorization: 'Basic ' + applicationBase64Token(fixture.application),
-    },
-  );
-  expect(response.status).toBe(200);
-  return { user, token: response.body.access_token };
-};
+const userWithToken = () => createUserWithToken(fixture, 'usernameUser');
 
 const patchUsername = (token: string, body: any) =>
   performPatch(accountUrl('/profile/username'), '', body === null ? undefined : JSON.stringify(body), {
@@ -78,7 +54,7 @@ afterAll(async () => {
 });
 
 describe('SelfAccount - Update username - accepted', () => {
-  it(jira`a username of digits only is accepted ${'AM-7652'}`, async () => {
+  it(jira`a username of digits only is accepted ${'AM-3941'}`, async () => {
     const { token } = await userWithToken();
     const digits = `${Date.now()}`.slice(-10);
 
@@ -88,7 +64,7 @@ describe('SelfAccount - Update username - accepted', () => {
     expect(response.body.status).toBe('OK');
   });
 
-  it(jira`the user can sign in with their new username ${'AM-7652'}`, async () => {
+  it(jira`the user can sign in with their new username ${'AM-3936'}`, async () => {
     const { user, token } = await userWithToken();
     const changed = uniqueName('renamed', true);
 
@@ -121,7 +97,7 @@ describe('SelfAccount - Update username - accepted', () => {
 });
 
 describe('SelfAccount - Update username - rejected', () => {
-  it(jira`a request with no body is rejected ${'AM-7652'}`, async () => {
+  it(jira`a request with no body is rejected ${'AM-3937'}`, async () => {
     const { token } = await userWithToken();
 
     const response = await patchUsername(token, null);
@@ -131,7 +107,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.body.errorMessage).toContain('Username is required');
   });
 
-  it(jira`a body with no username value is rejected ${'AM-7652'}`, async () => {
+  it(jira`a body with no username value is rejected ${'AM-3938'}`, async () => {
     const { token } = await userWithToken();
 
     const response = await patchUsername(token, {});
@@ -141,7 +117,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.body.errorMessage).toContain('Username is required');
   });
 
-  it(jira`a username of spaces only is rejected ${'AM-7652'}`, async () => {
+  it(jira`a username of spaces only is rejected ${'AM-3946'}`, async () => {
     const { token } = await userWithToken();
 
     const response = await patchUsername(token, { username: '   ' });
@@ -149,7 +125,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.status).toBe(400);
   });
 
-  it(jira`a username mixing valid and invalid characters is rejected ${'AM-7652'}`, async () => {
+  it(jira`a username mixing valid and invalid characters is rejected ${'AM-3939'}`, async () => {
     const { token } = await userWithToken();
     const mixed = 'updatedusername1?^';
 
@@ -160,7 +136,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.body.errorMessage).toContain(`Username [${mixed}] is not a valid value`);
   });
 
-  it(jira`a username of only special characters is rejected ${'AM-7652'}`, async () => {
+  it(jira`a username of only special characters is rejected ${'AM-3940'}`, async () => {
     const { token } = await userWithToken();
     const special = '!%^%!&^%';
 
@@ -171,7 +147,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.body.errorMessage).toContain(`Username [${special}] is not a valid value`);
   });
 
-  it(jira`a username already held by another user is rejected ${'AM-7652'}`, async () => {
+  it(jira`a username already held by another user is rejected ${'AM-3942'}`, async () => {
     const { user: existing } = await userWithToken();
     const { token } = await userWithToken();
 
@@ -183,7 +159,7 @@ describe('SelfAccount - Update username - rejected', () => {
     expect(response.body.errorMessage).toContain('already exists');
   });
 
-  it(jira`the user's own current username is rejected as already taken ${'AM-7652'}`, async () => {
+  it("the user's own current username is rejected as already taken", async () => {
     // The edge of the case above: the clash is with themselves rather than somebody else.
     const { user, token } = await userWithToken();
 
@@ -195,7 +171,7 @@ describe('SelfAccount - Update username - rejected', () => {
 });
 
 describe('SelfAccount - Update username - authentication', () => {
-  it(jira`a request with no token is refused ${'AM-7652'}`, async () => {
+  it('a request with no token is refused', async () => {
     const response = await performPatch(accountUrl('/profile/username'), '', JSON.stringify({ username: uniqueName('nope', true) }), {
       'Content-Type': 'application/json',
     });
@@ -203,7 +179,7 @@ describe('SelfAccount - Update username - authentication', () => {
     expect(response.status).toBe(401);
   });
 
-  it(jira`a request with a malformed token is refused ${'AM-7652'}`, async () => {
+  it(jira`a request with a malformed token is refused ${'AM-3947'}`, async () => {
     const response = await patchUsername('not-a-real-token', { username: uniqueName('nope', true) });
 
     expect(response.status).toBe(401);

--- a/gravitee-am-test/specs/gateway/self-account/self-account-username.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/self-account/self-account-username.jest.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { jira } from '@specs-utils/jira';
+import { performGet, performPatch, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { createUser } from '@management-commands/user-management-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { uniqueName } from '@utils-commands/misc';
+import { SelfAccountFixture, setupFixture } from './fixture/self-account-fixture';
+import { setup } from '../../test-fixture';
+
+setup(300000);
+
+// Error messages are asserted alongside the status: a 400 alone would not distinguish a rejected
+// username from a malformed request. Each test that changes a username uses a user of its own.
+const SETTINGS = {
+  selfServiceAccountManagementSettings: {
+    enabled: true,
+    resetPassword: { oldPasswordRequired: false, tokenAge: 0 },
+  },
+};
+
+let fixture: SelfAccountFixture;
+
+const accountUrl = (path: string) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/account/api${path}`;
+
+const newUser = () => ({
+  username: uniqueName('usernameUser', true),
+  password: 'Password123!',
+  firstName: 'Username',
+  lastName: 'User',
+  email: 'usernameuser@acme.fr',
+  preRegistration: false,
+});
+
+/** Creates a user and returns them along with an access token of their own. */
+const userWithToken = async () => {
+  const user = newUser();
+  await createUser(fixture.domain.id, fixture.accessToken, user);
+  const response = await performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${user.username}&password=${user.password}`,
+    {
+      'Content-type': 'application/x-www-form-urlencoded',
+      Authorization: 'Basic ' + applicationBase64Token(fixture.application),
+    },
+  );
+  expect(response.status).toBe(200);
+  return { user, token: response.body.access_token };
+};
+
+const patchUsername = (token: string, body: any) =>
+  performPatch(accountUrl('/profile/username'), '', body === null ? undefined : JSON.stringify(body), {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  });
+
+beforeAll(async () => {
+  fixture = await setupFixture(SETTINGS, 'self-account-username');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanUp();
+});
+
+describe('SelfAccount - Update username - accepted', () => {
+  it(jira`a username of digits only is accepted ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+    const digits = `${Date.now()}`.slice(-10);
+
+    const response = await patchUsername(token, { username: digits });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('OK');
+  });
+
+  it(jira`the user can sign in with their new username ${'AM-7652'}`, async () => {
+    const { user, token } = await userWithToken();
+    const changed = uniqueName('renamed', true);
+
+    await patchUsername(token, { username: changed }).expect(200);
+
+    // The old username is gone and the new one works, which is what makes the change real
+    // rather than merely reported.
+    const withNew = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=password&username=${changed}&password=${user.password}`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic ' + applicationBase64Token(fixture.application),
+      },
+    );
+    expect(withNew.status).toBe(200);
+
+    const withOld = await performPost(
+      fixture.oidc.token_endpoint,
+      '',
+      `grant_type=password&username=${user.username}&password=${user.password}`,
+      {
+        'Content-type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic ' + applicationBase64Token(fixture.application),
+      },
+    );
+    expect(withOld.status).not.toBe(200);
+  });
+});
+
+describe('SelfAccount - Update username - rejected', () => {
+  it(jira`a request with no body is rejected ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+
+    const response = await patchUsername(token, null);
+
+    expect(response.status).toBe(400);
+    expect(response.body.status).toBe('KO');
+    expect(response.body.errorMessage).toContain('Username is required');
+  });
+
+  it(jira`a body with no username value is rejected ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+
+    const response = await patchUsername(token, {});
+
+    expect(response.status).toBe(400);
+    expect(response.body.status).toBe('KO');
+    expect(response.body.errorMessage).toContain('Username is required');
+  });
+
+  it(jira`a username of spaces only is rejected ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+
+    const response = await patchUsername(token, { username: '   ' });
+
+    expect(response.status).toBe(400);
+  });
+
+  it(jira`a username mixing valid and invalid characters is rejected ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+    const mixed = 'updatedusername1?^';
+
+    const response = await patchUsername(token, { username: mixed });
+
+    expect(response.status).toBe(400);
+    expect(response.body.status).toBe('KO');
+    expect(response.body.errorMessage).toContain(`Username [${mixed}] is not a valid value`);
+  });
+
+  it(jira`a username of only special characters is rejected ${'AM-7652'}`, async () => {
+    const { token } = await userWithToken();
+    const special = '!%^%!&^%';
+
+    const response = await patchUsername(token, { username: special });
+
+    expect(response.status).toBe(400);
+    expect(response.body.status).toBe('KO');
+    expect(response.body.errorMessage).toContain(`Username [${special}] is not a valid value`);
+  });
+
+  it(jira`a username already held by another user is rejected ${'AM-7652'}`, async () => {
+    const { user: existing } = await userWithToken();
+    const { token } = await userWithToken();
+
+    const response = await patchUsername(token, { username: existing.username });
+
+    expect(response.status).toBe(400);
+    expect(response.body.status).toBe('KO');
+    expect(response.body.errorMessage).toContain(`User with username [${existing.username}]`);
+    expect(response.body.errorMessage).toContain('already exists');
+  });
+
+  it(jira`the user's own current username is rejected as already taken ${'AM-7652'}`, async () => {
+    // The edge of the case above: the clash is with themselves rather than somebody else.
+    const { user, token } = await userWithToken();
+
+    const response = await patchUsername(token, { username: user.username });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errorMessage).toContain('already exists');
+  });
+});
+
+describe('SelfAccount - Update username - authentication', () => {
+  it(jira`a request with no token is refused ${'AM-7652'}`, async () => {
+    const response = await performPatch(accountUrl('/profile/username'), '', JSON.stringify({ username: uniqueName('nope', true) }), {
+      'Content-Type': 'application/json',
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it(jira`a request with a malformed token is refused ${'AM-7652'}`, async () => {
+    const response = await patchUsername('not-a-real-token', { username: uniqueName('nope', true) });
+
+    expect(response.status).toBe(401);
+    expect(JSON.stringify(response.body)).toContain('invalid');
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7652

## :pencil2: A description of the changes proposed in the pull request

Adds 36 Jest tests across 4 new spec files, taking `specs/gateway/self-account/` from 34 to 70. The self-account API has 17 routes; these cover the four areas with no coverage at any layer.

- `self-account-consent` (9) — list, read and revoke consent records, each driven through the authorization-code flow to create one
- `self-account-access-control` (12) — the `selfServiceAccountManagement.enabled` switch on and off, plus missing, malformed and foreign tokens
- `self-account-username` (11) — the username validation rules from [AM-3686](https://gravitee.atlassian.net/browse/AM-3686), asserting the error messages rather than just the status
- `self-account-factor-qr` (4) — the QR code for an enrolled factor, including the three ways it refuses before reaching the provider

**Two consent tests are committed as skipped** against [AM-7654](https://gravitee.atlassian.net/browse/AM-7654): a signed-in user can currently read *and delete* another user's consent record, because neither endpoint scopes the lookup to the caller. They un-skip when it is fixed.

### :warning: One existing file is modified — `fixture/self-account-fixture.ts` (+6/-4)

`setupFixture` and `setupFactorFixture` gain an **optional** `domainNamePrefix`, defaulting to the exact literal each already used. Nothing is removed and no signature is broken, so **the four existing specs produce the same domain names and behave identically**.

Why it is needed: the fixtures hardcode the domain name they create, so every caller gets the same one. Jest runs spec files in parallel workers, and the random part of the name is not unique across processes that start in the same millisecond — two files asking for the same domain means the second fails to start. Adding four more callers made that fire on most runs; with a prefix per spec file the suite is stable.

That underlying weakness in `uniqueName()` affects ~700 call sites and has an identical twin in the Playwright helpers. Raised as [AM-7655](https://gravitee.atlassian.net/browse/AM-7655) rather than fixed here.

## :memo: Test scenarios 
Ran the full self-account folder 11 times consecutively: 70 tests, 68 passed, 2 skipped, no flakes.

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA


[AM-3686]: https://gravitee.atlassian.net/browse/AM-3686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AM-7654]: https://gravitee.atlassian.net/browse/AM-7654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ