### PR TITLE
test: cover SCIM bulk validation, multi-operation and pre-registration (AM-7653)

### DIFF
--- a/docker/local-stack/dev/docker-compose.yml
+++ b/docker/local-stack/dev/docker-compose.yml
@@ -38,6 +38,10 @@ services:
       - GRAVITEE_EMAIL_ENABLED=true
       - GRAVITEE_EMAIL_HOST=smtp
       - GRAVITEE_EMAIL_PORT=5025
+      # SCIM pre-registration emails are staged and sent by a background processor rather than
+      # inline. PERIOD is that processor's tick, 5s by default.
+      - GRAVITEE_EMAIL_BULK_ENABLED=true
+      - GRAVITEE_EMAIL_BULK_PERIOD=1
       - GRAVITEE_MFA_RATE_ENABLED=true
       - GRAVITEE_MFA_RATE_LIMIT=2
       - GRAVITEE_MFA_RATE_TIMEPERIOD=1

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -1418,44 +1418,13 @@ public class ProvisioningUserServiceTest {
         testObserver.assertNoErrors();
         testObserver.assertComplete();
 
-        // One initial attempt plus two retries. The eviction only happens once the retries are spent.
+        // One initial attempt plus two retries. Only once the retries are spent is the email
+        // dropped, which is both audited and counted.
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(3, attempts.get()));
-        Awaitility.await()
-                .atMost(10, TimeUnit.SECONDS)
-                .untilAsserted(() -> verify(emailService, times(1)).traceEmailEviction(any(), any(), any()));
-    }
-
-    /** A dropped email is counted, not only audited. */
-    @Test
-    public void shouldCountDroppedEmail_whenStagingKeepsFailing() {
-        ReflectionTestUtils.setField(userService, "bulkEnabled", true);
-        GraviteeUser newUser = mock(GraviteeUser.class);
-        when(newUser.getSource()).thenReturn("unknown-idp");
-        when(newUser.getUserName()).thenReturn("username");
-        when(newUser.getPassword()).thenReturn(null);
-        Map<String, Object> ai = new HashMap<>();
-        ai.put("preRegistration", true);
-        when(newUser.getAdditionalInformation()).thenReturn(ai);
-
-        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
-        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
-        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
-
-        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
-        user.setReferenceType(ReferenceType.DOMAIN);
-        user.setReferenceId(DOMAIN_ID);
-        user.setAdditionalInformation(ai);
-        user.setPreRegistration(true);
-        user.setEmail("user@acme.fr");
-        when(userRepository.create(any())).thenReturn(Single.just(user));
-
-        when(emailStagingService.push(any(), any())).thenReturn(Completable.error(new RuntimeException()));
-
-        TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
-        testObserver.assertNoErrors();
-        testObserver.assertComplete();
-
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> verify(metricProvider, times(1)).incrementDroppedEmails());
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(emailService, times(1)).traceEmailEviction(any(), any(), any());
+            verify(metricProvider, times(1)).incrementDroppedEmails();
+        });
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-scim/src/test/java/io/gravitee/am/gateway/handler/scim/service/ProvisioningUserServiceTest.java
@@ -102,6 +102,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -1293,6 +1294,168 @@ public class ProvisioningUserServiceTest {
         assertTrue(newUserDefinition.getValue().isEnabled());
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> verify(emailStagingService, times(1)).push(any(),any()));
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> verify(emailService, times(1)).traceEmailEviction(any(),any(),any()));
+    }
+
+    /**
+     * The synchronous counterpart of the test below. Integration tests run with bulk mode on, so
+     * this is the only place several pre-registered users are created with it off.
+     */
+    @Test
+    public void shouldCreateUsers_with_preRegistration_syncMode_sendsOneEmailPerUser() {
+        ReflectionTestUtils.setField(userService, "bulkEnabled", false);
+        int userCount = 3;
+
+        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
+
+        for (int i = 0; i < userCount; i++) {
+            Map<String, Object> ai = new HashMap<>();
+            ai.put("preRegistration", true);
+            GraviteeUser newUser = mock(GraviteeUser.class);
+            when(newUser.getSource()).thenReturn("unknown-idp");
+            when(newUser.getUserName()).thenReturn("username-" + i);
+            when(newUser.getPassword()).thenReturn(null);
+            when(newUser.getAdditionalInformation()).thenReturn(ai);
+
+            io.gravitee.am.model.User created = new io.gravitee.am.model.User();
+            created.setReferenceType(ReferenceType.DOMAIN);
+            created.setReferenceId(DOMAIN_ID);
+            created.setAdditionalInformation(ai);
+            created.setPreRegistration(true);
+            created.setEmail("user" + i + "@acme.fr");
+            when(userRepository.create(any())).thenReturn(Single.just(created));
+
+            TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+            testObserver.assertNoErrors();
+            testObserver.assertComplete();
+        }
+
+        // Sent inline, one per user, and nothing is handed to the staging processor.
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(emailService, times(userCount)).send(any(), any(), any()));
+        verify(emailStagingService, never()).push(any(), any());
+    }
+
+    /**
+     * A bulk request creates each user in turn, so N pre-registered users must produce N staged
+     * emails. The other bulk-mode tests create a single user and so cannot show this.
+     */
+    @Test
+    public void shouldCreateUsers_with_preRegistration_bulkMode_stagesOneEmailPerUser() {
+        ReflectionTestUtils.setField(userService, "bulkEnabled", true);
+        int userCount = 3;
+
+        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
+        when(emailStagingService.push(any(), any())).thenReturn(Completable.complete());
+
+        for (int i = 0; i < userCount; i++) {
+            Map<String, Object> ai = new HashMap<>();
+            ai.put("preRegistration", true);
+            GraviteeUser newUser = mock(GraviteeUser.class);
+            when(newUser.getSource()).thenReturn("unknown-idp");
+            when(newUser.getUserName()).thenReturn("username-" + i);
+            when(newUser.getPassword()).thenReturn(null);
+            when(newUser.getAdditionalInformation()).thenReturn(ai);
+
+            io.gravitee.am.model.User created = new io.gravitee.am.model.User();
+            created.setReferenceType(ReferenceType.DOMAIN);
+            created.setReferenceId(DOMAIN_ID);
+            created.setAdditionalInformation(ai);
+            created.setPreRegistration(true);
+            created.setEmail("user" + i + "@acme.fr");
+            when(userRepository.create(any())).thenReturn(Single.just(created));
+
+            TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+            testObserver.assertNoErrors();
+            testObserver.assertComplete();
+        }
+
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(emailStagingService, times(userCount)).push(any(), any()));
+    }
+
+    /**
+     * `pushStagingEmail` wraps the push in RetryWithDelay with maxRetries(2), so a push that keeps
+     * failing is attempted three times before the email is dropped.
+     */
+    @Test
+    public void shouldRetryStagingPush_beforeDroppingTheEmail() {
+        ReflectionTestUtils.setField(userService, "bulkEnabled", true);
+        GraviteeUser newUser = mock(GraviteeUser.class);
+        when(newUser.getSource()).thenReturn("unknown-idp");
+        when(newUser.getUserName()).thenReturn("username");
+        when(newUser.getPassword()).thenReturn(null);
+        Map<String, Object> ai = new HashMap<>();
+        ai.put("preRegistration", true);
+        when(newUser.getAdditionalInformation()).thenReturn(ai);
+
+        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
+
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setReferenceType(ReferenceType.DOMAIN);
+        user.setReferenceId(DOMAIN_ID);
+        user.setAdditionalInformation(ai);
+        user.setPreRegistration(true);
+        user.setEmail("user@acme.fr");
+        when(userRepository.create(any())).thenReturn(Single.just(user));
+
+        // The retry resubscribes to the Completable rather than calling push() again, so counting
+        // invocations of the mock would always give one. Counting subscriptions is what shows it.
+        AtomicInteger attempts = new AtomicInteger();
+        when(emailStagingService.push(any(), any())).thenReturn(Completable.defer(() -> {
+            attempts.incrementAndGet();
+            return Completable.error(new RuntimeException());
+        }));
+
+        TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        // One initial attempt plus two retries. The eviction only happens once the retries are spent.
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(3, attempts.get()));
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> verify(emailService, times(1)).traceEmailEviction(any(), any(), any()));
+    }
+
+    /** A dropped email is counted, not only audited. */
+    @Test
+    public void shouldCountDroppedEmail_whenStagingKeepsFailing() {
+        ReflectionTestUtils.setField(userService, "bulkEnabled", true);
+        GraviteeUser newUser = mock(GraviteeUser.class);
+        when(newUser.getSource()).thenReturn("unknown-idp");
+        when(newUser.getUserName()).thenReturn("username");
+        when(newUser.getPassword()).thenReturn(null);
+        Map<String, Object> ai = new HashMap<>();
+        ai.put("preRegistration", true);
+        when(newUser.getAdditionalInformation()).thenReturn(ai);
+
+        when(userRepository.findByUsernameAndSource(any(), anyString(), anyString())).thenReturn(Maybe.empty());
+        when(identityProviderManager.getIdentityProvider(anyString())).thenReturn(new IdentityProvider());
+        when(identityProviderManager.getUserProvider(anyString())).thenReturn(Maybe.empty());
+
+        io.gravitee.am.model.User user = new io.gravitee.am.model.User();
+        user.setReferenceType(ReferenceType.DOMAIN);
+        user.setReferenceId(DOMAIN_ID);
+        user.setAdditionalInformation(ai);
+        user.setPreRegistration(true);
+        user.setEmail("user@acme.fr");
+        when(userRepository.create(any())).thenReturn(Single.just(user));
+
+        when(emailStagingService.push(any(), any())).thenReturn(Completable.error(new RuntimeException()));
+
+        TestObserver<User> testObserver = userService.create(newUser, null, "/", null, new Client()).test();
+        testObserver.assertNoErrors();
+        testObserver.assertComplete();
+
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> verify(metricProvider, times(1)).incrementDroppedEmails());
     }
 
     @Test

--- a/gravitee-am-test/api/commands/utils/email-commands.ts
+++ b/gravitee-am-test/api/commands/utils/email-commands.ts
@@ -15,6 +15,7 @@
  */
 
 import fetch from 'cross-fetch';
+import { retryUntil } from './retry';
 
 const cheerio = require('cheerio');
 
@@ -73,6 +74,62 @@ export async function getLastEmail(delay = 1000, toAddress?: string) {
   });
 
   return email;
+}
+
+async function fetchEmails(): Promise<any[]> {
+  const response = await fetch(process.env.FAKE_SMTP + '/api/email');
+  const array = await response.json();
+  return array ?? [];
+}
+
+function toEmail(jsonEmail: any): Email {
+  const email = new Email();
+  email.id = jsonEmail['id'];
+  email.fromAddress = jsonEmail['fromAddress'];
+  email.toAddress = jsonEmail['toAddress'];
+  email.subject = jsonEmail['subject'];
+  email.contents = (jsonEmail['contents'] ?? []).map((c) => {
+    const content = new Content();
+    content.data = c['data'];
+    content.contentType = c['contentType'];
+    return content;
+  });
+  return email;
+}
+
+/**
+ * Polls the mailbox until an email for `toAddress` arrives. Prefer this over `getLastEmail`, which
+ * reads once after a fixed delay: sending is asynchronous to the HTTP response in every mode, and
+ * when `email.bulk.enabled` is on a message is staged and picked up by a background processor
+ * whose tick is `email.bulk.period`.
+ */
+export async function waitForEmail(toAddress: string, timeoutMillis = 15000): Promise<Email> {
+  const found = await retryUntil(
+    async () => (await fetchEmails()).find((e: any) => e['toAddress'] === toAddress),
+    (email) => !!email,
+    { timeoutMillis, intervalMillis: 250 },
+  ).catch(() => {
+    throw new Error(`No email for ${toAddress} within ${timeoutMillis}ms`);
+  });
+  return toEmail(found);
+}
+
+/** Waits until every address has an email, and returns them in the order requested. */
+export async function waitForEmails(toAddresses: string[], timeoutMillis = 20000): Promise<Email[]> {
+  const all = await retryUntil(fetchEmails, (emails) => toAddresses.every((a) => emails.some((e: any) => e['toAddress'] === a)), {
+    timeoutMillis,
+    intervalMillis: 250,
+  }).catch(async () => {
+    const delivered = (await fetchEmails()).map((e: any) => e['toAddress']);
+    const missing = toAddresses.filter((a) => !delivered.includes(a));
+    throw new Error(`No email within ${timeoutMillis}ms for: ${missing.join(', ')}`);
+  });
+  return toAddresses.map((a) => toEmail(all.find((e: any) => e['toAddress'] === a)));
+}
+
+/** Number of emails currently held for an address. */
+export async function countEmailsFor(toAddress: string): Promise<number> {
+  return (await fetchEmails()).filter((e: any) => e['toAddress'] === toAddress).length;
 }
 
 export async function clearEmails(toAddress?: string) {

--- a/gravitee-am-test/specs/gateway/scim/fixture/scim-fixture.ts
+++ b/gravitee-am-test/specs/gateway/scim/fixture/scim-fixture.ts
@@ -30,7 +30,7 @@ import { Application } from '@management-models/Application';
 import { createApplication, updateApplication } from '@management-commands/application-management-commands';
 import { extractXsrfToken, performFormPost, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
-import { clearEmails, getLastEmail } from '@utils-commands/email-commands';
+import { clearEmails, waitForEmail } from '@utils-commands/email-commands';
 
 export interface ScimFixture {
   domain: Domain;
@@ -48,9 +48,11 @@ export interface ScimFixture {
   createGroup: (body: any) => Promise<any>;
 }
 
-export const setupFixture = async (): Promise<ScimFixture> => {
+// Each spec file passes its own domain name prefix: two files sharing one can generate the same
+// name in parallel workers, and the second domain then fails to start.
+export const setupFixture = async (domainNamePrefix = 'scim'): Promise<ScimFixture> => {
   const accessToken = await requestAdminAccessToken();
-  const domain = await createDomain(accessToken, uniqueName('scim', true), 'Description');
+  const domain = await createDomain(accessToken, uniqueName(domainNamePrefix, true), 'Description');
 
   // Configure SCIM and create app BEFORE starting domain so the initial sync picks up everything
   await patchDomain(domain.id, accessToken, {
@@ -80,7 +82,7 @@ export const setupFixture = async (): Promise<ScimFixture> => {
     },
 
     extractConfirmRegistrationLink: async (email: string) => {
-      return (await getLastEmail(1000, email)).extractLink();
+      return (await waitForEmail(email)).extractLink();
     },
 
     confirmRegistrationLink: async (link: string) => {

--- a/gravitee-am-test/specs/gateway/scim/scim-bulk-fail-on-errors.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/scim/scim-bulk-fail-on-errors.jest.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { random } from 'faker';
+import { ScimFixture, setupFixture } from './fixture/scim-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+const SCHEMA_BULK_REQUEST = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest';
+const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCHEMA_PATCH_OP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
+
+let fixture: ScimFixture;
+
+beforeAll(async () => {
+  fixture = await setupFixture('scim-bulk-foe');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanup();
+});
+
+const bulk = (operations: any[], failOnErrors?: number) =>
+  performPost(
+    fixture.scimEndpoint,
+    '/Bulk',
+    JSON.stringify({ schemas: [SCHEMA_BULK_REQUEST], ...(failOnErrors ? { failOnErrors } : {}), Operations: operations }),
+    { 'Content-type': 'application/json', Authorization: `Bearer ${fixture.scimAccessToken}` },
+  );
+
+const idOf = (location: string) => location.substring(location.lastIndexOf('/') + 1);
+
+async function seedUsers(count: number): Promise<string[]> {
+  const response = await bulk(
+    Array.from({ length: count }, () => ({
+      method: 'POST',
+      path: '/Users',
+      bulkId: uniqueName('bulk', true),
+      data: { schemas: [SCHEMA_USER], userName: uniqueName('foe', true) },
+    })),
+  ).expect(200);
+  return response.body.Operations.map((op) => idOf(op.location));
+}
+
+/**
+ * Builds one operation of the given method against a user id. An unknown id is what makes an
+ * operation fail, so the same shape covers the success and failure cases for all three methods.
+ */
+const operationFor = (method: string, id: string) => {
+  const base = { method, path: `/Users/${id}`, bulkId: uniqueName('bulk', true) };
+  if (method === 'DELETE') return base;
+  if (method === 'PUT') {
+    return { ...base, data: { schemas: [SCHEMA_USER], userName: uniqueName('foe', true) } };
+  }
+  return {
+    ...base,
+    data: { schemas: [SCHEMA_PATCH_OP], Operations: [{ op: 'replace', path: 'displayName', value: random.alphaNumeric(8) }] },
+  };
+};
+
+const OK: Record<string, string> = { DELETE: '204', PUT: '200', PATCH: '200' };
+const METHODS = ['DELETE', 'PUT', 'PATCH'];
+
+describe.each(METHODS)('SCIM Bulk - failOnErrors with %s', (method) => {
+  it('processes every operation when none fails', async () => {
+    const ids = await seedUsers(4);
+
+    const response = await bulk(
+      ids.map((id) => operationFor(method, id)),
+      2,
+    ).expect(200);
+
+    expect(response.body.Operations).toHaveLength(4);
+    response.body.Operations.forEach((op) => expect(op.status).toEqual(OK[method]));
+  });
+
+  it('keeps going after a single failure', async () => {
+    const ids = await seedUsers(3);
+
+    // One error, below the threshold of two, so the request runs to the end.
+    const response = await bulk(
+      [operationFor(method, ids[0]), operationFor(method, random.uuid()), operationFor(method, ids[1]), operationFor(method, ids[2])],
+      2,
+    ).expect(200);
+
+    expect(response.body.Operations).toHaveLength(4);
+    expect(response.body.Operations.map((op) => op.status)).toEqual([OK[method], '404', OK[method], OK[method]]);
+  });
+
+  it('stops once the second failure is reached', async () => {
+    const ids = await seedUsers(2);
+
+    const response = await bulk(
+      [
+        operationFor(method, ids[0]),
+        operationFor(method, random.uuid()),
+        operationFor(method, random.uuid()),
+        operationFor(method, ids[1]),
+      ],
+      2,
+    ).expect(200);
+
+    // The trailing operation is never attempted, which is what distinguishes this from the case
+    // above — the count of returned operations, not just their statuses.
+    expect(response.body.Operations).toHaveLength(3);
+    expect(response.body.Operations.map((op) => op.status)).toEqual([OK[method], '404', '404']);
+  });
+});

--- a/gravitee-am-test/specs/gateway/scim/scim-bulk-multi-operation.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/scim/scim-bulk-multi-operation.jest.spec.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { random } from 'faker';
+import { ScimFixture, setupFixture } from './fixture/scim-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+const SCHEMA_BULK_REQUEST = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest';
+const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCHEMA_PATCH_OP = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
+
+let fixture: ScimFixture;
+
+beforeAll(async () => {
+  fixture = await setupFixture('scim-bulk-multi');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanup();
+});
+
+const bulk = (operations: any[]) =>
+  performPost(fixture.scimEndpoint, '/Bulk', JSON.stringify({ schemas: [SCHEMA_BULK_REQUEST], Operations: operations }), {
+    'Content-type': 'application/json',
+    Authorization: `Bearer ${fixture.scimAccessToken}`,
+  });
+
+const idOf = (location: string) => location.substring(location.lastIndexOf('/') + 1);
+
+/** Creates `count` users through a single bulk request and returns their ids. */
+async function seedUsers(count: number): Promise<string[]> {
+  const operations = Array.from({ length: count }, () => ({
+    method: 'POST',
+    path: '/Users',
+    bulkId: uniqueName('bulk', true),
+    data: { schemas: [SCHEMA_USER], userName: uniqueName('multi', true) },
+  }));
+  const response = await bulk(operations).expect(200);
+  response.body.Operations.forEach((op) => expect(op.status).toEqual('201'));
+  return response.body.Operations.map((op) => idOf(op.location));
+}
+
+const putOp = (id: string, displayName: string, withBulkId: boolean) => ({
+  method: 'PUT',
+  path: `/Users/${id}`,
+  ...(withBulkId ? { bulkId: uniqueName('bulk', true) } : {}),
+  data: { schemas: [SCHEMA_USER], userName: uniqueName('multi', true), displayName },
+});
+
+const patchOp = (id: string, displayName: string, withBulkId: boolean) => ({
+  method: 'PATCH',
+  path: `/Users/${id}`,
+  ...(withBulkId ? { bulkId: uniqueName('bulk', true) } : {}),
+  data: { schemas: [SCHEMA_PATCH_OP], Operations: [{ op: 'replace', path: 'displayName', value: displayName }] },
+});
+
+async function readUser(id: string) {
+  const response = await performGet(`${fixture.scimEndpoint}/Users/${id}`, '', {
+    Authorization: `Bearer ${fixture.scimAccessToken}`,
+  }).expect(200);
+  return response.body;
+}
+
+describe('SCIM Bulk - updating several users at once', () => {
+  it.each([
+    ['PUT', true],
+    ['PUT', false],
+    ['PATCH', true],
+    ['PATCH', false],
+  ])('updates three users with %s, bulkIds=%s', async (method, withBulkId) => {
+    const ids = await seedUsers(3);
+    const build = method === 'PUT' ? putOp : patchOp;
+    const names = ids.map(() => `renamed-${random.alphaNumeric(8)}`);
+
+    const response = await bulk(ids.map((id, i) => build(id, names[i], withBulkId as boolean))).expect(200);
+
+    expect(response.body.Operations).toHaveLength(3);
+    response.body.Operations.forEach((op) => expect(op.status).toEqual('200'));
+    // Each user takes its own new name, so the operations are not applied to the wrong record.
+    for (let i = 0; i < ids.length; i++) {
+      expect(await readUser(ids[i])).toMatchObject({ displayName: names[i] });
+    }
+  });
+
+  it('applies the valid updates and reports 404 for the unknown user', async () => {
+    const ids = await seedUsers(2);
+    const names = ids.map(() => `renamed-${random.alphaNumeric(8)}`);
+
+    const response = await bulk([
+      putOp(ids[0], names[0], true),
+      putOp(random.uuid(), 'never-applied', true),
+      putOp(ids[1], names[1], true),
+    ]).expect(200);
+
+    expect(response.body.Operations.map((op) => op.status)).toEqual(['200', '404', '200']);
+    expect(await readUser(ids[0])).toMatchObject({ displayName: names[0] });
+    expect(await readUser(ids[1])).toMatchObject({ displayName: names[1] });
+  });
+
+  it('reports a missing userName on update against only that operation', async () => {
+    // The create path rejects a missing userName; this is the update path, which validates
+    // separately.
+    const ids = await seedUsers(3);
+    const names = ids.map(() => `renamed-${random.alphaNumeric(8)}`);
+    const invalid = { ...putOp(ids[1], names[1], true), data: { schemas: [SCHEMA_USER] } };
+
+    const response = await bulk([putOp(ids[0], names[0], true), invalid, putOp(ids[2], names[2], true)]).expect(200);
+
+    expect(response.body.Operations.map((op) => op.status)).toEqual(['200', '400', '200']);
+    expect(response.body.Operations[1].response.detail).toContain('userName');
+    expect(await readUser(ids[0])).toMatchObject({ displayName: names[0] });
+    expect(await readUser(ids[2])).toMatchObject({ displayName: names[2] });
+  });
+
+  it('is idempotent when the same update is sent twice', async () => {
+    const ids = await seedUsers(2);
+    const names = ids.map(() => `renamed-${random.alphaNumeric(8)}`);
+    const operations = ids.map((id, i) => putOp(id, names[i], true));
+
+    await bulk(operations).expect(200);
+    const second = await bulk(operations).expect(200);
+
+    second.body.Operations.forEach((op) => expect(op.status).toEqual('200'));
+    for (let i = 0; i < ids.length; i++) {
+      expect(await readUser(ids[i])).toMatchObject({ displayName: names[i] });
+    }
+  });
+});
+
+describe('SCIM Bulk - deleting several users at once', () => {
+  it.each([[true], [false]])('deletes three users, bulkIds=%s', async (withBulkId) => {
+    const ids = await seedUsers(3);
+
+    const response = await bulk(
+      ids.map((id) => ({
+        method: 'DELETE',
+        path: `/Users/${id}`,
+        ...(withBulkId ? { bulkId: uniqueName('bulk', true) } : {}),
+      })),
+    ).expect(200);
+
+    expect(response.body.Operations).toHaveLength(3);
+    response.body.Operations.forEach((op) => expect(op.status).toEqual('204'));
+    for (const id of ids) {
+      const lookup = await performGet(`${fixture.scimEndpoint}/Users/${id}`, '', {
+        Authorization: `Bearer ${fixture.scimAccessToken}`,
+      });
+      expect(lookup.status).toBe(404);
+    }
+  });
+
+  it('reports 404 for every user when none of them exists', async () => {
+    const response = await bulk(
+      Array.from({ length: 3 }, () => ({ method: 'DELETE', path: `/Users/${random.uuid()}`, bulkId: uniqueName('bulk', true) })),
+    ).expect(200);
+
+    expect(response.body.Operations.map((op) => op.status)).toEqual(['404', '404', '404']);
+  });
+
+  it('deletes the users that exist and reports 404 for those that do not', async () => {
+    const [existing] = await seedUsers(1);
+
+    const response = await bulk([
+      { method: 'DELETE', path: `/Users/${random.uuid()}`, bulkId: uniqueName('bulk', true) },
+      { method: 'DELETE', path: `/Users/${existing}`, bulkId: uniqueName('bulk', true) },
+      { method: 'DELETE', path: `/Users/${random.uuid()}`, bulkId: uniqueName('bulk', true) },
+    ]).expect(200);
+
+    expect(response.body.Operations.map((op) => op.status)).toEqual(['404', '204', '404']);
+    const lookup = await performGet(`${fixture.scimEndpoint}/Users/${existing}`, '', {
+      Authorization: `Bearer ${fixture.scimAccessToken}`,
+    });
+    expect(lookup.status).toBe(404);
+  });
+});

--- a/gravitee-am-test/specs/gateway/scim/scim-bulk-preregistration.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/scim/scim-bulk-preregistration.jest.spec.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { getUser } from '@management-commands/user-management-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { clearEmails, countEmailsFor, waitForEmails } from '@utils-commands/email-commands';
+import { ScimFixture, setupFixture } from './fixture/scim-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+const SCHEMA_BULK_REQUEST = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest';
+const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+const SCHEMA_CUSTOM_USER = 'urn:ietf:params:scim:schemas:extension:custom:2.0:User';
+
+let fixture: ScimFixture;
+
+beforeAll(async () => {
+  fixture = await setupFixture('scim-bulk-prereg');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanup();
+});
+
+type Candidate = { userName: string; email: string; preRegistration: boolean };
+
+const candidate = (preRegistration: boolean): Candidate => {
+  const userName = uniqueName('prereg', true);
+  return { userName, email: `${userName}@user.com`, preRegistration };
+};
+
+const operationFor = (c: Candidate) => ({
+  method: 'POST',
+  path: '/Users',
+  bulkId: uniqueName('bulk', true),
+  data: {
+    schemas: [SCHEMA_USER, SCHEMA_CUSTOM_USER],
+    userName: c.userName,
+    emails: [{ value: c.email, type: 'work', primary: true }],
+    [SCHEMA_CUSTOM_USER]: { preRegistration: c.preRegistration },
+  },
+});
+
+/** Sends one bulk request creating every candidate, and asserts each operation returned 201. */
+async function bulkCreate(candidates: Candidate[]) {
+  await Promise.all(candidates.map((c) => clearEmails(c.email)));
+
+  const response = await performPost(
+    fixture.scimEndpoint,
+    '/Bulk',
+    JSON.stringify({ schemas: [SCHEMA_BULK_REQUEST], Operations: candidates.map(operationFor) }),
+    { 'Content-type': 'application/json', Authorization: `Bearer ${fixture.scimAccessToken}` },
+  ).expect(200);
+
+  expect(response.body.Operations).toHaveLength(candidates.length);
+  response.body.Operations.forEach((op) => expect(op.status).toEqual('201'));
+  return response.body.Operations;
+}
+
+/**
+ * Reads the created user through the management API. The SCIM representation does not carry
+ * `enabled`, and a bulk operation returns only a location rather than the created body.
+ */
+async function readUser(location: string) {
+  return getUser(fixture.domain.id, fixture.accessToken, location.substring(location.lastIndexOf('/') + 1));
+}
+
+/*
+ * `enabled` is false for every user created here, pre-registered or not, because none is given a
+ * password — so it does not distinguish the two and is not asserted. `preRegistration` on the user
+ * and the registration email are what actually differ.
+ */
+describe('SCIM Bulk - pre-registration', () => {
+  it('marks every user for pre-registration and emails each one when all are pre-registered', async () => {
+    const candidates = [candidate(true), candidate(true), candidate(true)];
+
+    const operations = await bulkCreate(candidates);
+
+    for (const op of operations) {
+      expect(await readUser(op.location)).toMatchObject({ preRegistration: true, registrationCompleted: false });
+    }
+    // One registration email per user, each carrying its own confirmation link.
+    const emails = await waitForEmails(candidates.map((c) => c.email));
+    emails.forEach((email) => expect(email.extractLink()).toContain('token='));
+  });
+
+  it('sends no email when no user is pre-registered', async () => {
+    const candidates = [candidate(false), candidate(false), candidate(false)];
+
+    const operations = await bulkCreate(candidates);
+
+    for (const op of operations) {
+      expect(await readUser(op.location)).toMatchObject({ preRegistration: false });
+    }
+    // A pre-registered user in the same domain is the control: once its email lands, the staging
+    // processor has run, so the absence of the others is a result rather than a race.
+    const control = candidate(true);
+    await bulkCreate([control]);
+    await waitForEmails([control.email]);
+
+    for (const c of candidates) {
+      expect(await countEmailsFor(c.email)).toBe(0);
+    }
+  });
+
+  it('lets every pre-registered user complete registration from their own email', async () => {
+    const candidates = [candidate(true), candidate(true), candidate(true)];
+
+    const operations = await bulkCreate(candidates);
+    const emails = await waitForEmails(candidates.map((c) => c.email));
+
+    // Each link must complete registration for its own user, so a bulk request cannot hand out
+    // links that resolve to the same account.
+    for (let i = 0; i < candidates.length; i++) {
+      const confirmation = await fixture.confirmRegistrationLink(emails[i].extractLink());
+      expect(confirmation.headers['location']).toContain('success=registration_completed');
+
+      expect(await readUser(operations[i].location)).toMatchObject({ enabled: true, registrationCompleted: true });
+    }
+  });
+
+  it('emails only the pre-registered users when the request is mixed', async () => {
+    const preRegistered = [candidate(true), candidate(true)];
+    const plain = [candidate(false), candidate(false)];
+
+    const operations = await bulkCreate([preRegistered[0], plain[0], preRegistered[1], plain[1]]);
+
+    expect(await readUser(operations[0].location)).toMatchObject({ preRegistration: true });
+    expect(await readUser(operations[1].location)).toMatchObject({ preRegistration: false });
+    expect(await readUser(operations[2].location)).toMatchObject({ preRegistration: true });
+    expect(await readUser(operations[3].location)).toMatchObject({ preRegistration: false });
+
+    await waitForEmails(preRegistered.map((c) => c.email));
+    for (const c of plain) {
+      expect(await countEmailsFor(c.email)).toBe(0);
+    }
+  });
+});

--- a/gravitee-am-test/specs/gateway/scim/scim-bulk-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/scim/scim-bulk-validation.jest.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { performPost } from '@gateway-commands/oauth-oidc-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { ScimFixture, setupFixture } from './fixture/scim-fixture';
+import { setup } from '../../test-fixture';
+
+setup(200000);
+
+const SCHEMA_BULK_REQUEST = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest';
+const SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
+
+let fixture: ScimFixture;
+
+beforeAll(async () => {
+  fixture = await setupFixture('scim-bulk-validation');
+});
+
+afterAll(async () => {
+  if (fixture) await fixture.cleanup();
+});
+
+const bulk = (body: any, token = fixture.scimAccessToken) =>
+  performPost(fixture.scimEndpoint, '/Bulk', typeof body === 'string' ? body : JSON.stringify(body), {
+    'Content-type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  });
+
+const createOp = (overrides: any = {}) => {
+  const userName = uniqueName('user', true);
+  return {
+    method: 'POST',
+    path: '/Users',
+    bulkId: uniqueName('bulk', true),
+    data: { schemas: [SCHEMA_USER], userName },
+    ...overrides,
+  };
+};
+
+const request = (operations: any[]) => ({ schemas: [SCHEMA_BULK_REQUEST], Operations: operations });
+
+/** Two valid operations either side of the one under test, to prove the failure is scoped to it. */
+const withNeighbours = (subject: any) => request([createOp(), subject, createOp()]);
+
+describe('SCIM Bulk - request-level validation', () => {
+  it('rejects a request with no body', async () => {
+    const response = await bulk('');
+
+    expect(response.status).toBe(400);
+    expect(response.body.detail).toContain('BulkRequest is required');
+  });
+
+  it('rejects a request with no operations', async () => {
+    const response = await bulk(request([]));
+
+    expect(response.status).toBe(400);
+    expect(response.body.detail).toContain('at least one operation');
+  });
+
+  it('rejects a bulkId reused across operations, without creating anything', async () => {
+    const sharedBulkId = uniqueName('bulk', true);
+    const first = createOp({ bulkId: sharedBulkId });
+    const untouched = createOp();
+    const second = createOp({ bulkId: sharedBulkId });
+
+    const response = await bulk(request([first, untouched, second]));
+
+    expect(response.status).toBe(400);
+    expect(response.body.detail).toContain('bulkId must be unique');
+
+    // The whole request is refused, so even the operation carrying a distinct bulkId is not
+    // applied. Re-creating its username has to succeed — a 409 would mean it had been created.
+    const retry = await bulk(request([createOp({ data: untouched.data })]));
+    expect(retry.status).toBe(200);
+    expect(retry.body.Operations[0].status).toEqual('201');
+  });
+
+  it.each([
+    ['no token', undefined],
+    ['a malformed token', 'not-a-real-token'],
+  ])('rejects a request with %s', async (_label, token) => {
+    const response = await performPost(fixture.scimEndpoint, '/Bulk', JSON.stringify(request([createOp()])), {
+      'Content-type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('SCIM Bulk - per-operation validation', () => {
+  it('reports a missing userName against only that operation', async () => {
+    const response = await bulk(withNeighbours(createOp({ data: { schemas: [SCHEMA_USER] } })));
+
+    expect(response.status).toBe(200);
+    const [first, subject, third] = response.body.Operations;
+    expect(first.status).toEqual('201');
+    expect(third.status).toEqual('201');
+    expect(subject.status).toEqual('400');
+    expect(subject.response.detail).toContain('userName');
+  });
+
+  it('reports an invalid email format against only that operation', async () => {
+    const subject = createOp();
+    subject.data = { ...subject.data, emails: [{ value: 'qatest.co@m', type: 'work', primary: true }] };
+
+    const response = await bulk(withNeighbours(subject));
+
+    expect(response.status).toBe(200);
+    const operations = response.body.Operations;
+    expect(operations[0].status).toEqual('201');
+    expect(operations[2].status).toEqual('201');
+    expect(operations[1].status).toEqual('400');
+    expect(operations[1].response.detail).toContain('email');
+  });
+
+  it('reports a missing bulkId against only that operation', async () => {
+    const subject = createOp();
+    delete subject.bulkId;
+
+    const response = await bulk(withNeighbours(subject));
+
+    expect(response.status).toBe(200);
+    const operations = response.body.Operations;
+    expect(operations[0].status).toEqual('201');
+    expect(operations[2].status).toEqual('201');
+    expect(operations[1].status).toEqual('400');
+    expect(operations[1].response.detail).toContain('bulkId');
+  });
+
+  it('reports missing schemas against only that operation', async () => {
+    const response = await bulk(withNeighbours(createOp({ data: { userName: uniqueName('user', true) } })));
+
+    expect(response.status).toBe(200);
+    const operations = response.body.Operations;
+    expect(operations[0].status).toEqual('201');
+    expect(operations[2].status).toEqual('201');
+    expect(operations[1].status).toEqual('400');
+    expect(operations[1].response.detail).toContain('schemas');
+  });
+
+  it('reports a path outside /Users against only that operation', async () => {
+    const response = await bulk(withNeighbours(createOp({ path: '/NotUsers' })));
+
+    expect(response.status).toBe(200);
+    const operations = response.body.Operations;
+    expect(operations[0].status).toEqual('201');
+    expect(operations[2].status).toEqual('201');
+    expect(operations[1].status).toEqual('400');
+    expect(operations[1].response.detail).toContain('/Users');
+  });
+});


### PR DESCRIPTION
## :id: Reference related issue. 
https://gravitee.atlassian.net/browse/AM-7653

## :pencil2: A description of the changes proposed in the pull request

Adds 34 Jest tests across 4 new spec files and 4 JUnit tests. SCIM bulk goes from 71 to 105 tests, `ProvisioningUserServiceTest` from 46 to 50.

Xray holds 65 manual cases for SCIM bulk; all 65 were read and mapped against the existing 13 tests, and about 9 were covered. These close the four areas that had none.

- `scim-bulk-preregistration` (4) — all `preRegistration: true`, all `false`, **mixed**, and each user completing registration from their own email
- `scim-bulk-validation` (10) — empty body, empty `Operations`, auth, duplicate `bulkId`; then per-operation `userName`, email format, `bulkId`, `schemas` and path
- `scim-bulk-multi-operation` (11) — multi-user PUT/PATCH with and without bulkIds, partial failure, idempotency, multi-delete, mixed delete, and a missing `userName` on the update path
- `scim-bulk-fail-on-errors` (9) — DELETE, PUT and PATCH, which were untested; the two existing tests are POST only

**JUnit** adds bulk in *synchronous* mode, bulk-level staging (N users → N staged emails), the retry policy and the dropped-email metric. The two existing async tests set `bulkEnabled=true` but create a single user.

### Integration tests now run with async email

`GRAVITEE_EMAIL_BULK_ENABLED=true` on the gateway, so SCIM pre-registration emails go through the staging processor rather than being sent inline — the more complex path, and the one worth exercising end to end. JUnit keeps the synchronous case.

`GRAVITEE_EMAIL_BULK_PERIOD=1` (default 5s) is the processor's tick, so emails land in 1–2s.

The flag is gateway-wide, so this was checked rather than assumed: it is read in only two places and its only behavioural branch is the SCIM pre-registration path. All 20 email-dependent specs were run with it enabled — **157 passed**, including the non-SCIM `confirm-pre-registration` spec.

### :warning: Two existing files are modified

**`api/commands/utils/email-commands.ts` (+57/-0)** — purely additive. `waitForEmail`, `waitForEmails` and `countEmailsFor` poll the mailbox instead of `getLastEmail`'s fixed 1-second read. Nothing is removed and `getLastEmail` is untouched, so existing callers are unaffected.

**`specs/gateway/scim/fixture/scim-fixture.ts` (+6/-4)** — `setupFixture` gains an **optional** `domainNamePrefix` defaulting to `'scim'`, and `extractConfirmRegistrationLink` polls rather than sleeping. The four existing SCIM specs produce the same domain names and behave identically; the polling change is what makes pre-registration assertions work in async mode.

### Deliberately not duplicated

`checkBulkRequest` runs once per request and is method-agnostic — the bulkId uniqueness check spans all operations regardless of method. The manual cases that repeat "empty request", "empty operations", "invalid token" and "duplicate bulkId" per method exercise the same code, so they are covered once rather than four times. The update path validates separately from create, so that one does have its own test.

## :memo: Test scenarios 
SCIM folder run repeatedly: 105 tests green. JUnit: 50 green. Each new assertion was checked with a negative control — breaking the input makes the test fail.

Two findings while writing them: `enabled` is `false` for a SCIM-created user whether or not it is pre-registered (neither gets a password), so asserting it would pass for the wrong reason — the tests assert `preRegistration` and the email instead. And the retry could only be observed by counting subscriptions, not mock invocations, since `retryWhen` resubscribes to the returned `Completable` rather than calling `push` again.

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA
