### PR TITLE
feat: id jag part 2

### DIFF
--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -14325,9 +14325,9 @@ components:
           additionalProperties:
             type: string
             description: One-to-one mapping from domain scope to the name this authority
-              knows it by. Unmapped domain scopes are dropped (fail-closed).
+              knows it by. A requested domain scope with no mapping is refused.
           description: One-to-one mapping from domain scope to the name this authority
-            knows it by. Unmapped domain scopes are dropped (fail-closed).
+            knows it by. A requested domain scope with no mapping is refused.
       title: Cross App Access settings
     CspSettings:
       type: object

--- a/docs/mapi/openapi.yaml
+++ b/docs/mapi/openapi.yaml
@@ -14305,10 +14305,11 @@ components:
       properties:
         audSubMapping:
           type: string
-          description: Expression evaluated against the user profile (variable "user")
-            to produce the optional "aud_sub" claim. The claim is omitted when the
-            expression yields nothing.
-          example: "{#user.email}"
+          description: "Expression producing the optional \"aud_sub\" claim, with\
+            \ the user profile available as context.attributes['user']. The claim\
+            \ is omitted when the expression yields nothing, and issuance is refused\
+            \ when the expression fails."
+          example: "{#context.attributes['user'].email}"
           maxLength: 512
         enabled:
           type: boolean

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/Claims.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/jwt/Claims.java
@@ -138,6 +138,8 @@ public interface Claims {
 
     String SESSION_ID = "session_id";
 
+    String AUD_SUB = "aud_sub";
+
     /**
      * RFC 8693 Token Exchange - Actor claim for delegation scenarios.
      * Contains a JSON object with claims identifying the actor (at minimum "sub").

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -293,7 +293,8 @@ public class TokenServiceImpl implements TokenService {
     }
 
     private Single<Token> createIdJagResponse(OAuth2Request oAuth2Request, Client client, User endUser) {
-        return idJagService.create(oAuth2Request, client, endUser)
+        return Single.fromCallable(() -> createExecutionContext(oAuth2Request, client, endUser))
+                .flatMap(executionContext -> idJagService.create(oAuth2Request, client, endUser, executionContext))
                 .doOnSuccess(idJag -> auditService.report(
                         AuditBuilder.builder(ClientTokenAuditBuilder.class)
                                 .idJag(idJag.tokenId())

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImpl.java
@@ -304,6 +304,7 @@ public class TokenServiceImpl implements TokenService {
                 .map(idJag -> {
                     ExchangedIdJag token = new ExchangedIdJag(idJag.value());
                     token.setExpiresIn(idJag.expiresIn());
+                    token.setScope(idJag.scope());
                     return (Token) token;
                 })
                 .doOnError(error -> auditService.report(

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/jackson/ExchangedIdJagSerializer.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/jackson/ExchangedIdJagSerializer.java
@@ -36,6 +36,9 @@ public class ExchangedIdJagSerializer extends StdSerializer<ExchangedIdJag> {
         jsonGenerator.writeStringField(Token.TOKEN_TYPE, token.getTokenType());
         jsonGenerator.writeNumberField(Token.EXPIRES_IN, token.getExpiresIn());
         jsonGenerator.writeStringField(Token.ISSUED_TOKEN_TYPE, token.getIssuedTokenType());
+        if (token.getScope() != null) {
+            jsonGenerator.writeStringField(Token.SCOPE, token.getScope());
+        }
         jsonGenerator.writeEndObject();
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/IdJagTarget.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/IdJagTarget.java
@@ -29,7 +29,8 @@ public record IdJagTarget(
         String audience,
         String resource,
         String clientId,
-        Map<String, String> scopeMappings
+        Map<String, String> scopeMappings,
+        String audSubMapping
 ) {
 
     public IdJagTarget {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/IdJagTarget.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/IdJagTarget.java
@@ -15,9 +15,41 @@
  */
 package io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange;
 
+import io.gravitee.am.gateway.handler.oauth2.exception.InvalidScopeException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
 public record IdJagTarget(
         String audience,
         String resource,
-        String clientId
+        String clientId,
+        Map<String, String> scopeMappings
 ) {
+
+    public IdJagTarget {
+        scopeMappings = scopeMappings == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(scopeMappings));
+    }
+
+    public void requireMapped(Collection<String> domainScopes) {
+        Set<String> unmapped = domainScopes.stream()
+                .filter(scope -> !scopeMappings.containsKey(scope))
+                .collect(Collectors.toCollection(TreeSet::new));
+        if (!unmapped.isEmpty()) {
+            throw new InvalidScopeException("Scope has no mapping at audience " + audience + ": " + String.join(" ", unmapped));
+        }
+    }
+
+    public String partnerScope(Collection<String> domainScopes) {
+        return scopeMappings.entrySet().stream()
+                .filter(mapping -> domainScopes.contains(mapping.getKey()))
+                .map(Map.Entry::getValue)
+                .distinct()
+                .collect(Collectors.joining(" "));
+    }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
@@ -56,6 +56,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -242,7 +243,8 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
         return new IdJagTarget(
                 trustDomain.getDomainIdentifier(),
                 resolved.resourceServer().getResource(),
-                resolved.row().getClientId());
+                resolved.row().getClientId(),
+                trustDomain.getCrossAppAccess().getScopeMappings());
     }
 
     private Map<String, ResolvedResourceServer> survivingRows(ApplicationCrossAppAccessSettings crossAppAccess, TrustedDomain trustDomain) {
@@ -532,10 +534,7 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
                                                      TokenRequest tokenRequest, Client client, Domain domain,
                                                      IdJagTarget idJagTarget) {
         if (idJagTarget != null) {
-            if (requestedScopes != null && !requestedScopes.isEmpty()) {
-                return Single.error(new InvalidRequestException("scope is not supported for requested_token_type: " + TokenType.ID_JAG));
-            }
-            return Single.just(Collections.emptySet());
+            return grantIdJagScopes(requestedScopes, idJagTarget);
         }
         boolean noRequestedScopes = requestedScopes == null || requestedScopes.isEmpty();
         Set<String> clientScopes = noRequestedScopes ? getClientDefaultScopes(client) : getClientScopes(client);
@@ -556,6 +555,16 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
             return Single.just(requestedScopes);
         }
         return Single.error(new InvalidScopeException("Requested scope is not allowed"));
+    }
+
+    private static Single<Set<String>> grantIdJagScopes(Set<String> requestedScopes, IdJagTarget idJagTarget) {
+        if (requestedScopes.isEmpty()) {
+            return Single.just(new LinkedHashSet<>(idJagTarget.scopeMappings().keySet()));
+        }
+        return Single.fromCallable(() -> {
+            idJagTarget.requireMapped(requestedScopes);
+            return requestedScopes;
+        });
     }
 
     private Single<TokenExchangeResult> buildImpersonationResult(TokenRequest tokenRequest,

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImpl.java
@@ -46,6 +46,7 @@ import io.gravitee.am.model.application.TokenExchangeOAuthSettings;
 import io.gravitee.am.model.application.TokenExchangeScopeHandling;
 import io.gravitee.am.model.oidc.Client;
 import io.gravitee.am.model.oidc.CrossAppAccessResourceServer;
+import io.gravitee.am.model.oidc.CrossAppAccessSettings;
 import io.gravitee.am.model.oidc.TrustedDomain;
 import io.reactivex.rxjava3.core.Single;
 import lombok.Builder;
@@ -240,11 +241,13 @@ public class TokenExchangeServiceImpl implements TokenExchangeService {
         }
 
         ResolvedResourceServer resolved = selectResourceServer(byResourceServer, singleIdJagResource(tokenRequest), audience);
+        CrossAppAccessSettings crossAppAccessSettings = trustDomain.getCrossAppAccess();
         return new IdJagTarget(
                 trustDomain.getDomainIdentifier(),
                 resolved.resourceServer().getResource(),
                 resolved.row().getClientId(),
-                trustDomain.getCrossAppAccess().getScopeMappings());
+                crossAppAccessSettings.getScopeMappings(),
+                crossAppAccessSettings.getAudSubMapping());
     }
 
     private Map<String, ResolvedResourceServer> survivingRows(ApplicationCrossAppAccessSettings crossAppAccess, TrustedDomain trustDomain) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
@@ -120,6 +120,9 @@ public class OpenIDProviderMetadata {
     @JsonProperty("dpop_signing_alg_values_supported")
     private List<String> dpopSigningAlgValuesSupported;
 
+    @JsonProperty("identity_chaining_requested_token_types_supported")
+    private List<String> identityChainingRequestedTokenTypesSupported;
+
     @JsonProperty("display_values_supported")
     private List<String> displayValuesSupported;
 
@@ -432,6 +435,14 @@ public class OpenIDProviderMetadata {
 
     public void setDpopSigningAlgValuesSupported(List<String> dpopSigningAlgValuesSupported) {
         this.dpopSigningAlgValuesSupported = dpopSigningAlgValuesSupported;
+    }
+
+    public List<String> getIdentityChainingRequestedTokenTypesSupported() {
+        return identityChainingRequestedTokenTypesSupported;
+    }
+
+    public void setIdentityChainingRequestedTokenTypesSupported(List<String> identityChainingRequestedTokenTypesSupported) {
+        this.identityChainingRequestedTokenTypesSupported = identityChainingRequestedTokenTypesSupported;
     }
 
     public List<String> getDisplayValuesSupported() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.am.gateway.handler.oidc.service.discovery.impl;
 
 import io.gravitee.am.common.oauth2.CodeChallengeMethod;
+import io.gravitee.am.common.oauth2.TokenType;
 import io.gravitee.am.common.oidc.*;
 import io.gravitee.am.common.oidc.idtoken.Claims;
 import io.gravitee.am.common.utils.ConstantKeys;
@@ -173,6 +174,11 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService, Initi
         openIDProviderMetadata.setDpopSigningAlgValuesSupported(
                 JWAlgorithmUtils.resolveDpopSigningAlg(domain.getOidc() != null && domain.getOidc().getDpopSettings() != null
                         ? domain.getOidc().getDpopSettings().getDpopSigningAlgorithms() : null));
+
+        List<String> requestedTokenTypes = domain.useTokenExchange() ? domain.getTokenExchangeSettings().getAllowedRequestedTokenTypes() : null;
+        if (requestedTokenTypes != null && requestedTokenTypes.contains(TokenType.ID_JAG)) {
+            openIDProviderMetadata.setIdentityChainingRequestedTokenTypesSupported(List.of(TokenType.ID_JAG));
+        }
 
         if (domain.useFapiBrazilProfile()) {
             openIDProviderMetadata.setAcrValuesSupported(Stream.concat(AcrValues.values().stream(), BrazilAcrValues.values().stream()).collect(Collectors.toList()));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJag.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJag.java
@@ -18,6 +18,7 @@ package io.gravitee.am.gateway.handler.oidc.service.idjag;
 public record IdJag(
         String value,
         String tokenId,
-        long expiresIn
+        long expiresIn,
+        String scope
 ) {
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagService.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagService.java
@@ -18,9 +18,10 @@ package io.gravitee.am.gateway.handler.oidc.service.idjag;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.gateway.api.ExecutionContext;
 import io.reactivex.rxjava3.core.Single;
 
 public interface IdJagService {
 
-    Single<IdJag> create(OAuth2Request oAuth2Request, Client client, User user);
+    Single<IdJag> create(OAuth2Request oAuth2Request, Client client, User user, ExecutionContext executionContext);
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/impl/IdJagServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/impl/IdJagServiceImpl.java
@@ -32,6 +32,7 @@ import io.reactivex.rxjava3.core.Single;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Instant;
+import java.util.Set;
 
 public class IdJagServiceImpl implements IdJagService {
 
@@ -45,7 +46,8 @@ public class IdJagServiceImpl implements IdJagService {
     public Single<IdJag> create(OAuth2Request oAuth2Request, Client client, User user) {
         return Single.fromCallable(() -> createAssertion(oAuth2Request, client, user))
                 .flatMap(assertion -> jwtService.encode(assertion, client)
-                        .map(value -> new IdJag(value, assertion.getJti(), assertion.getExp() - assertion.getIat())));
+                        .map(value -> new IdJag(value, assertion.getJti(), assertion.getExp() - assertion.getIat(),
+                                (String) assertion.get(Claims.SCOPE))));
     }
 
     private JWT createAssertion(OAuth2Request oAuth2Request, Client client, User user) {
@@ -59,6 +61,11 @@ public class IdJagServiceImpl implements IdJagService {
         assertion.setAud(target.audience());
         assertion.put(Claims.CLIENT_ID, target.clientId());
         assertion.put(Parameters.RESOURCE, target.resource());
+        Set<String> grantedScopes = oAuth2Request.getScopes();
+        if (grantedScopes != null && !grantedScopes.isEmpty()) {
+            target.requireMapped(grantedScopes);
+            assertion.put(Claims.SCOPE, target.partnerScope(grantedScopes));
+        }
         assertion.setJti(SecureRandomString.generate());
         assertion.setIat(issuedAt);
         assertion.setExp(expiration(oAuth2Request, client, issuedAt));

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/impl/IdJagServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/idjag/impl/IdJagServiceImpl.java
@@ -19,22 +19,39 @@ import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.jwt.JwtType;
 import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.common.utils.SecureRandomString;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
+import io.gravitee.am.gateway.handler.oauth2.service.el.ExecutionContextTokenEnhancer;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.IdJagTarget;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
 import io.gravitee.am.gateway.handler.oidc.service.idjag.IdJag;
 import io.gravitee.am.gateway.handler.oidc.service.idjag.IdJagService;
+import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.gateway.api.ExecutionContext;
 import io.reactivex.rxjava3.core.Single;
+import lombok.CustomLog;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+@CustomLog
 public class IdJagServiceImpl implements IdJagService {
+
+    private static final Set<String> RESERVED_CLAIMS = Set.of(Claims.ISS, Claims.AUD, Claims.CLIENT_ID, Claims.JTI, Claims.EXP, Claims.IAT);
 
     @Autowired
     private JWTService jwtService;
@@ -43,14 +60,14 @@ public class IdJagServiceImpl implements IdJagService {
     private OpenIDDiscoveryService openIDDiscoveryService;
 
     @Override
-    public Single<IdJag> create(OAuth2Request oAuth2Request, Client client, User user) {
-        return Single.fromCallable(() -> createAssertion(oAuth2Request, client, user))
+    public Single<IdJag> create(OAuth2Request oAuth2Request, Client client, User user, ExecutionContext executionContext) {
+        return Single.fromCallable(() -> createAssertion(oAuth2Request, client, user, executionContext))
                 .flatMap(assertion -> jwtService.encode(assertion, client)
                         .map(value -> new IdJag(value, assertion.getJti(), assertion.getExp() - assertion.getIat(),
-                                (String) assertion.get(Claims.SCOPE))));
+                                Objects.toString(assertion.get(Claims.SCOPE), null))));
     }
 
-    private JWT createAssertion(OAuth2Request oAuth2Request, Client client, User user) {
+    private JWT createAssertion(OAuth2Request oAuth2Request, Client client, User user, ExecutionContext executionContext) {
         IdJagTarget target = oAuth2Request.getIdJagTarget();
         long issuedAt = Instant.now().getEpochSecond();
 
@@ -74,7 +91,53 @@ public class IdJagServiceImpl implements IdJagService {
             assertion.put(Claims.ACT, oAuth2Request.getActClaim());
         }
 
+        List<TokenClaim> customClaims = idJagCustomClaims(client);
+        if (customClaims.stream().noneMatch(claim -> Claims.AUD_SUB.equals(claim.getClaimName()))) {
+            audSub(target, executionContext).ifPresent(audSub -> assertion.put(Claims.AUD_SUB, audSub));
+        }
+        new ExecutionContextTokenEnhancer().enhanceToken(assertion, TokenTypeHint.ID_JAG, customClaims, executionContext);
+        if (assertion.get(Claims.SCOPE) instanceof Collection<?> scopes) {
+            assertion.put(Claims.SCOPE, scopes.stream().map(String::valueOf).collect(Collectors.joining(" ")));
+        }
+
         return assertion;
+    }
+
+    private static List<TokenClaim> idJagCustomClaims(Client client) {
+        if (client.getTokenCustomClaims() == null) {
+            return List.of();
+        }
+        return client.getTokenCustomClaims().stream()
+                .filter(claim -> TokenTypeHint.ID_JAG.equals(claim.getTokenType()))
+                .filter(claim -> {
+                    boolean reserved = RESERVED_CLAIMS.contains(claim.getClaimName());
+                    if (reserved) {
+                        log.warn("Ignoring reserved ID-JAG custom claim, claim={} clientId={}", claim.getClaimName(), client.getClientId());
+                    }
+                    return !reserved;
+                })
+                .toList();
+    }
+
+    private static Optional<String> audSub(IdJagTarget target, ExecutionContext executionContext) {
+        if (StringUtils.isBlank(target.audSubMapping())) {
+            return Optional.empty();
+        }
+        Object value;
+        try {
+            value = executionContext.getTemplateEngine().getValue(target.audSubMapping(), Object.class);
+        } catch (Exception e) {
+            log.warn("aud_sub mapping could not be evaluated, audience={}", target.audience());
+            throw new InvalidGrantException("The aud_sub mapping could not be evaluated for audience: " + target.audience());
+        }
+        if (ObjectUtils.isEmpty(value)) {
+            return Optional.empty();
+        }
+        if (value instanceof Collection<?> || value instanceof Map<?, ?> || value.getClass().isArray()) {
+            log.warn("aud_sub mapping produced several values, audience={}", target.audience());
+            throw new InvalidGrantException("The aud_sub mapping did not produce a single value for audience: " + target.audience());
+        }
+        return Optional.of(value.toString()).filter(StringUtils::isNotBlank);
     }
 
     private static long expiration(OAuth2Request oAuth2Request, Client client, long issuedAt) {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
@@ -46,6 +46,8 @@ import io.gravitee.am.service.AuditService;
 import io.gravitee.am.service.reporter.builder.AuditBuilder;
 import io.gravitee.am.service.reporter.builder.ClientTokenAuditBuilder;
 import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.am.common.utils.ConstantKeys;
+import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
@@ -1303,8 +1305,24 @@ public class TokenServiceImplTest {
         request.setSubjectTokenId("subject-jti-1");
         request.setSubjectTokenType(TokenType.ACCESS_TOKEN);
         request.setOrigin("https://auth.example.com");
-        request.setIdJagTarget(new IdJagTarget("https://auth.acme.com", "https://calendar.acme.com", "agent-at-acme", Map.of()));
+        request.setIdJagTarget(new IdJagTarget("https://auth.acme.com", "https://calendar.acme.com", "agent-at-acme", Map.of(), null));
+        when(executionContextFactory.create(any())).thenReturn(new SimpleExecutionContext(request, null));
         return request;
+    }
+
+    @Test
+    public void shouldHandTheIssuanceExecutionContextToTheIdJagService() {
+        OAuth2Request request = idJagRequest();
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
+                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, null)));
+
+        tokenService.create(request, createClient("agent-at-am"), createUser("user-123")).test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertComplete();
+
+        ArgumentCaptor<ExecutionContext> executionContext = ArgumentCaptor.forClass(ExecutionContext.class);
+        verify(idJagService).create(any(OAuth2Request.class), any(Client.class), any(User.class), executionContext.capture());
+        assertThat(executionContext.getValue().getAttribute(ConstantKeys.USER_CONTEXT_KEY)).extracting("id").isEqualTo("user-123");
     }
 
     @Test
@@ -1313,7 +1331,7 @@ public class TokenServiceImplTest {
         Client client = createClient("agent-at-am");
         User user = createUser("user-123");
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.just(new IdJag("eyJ0eXAiOiJvYXV0aC1pZC1qYWcrand0In0.payload.signature", "assertion-jti", 300, null)));
 
         TestObserver<Token> observer = tokenService.create(request, client, user).test();
@@ -1335,7 +1353,7 @@ public class TokenServiceImplTest {
         OAuth2Request request = idJagRequest();
         request.setScopes(Set.of("calendar.read"));
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, "read:calendar")));
 
         TestObserver<Token> observer = tokenService.create(request, createClient("agent-at-am"), createUser("user-123")).test();
@@ -1352,7 +1370,7 @@ public class TokenServiceImplTest {
         Client client = createClient("agent-at-am");
         client.setDomain("test-domain");
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, "read:calendar")));
 
         tokenService.create(request, client, createUser("user-123")).test()
@@ -1368,7 +1386,7 @@ public class TokenServiceImplTest {
     public void shouldNotStoreOrSignAnAssertionOutsideTheIdJagService() {
         OAuth2Request request = idJagRequest();
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, null)));
 
         tokenService.create(request, createClient("agent-at-am"), createUser("user-123")).test()
@@ -1386,7 +1404,7 @@ public class TokenServiceImplTest {
         Client client = createClient("agent-at-am");
         client.setDomain("test-domain");
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, null)));
 
         tokenService.create(request, client, createUser("user-123")).test()
@@ -1410,7 +1428,7 @@ public class TokenServiceImplTest {
         Client client = createClient("agent-at-am");
         client.setDomain("test-domain");
 
-        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class), any()))
                 .thenReturn(Single.error(new IllegalStateException("assertion refused")));
 
         tokenService.create(request, client, createUser("user-123")).test()

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/impl/TokenServiceImplTest.java
@@ -1303,7 +1303,7 @@ public class TokenServiceImplTest {
         request.setSubjectTokenId("subject-jti-1");
         request.setSubjectTokenType(TokenType.ACCESS_TOKEN);
         request.setOrigin("https://auth.example.com");
-        request.setIdJagTarget(new IdJagTarget("https://auth.acme.com", "https://calendar.acme.com", "agent-at-acme"));
+        request.setIdJagTarget(new IdJagTarget("https://auth.acme.com", "https://calendar.acme.com", "agent-at-acme", Map.of()));
         return request;
     }
 
@@ -1314,7 +1314,7 @@ public class TokenServiceImplTest {
         User user = createUser("user-123");
 
         when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
-                .thenReturn(Single.just(new IdJag("eyJ0eXAiOiJvYXV0aC1pZC1qYWcrand0In0.payload.signature", "assertion-jti", 300)));
+                .thenReturn(Single.just(new IdJag("eyJ0eXAiOiJvYXV0aC1pZC1qYWcrand0In0.payload.signature", "assertion-jti", 300, null)));
 
         TestObserver<Token> observer = tokenService.create(request, client, user).test();
         observer.awaitDone(5, TimeUnit.SECONDS);
@@ -1331,11 +1331,45 @@ public class TokenServiceImplTest {
     }
 
     @Test
+    public void shouldReturnTheAssertionsScopeInThePartnersVocabulary() {
+        OAuth2Request request = idJagRequest();
+        request.setScopes(Set.of("calendar.read"));
+
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, "read:calendar")));
+
+        TestObserver<Token> observer = tokenService.create(request, createClient("agent-at-am"), createUser("user-123")).test();
+        observer.awaitDone(5, TimeUnit.SECONDS);
+
+        observer.assertComplete();
+        observer.assertValue(token -> "read:calendar".equals(token.getScope()));
+    }
+
+    @Test
+    public void shouldAuditTheSecurityDomainsOwnScopeNames() {
+        OAuth2Request request = idJagRequest();
+        request.setScopes(Set.of("calendar.read"));
+        Client client = createClient("agent-at-am");
+        client.setDomain("test-domain");
+
+        when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
+                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, "read:calendar")));
+
+        tokenService.create(request, client, createUser("user-123")).test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertComplete();
+
+        assertThat(captureTokenAudit().getOutcome().getMessage())
+                .contains("calendar.read")
+                .doesNotContain("read:calendar");
+    }
+
+    @Test
     public void shouldNotStoreOrSignAnAssertionOutsideTheIdJagService() {
         OAuth2Request request = idJagRequest();
 
         when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
-                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300)));
+                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, null)));
 
         tokenService.create(request, createClient("agent-at-am"), createUser("user-123")).test()
                 .awaitDone(5, TimeUnit.SECONDS)
@@ -1353,7 +1387,7 @@ public class TokenServiceImplTest {
         client.setDomain("test-domain");
 
         when(idJagService.create(any(OAuth2Request.class), any(Client.class), any(User.class)))
-                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300)));
+                .thenReturn(Single.just(new IdJag("assertion", "assertion-jti", 300, null)));
 
         tokenService.create(request, client, createUser("user-123")).test()
                 .awaitDone(5, TimeUnit.SECONDS)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -2693,6 +2693,10 @@ public class TokenExchangeServiceImplTest {
         }
 
         private void trustDomainWith(CrossAppAccessResourceServer... resourceServers) {
+            trustDomainWith(Map.of(), resourceServers);
+        }
+
+        private void trustDomainWith(Map<String, String> scopeMappings, CrossAppAccessResourceServer... resourceServers) {
             TrustedDomain trustDomain = TrustedDomain.builder()
                     .id("td-1")
                     .name("acme")
@@ -2700,6 +2704,7 @@ public class TokenExchangeServiceImplTest {
                     .crossAppAccess(CrossAppAccessSettings.builder()
                             .enabled(true)
                             .resourceServers(List.of(resourceServers))
+                            .scopeMappings(scopeMappings)
                             .build())
                     .build();
             lenient().when(trustDomainManager.findByCrossAppAccessAudience(AUDIENCE)).thenReturn(java.util.Optional.of(trustDomain));
@@ -2859,15 +2864,51 @@ public class TokenExchangeServiceImplTest {
         }
 
         @Test
-        void shouldDenyAScopedRequestUntilScopesAreTranslated() {
-            trustDomainWith(resourceServer("rs-calendar", CALENDAR));
+        void shouldGrantARequestedScopeTheTrustedDomainMapsWhateverTheSubjectTokenCarries() {
+            trustDomainWith(Map.of("calendar.read", "read:calendar"), resourceServer("rs-calendar", CALENDAR));
             MultiValueMap<String, String> params = idJagParameters(AUDIENCE);
-            params.add(Parameters.SCOPE, "openid");
+            params.add(Parameters.SCOPE, "calendar.read");
+            TokenRequest tokenRequest = idJagRequest(params);
+
+            service.exchange(tokenRequest, clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactly("calendar.read");
+        }
+
+        @Test
+        void shouldGrantAMappedScopeToASubjectTokenCarryingNoScopeClaim() {
+            service = createService(List.of(scopeValidator(Set.of())));
+            trustDomainWith(Map.of("calendar.read", "read:calendar"), resourceServer("rs-calendar", CALENDAR));
+            MultiValueMap<String, String> params = idJagParameters(AUDIENCE);
+            params.add(Parameters.SCOPE, "calendar.read");
+            TokenRequest tokenRequest = idJagRequest(params);
+
+            service.exchange(tokenRequest, clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactly("calendar.read");
+        }
+
+        @Test
+        void shouldRefuseARequestedScopeWithNoMappingRatherThanNarrowTheGrant() {
+            trustDomainWith(Map.of("calendar.read", "read:calendar"), resourceServer("rs-calendar", CALENDAR));
+            MultiValueMap<String, String> params = idJagParameters(AUDIENCE);
+            params.add(Parameters.SCOPE, "calendar.read calendar.write");
 
             assertThatThrownBy(() -> service.exchange(idJagRequest(params),
                     clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet())
-                    .isInstanceOf(InvalidRequestException.class)
-                    .hasMessageContaining("scope is not supported");
+                    .isInstanceOf(InvalidScopeException.class)
+                    .hasMessageContaining("calendar.write");
+        }
+
+        @Test
+        void shouldGrantTheFullMappedSetWhenTheRequestNamesNoScope() {
+            trustDomainWith(Map.of("calendar.read", "read:calendar", "calendar.write", "write:calendar"),
+                    resourceServer("rs-calendar", CALENDAR));
+            TokenRequest tokenRequest = idJagRequest(idJagParameters(AUDIENCE));
+
+            service.exchange(tokenRequest, clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet();
+
+            assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("calendar.read", "calendar.write");
         }
 
         @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/token/tokenexchange/impl/TokenExchangeServiceImplTest.java
@@ -2697,6 +2697,10 @@ public class TokenExchangeServiceImplTest {
         }
 
         private void trustDomainWith(Map<String, String> scopeMappings, CrossAppAccessResourceServer... resourceServers) {
+            trustDomainWith(scopeMappings, null, resourceServers);
+        }
+
+        private void trustDomainWith(Map<String, String> scopeMappings, String audSubMapping, CrossAppAccessResourceServer... resourceServers) {
             TrustedDomain trustDomain = TrustedDomain.builder()
                     .id("td-1")
                     .name("acme")
@@ -2705,6 +2709,7 @@ public class TokenExchangeServiceImplTest {
                             .enabled(true)
                             .resourceServers(List.of(resourceServers))
                             .scopeMappings(scopeMappings)
+                            .audSubMapping(audSubMapping)
                             .build())
                     .build();
             lenient().when(trustDomainManager.findByCrossAppAccessAudience(AUDIENCE)).thenReturn(java.util.Optional.of(trustDomain));
@@ -2909,6 +2914,16 @@ public class TokenExchangeServiceImplTest {
             service.exchange(tokenRequest, clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet();
 
             assertThat(tokenRequest.getScopes()).containsExactlyInAnyOrder("calendar.read", "calendar.write");
+        }
+
+        @Test
+        void shouldCarryTheTrustedDomainsAudSubMappingToMinting() {
+            trustDomainWith(Map.of(), "{#context.attributes['user'].email}", resourceServer("rs-calendar", CALENDAR));
+
+            var result = service.exchange(idJagRequest(idJagParameters(AUDIENCE)),
+                    clientWithRows(row("rs-calendar", "acme-calendar-client")), domainAllowingIdJag()).blockingGet();
+
+            assertThat(result.idJagTarget().audSubMapping()).isEqualTo("{#context.attributes['user'].email}");
         }
 
         @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDDiscoveryServiceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.am.gateway.handler.oidc.service.discovery;
 
+import io.gravitee.am.common.oauth2.TokenType;
 import io.gravitee.am.common.oidc.AcrValues;
 import io.gravitee.am.common.oidc.BrazilAcrValues;
 import io.gravitee.am.common.oidc.CIBADeliveryMode;
@@ -24,6 +25,7 @@ import io.gravitee.am.gateway.handler.oauth2.service.scope.ScopeService;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.impl.OpenIDDiscoveryServiceImpl;
 import io.gravitee.am.gateway.handler.oidc.service.utils.JWAlgorithmUtils;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.model.TokenExchangeSettings;
 import io.gravitee.am.model.oidc.DPoPSettings;
 import io.gravitee.am.model.oidc.OIDCSettings;
 import org.junit.Before;
@@ -84,6 +86,45 @@ public class OpenIDDiscoveryServiceTest {
 
     private void filterPromptValues() {
         when(environment.getProperty("legacy.openid.filterCustomPrompt", Boolean.class, false)).thenReturn(true);
+    }
+
+    private static TokenExchangeSettings tokenExchangeAllowing(String... requestedTokenTypes) {
+        TokenExchangeSettings settings = new TokenExchangeSettings();
+        settings.setEnabled(true);
+        settings.setAllowedRequestedTokenTypes(List.of(requestedTokenTypes));
+        return settings;
+    }
+
+    @Test
+    public void shouldAdvertiseIdJagIssuanceWhenTheDomainPermitsIt() {
+        when(domain.useTokenExchange()).thenReturn(true);
+        when(domain.getTokenExchangeSettings()).thenReturn(tokenExchangeAllowing(TokenType.ACCESS_TOKEN, TokenType.ID_JAG));
+
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+
+        assertEquals(List.of(TokenType.ID_JAG), openIDProviderMetadata.getIdentityChainingRequestedTokenTypesSupported());
+    }
+
+    @Test
+    public void shouldNotAdvertiseIdJagIssuanceWhenTheDomainDoesNotPermitIt() {
+        when(domain.useTokenExchange()).thenReturn(true);
+        when(domain.getTokenExchangeSettings()).thenReturn(tokenExchangeAllowing(TokenType.ACCESS_TOKEN, TokenType.ID_TOKEN));
+
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+
+        assertNull(openIDProviderMetadata.getIdentityChainingRequestedTokenTypesSupported());
+    }
+
+    @Test
+    public void shouldNotAdvertiseIdJagIssuanceWhenTokenExchangeIsDisabled() {
+        TokenExchangeSettings disabled = tokenExchangeAllowing(TokenType.ID_JAG);
+        disabled.setEnabled(false);
+        when(domain.useTokenExchange()).thenReturn(false);
+        Mockito.lenient().when(domain.getTokenExchangeSettings()).thenReturn(disabled);
+
+        OpenIDProviderMetadata openIDProviderMetadata = openIDDiscoveryService.getConfiguration("/");
+
+        assertNull(openIDProviderMetadata.getIdentityChainingRequestedTokenTypesSupported());
     }
 
     @Test

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagServiceImplTest.java
@@ -19,14 +19,19 @@ import io.gravitee.am.common.jwt.Claims;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.jwt.JwtType;
 import io.gravitee.am.common.oauth2.Parameters;
+import io.gravitee.am.common.oauth2.TokenTypeHint;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidScopeException;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.IdJagTarget;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
 import io.gravitee.am.gateway.handler.oidc.service.idjag.impl.IdJagServiceImpl;
+import io.gravitee.am.model.TokenClaim;
 import io.gravitee.am.model.User;
 import io.gravitee.am.model.oidc.Client;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.ExecutionContext;
 import io.reactivex.rxjava3.core.Single;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,6 +63,15 @@ class IdJagServiceImplTest {
     private static final String AUDIENCE = "https://auth.acme.com";
     private static final String RESOURCE = "https://calendar.acme.com";
 
+    private static final String EMAIL = "{#context.attributes['user'].email}";
+    private static final String USERNAME = "{#context.attributes['user'].username}";
+    private static final String NOTHING = "{#context.attributes['user'].additionalInformation['acme_id']}";
+    private static final String BROKEN = "{#context.attributes['user'].noSuchProperty}";
+    private static final String CLIENT_ID = "{#context.attributes['client'].clientId}";
+    private static final String FORGED = "{#forged}";
+    private static final String FORGED_AUDIENCES = "{#forgedAudiences}";
+    private static final String SCOPES = "{#scopes}";
+
     @InjectMocks
     private final IdJagServiceImpl service = new IdJagServiceImpl();
 
@@ -66,18 +81,31 @@ class IdJagServiceImplTest {
     @Mock
     private OpenIDDiscoveryService openIDDiscoveryService;
 
+    @Mock
+    private ExecutionContext executionContext;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
     private final ArgumentCaptor<JWT> assertionCaptor = ArgumentCaptor.forClass(JWT.class);
 
     @BeforeEach
     void setUp() {
         lenient().when(openIDDiscoveryService.getIssuer(any())).thenReturn(ISSUER);
         lenient().when(jwtService.encode(any(JWT.class), any(Client.class))).thenReturn(Single.just("signed-assertion"));
+        lenient().when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
     }
 
     private static Client client(int idJagValiditySeconds) {
         Client client = new Client();
         client.setClientId("agent-at-am");
         client.setIdJagValiditySeconds(idJagValiditySeconds);
+        return client;
+    }
+
+    private static Client clientWithClaims(TokenClaim... claims) {
+        Client client = client(300);
+        client.setTokenCustomClaims(List.of(claims));
         return client;
     }
 
@@ -91,7 +119,15 @@ class IdJagServiceImplTest {
         OAuth2Request oAuth2Request = new OAuth2Request();
         oAuth2Request.setClientId("agent-at-am");
         oAuth2Request.setIdJagTarget(new IdJagTarget(AUDIENCE, RESOURCE, "agent-at-acme",
-                Map.of("calendar.read", "read:calendar", "calendar.write", "write:calendar")));
+                Map.of("calendar.read", "read:calendar", "calendar.write", "write:calendar"), null));
+        return oAuth2Request;
+    }
+
+    private static OAuth2Request requestWithAudSub(String audSubMapping) {
+        OAuth2Request oAuth2Request = request();
+        IdJagTarget target = oAuth2Request.getIdJagTarget();
+        oAuth2Request.setIdJagTarget(new IdJagTarget(target.audience(), target.resource(), target.clientId(),
+                target.scopeMappings(), audSubMapping));
         return oAuth2Request;
     }
 
@@ -102,7 +138,7 @@ class IdJagServiceImplTest {
     }
 
     private JWT mintedAssertion() {
-        service.create(request(), client(300), user()).blockingGet();
+        service.create(request(), client(300), user(), executionContext).blockingGet();
         return capturedAssertion();
     }
 
@@ -134,14 +170,14 @@ class IdJagServiceImplTest {
     void shouldSignWithTheApplicationCertificate() {
         Client client = client(300);
 
-        service.create(request(), client, user()).blockingGet();
+        service.create(request(), client, user(), executionContext).blockingGet();
 
         verify(jwtService).encode(any(JWT.class), eq(client));
     }
 
     @Test
     void shouldOmitTheScopeClaimWhenNoScopeIsGranted() {
-        IdJag idJag = service.create(request(), client(300), user()).blockingGet();
+        IdJag idJag = service.create(request(), client(300), user(), executionContext).blockingGet();
 
         assertThat(capturedAssertion()).doesNotContainKey(Claims.SCOPE);
         assertThat(idJag.scope()).isNull();
@@ -149,7 +185,7 @@ class IdJagServiceImplTest {
 
     @Test
     void shouldCarryTheGrantedScopesInThePartnersVocabulary() {
-        IdJag idJag = service.create(requestGranting("calendar.read", "calendar.write"), client(300), user()).blockingGet();
+        IdJag idJag = service.create(requestGranting("calendar.read", "calendar.write"), client(300), user(), executionContext).blockingGet();
         Object scopeClaim = capturedAssertion().get(Claims.SCOPE);
 
         assertThat(((String) scopeClaim).split(" ")).containsExactlyInAnyOrder("read:calendar", "write:calendar");
@@ -158,7 +194,7 @@ class IdJagServiceImplTest {
 
     @Test
     void shouldRefuseToMintAGrantedScopeWithNoMapping() {
-        service.create(requestGranting("calendar.read", "calendar.delete"), client(300), user())
+        service.create(requestGranting("calendar.read", "calendar.delete"), client(300), user(), executionContext)
                 .test()
                 .assertError(error -> error instanceof InvalidScopeException && error.getMessage().contains("calendar.delete"));
 
@@ -166,8 +202,148 @@ class IdJagServiceImplTest {
     }
 
     @Test
+    void shouldCarryAudSubFromTheTrustedDomainsExpression() {
+        when(templateEngine.getValue(EMAIL, Object.class)).thenReturn("jdoe@acme.com");
+
+        service.create(requestWithAudSub(EMAIL), client(300), user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion().get(Claims.AUD_SUB)).isEqualTo("jdoe@acme.com");
+    }
+
+    @Test
+    void shouldOmitAudSubWhenTheExpressionYieldsNothing() {
+        when(templateEngine.getValue(NOTHING, Object.class)).thenReturn(null);
+
+        service.create(requestWithAudSub(NOTHING), client(300), user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion()).doesNotContainKey(Claims.AUD_SUB);
+    }
+
+    @Test
+    void shouldOmitAudSubWhenTheExpressionYieldsAnEmptyString() {
+        when(templateEngine.getValue(EMAIL, Object.class)).thenReturn("");
+
+        service.create(requestWithAudSub(EMAIL), client(300), user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion()).doesNotContainKey(Claims.AUD_SUB);
+    }
+
+    @Test
+    void shouldOmitAudSubWhenTheExpressionYieldsAnEmptyCollection() {
+        when(templateEngine.getValue(EMAIL, Object.class)).thenReturn(List.of());
+
+        service.create(requestWithAudSub(EMAIL), client(300), user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion()).doesNotContainKey(Claims.AUD_SUB);
+    }
+
+    @Test
+    void shouldRefuseIssuanceWhenTheAudSubExpressionYieldsSeveralValues() {
+        when(templateEngine.getValue(EMAIL, Object.class)).thenReturn(List.of("jdoe@acme.com", "john@acme.com"));
+
+        service.create(requestWithAudSub(EMAIL), client(300), user(), executionContext)
+                .test()
+                .assertError(error -> error instanceof InvalidGrantException && error.getMessage().contains(AUDIENCE));
+
+        verify(jwtService, never()).encode(any(JWT.class), any(Client.class));
+    }
+
+    @Test
+    void shouldRefuseIssuanceWhenTheAudSubExpressionFails() {
+        when(templateEngine.getValue(BROKEN, Object.class))
+                .thenThrow(new IllegalStateException("EL1008E: Property 'noSuchProperty' cannot be found"));
+
+        service.create(requestWithAudSub(BROKEN), client(300), user(), executionContext)
+                .test()
+                .assertError(error -> error instanceof InvalidGrantException
+                        && error.getMessage().contains(AUDIENCE)
+                        && !error.getMessage().contains("EL1008E"));
+
+        verify(jwtService, never()).encode(any(JWT.class), any(Client.class));
+    }
+
+    @Test
+    void shouldApplyTheApplicationsIdJagCustomClaims() {
+        Client client = clientWithClaims(
+                TokenClaim.of(TokenTypeHint.ID_JAG, "tenant", CLIENT_ID),
+                TokenClaim.of(TokenTypeHint.ACCESS_TOKEN, "access_only", CLIENT_ID));
+        when(templateEngine.getValue(CLIENT_ID, Object.class)).thenReturn("acme-tenant");
+
+        service.create(request(), client, user(), executionContext).blockingGet();
+
+        JWT assertion = capturedAssertion();
+        assertThat(assertion.get("tenant")).isEqualTo("acme-tenant");
+        assertThat(assertion).doesNotContainKey("access_only");
+    }
+
+    @Test
+    void shouldLetTheApplicationsAudSubTakePrecedenceOverTheTrustedDomains() {
+        Client client = clientWithClaims(TokenClaim.of(TokenTypeHint.ID_JAG, Claims.AUD_SUB, USERNAME));
+        when(templateEngine.getValue(USERNAME, Object.class)).thenReturn("jdoe");
+        lenient().when(templateEngine.getValue(BROKEN, Object.class)).thenThrow(new IllegalStateException("EL1008E"));
+
+        service.create(requestWithAudSub(BROKEN), client, user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion().get(Claims.AUD_SUB)).isEqualTo("jdoe");
+    }
+
+    @Test
+    void shouldLetTheApplicationOverrideSub() {
+        Client client = clientWithClaims(TokenClaim.of(TokenTypeHint.ID_JAG, Claims.SUB, USERNAME));
+        when(templateEngine.getValue(USERNAME, Object.class)).thenReturn("jdoe");
+
+        service.create(request(), client, user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion().getSub()).isEqualTo("jdoe");
+    }
+
+    @Test
+    void shouldReportAListValuedScopeOverrideAsASpaceDelimitedString() {
+        Client client = clientWithClaims(TokenClaim.of(TokenTypeHint.ID_JAG, Claims.SCOPE, SCOPES));
+        when(templateEngine.getValue(SCOPES, Object.class)).thenReturn(List.of("read:calendar", "write:calendar"));
+
+        IdJag idJag = service.create(request(), client, user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion().get(Claims.SCOPE)).isEqualTo("read:calendar write:calendar");
+        assertThat(idJag.scope()).isEqualTo("read:calendar write:calendar");
+    }
+
+    @Test
+    void shouldIgnoreACustomClaimNamingOneOfTheAssertionsOwnIdentityClaims() {
+        Client client = clientWithClaims(
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.ISS, FORGED),
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.AUD, FORGED_AUDIENCES),
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.CLIENT_ID, FORGED),
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.JTI, FORGED),
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.EXP, FORGED),
+                TokenClaim.of(TokenTypeHint.ID_JAG, Claims.IAT, FORGED));
+        lenient().when(templateEngine.getValue(FORGED, Object.class)).thenReturn("forged");
+        lenient().when(templateEngine.getValue(FORGED_AUDIENCES, Object.class)).thenReturn(List.of("https://evil.example.com"));
+
+        service.create(request(), client, user(), executionContext).blockingGet();
+
+        JWT assertion = capturedAssertion();
+        assertThat(assertion.get(Claims.ISS)).isEqualTo(ISSUER);
+        assertThat(assertion.get(Claims.AUD)).isEqualTo(AUDIENCE);
+        assertThat(assertion.get(Claims.CLIENT_ID)).isEqualTo("agent-at-acme");
+        assertThat(assertion.get(Claims.JTI)).isNotEqualTo("forged");
+        assertThat(assertion.get(Claims.EXP)).isNotEqualTo("forged");
+        assertThat(assertion.get(Claims.IAT)).isNotEqualTo("forged");
+    }
+
+    @Test
+    void shouldKeepTheApplicationsCustomClaimsLenient() {
+        Client client = clientWithClaims(TokenClaim.of(TokenTypeHint.ID_JAG, "tenant", BROKEN));
+        when(templateEngine.getValue(BROKEN, Object.class)).thenThrow(new IllegalStateException("EL1008E"));
+
+        service.create(request(), client, user(), executionContext).blockingGet();
+
+        assertThat(capturedAssertion()).doesNotContainKey("tenant");
+    }
+
+    @Test
     void shouldTakeItsLifetimeFromTheApplicationSetting() {
-        service.create(request(), client(120), user()).blockingGet();
+        service.create(request(), client(120), user(), executionContext).blockingGet();
         JWT assertion = capturedAssertion();
 
         assertThat(assertion.getExp() - assertion.getIat()).isEqualTo(120);
@@ -175,7 +351,7 @@ class IdJagServiceImplTest {
 
     @Test
     void shouldReportTheMintedLifetimeAsExpiresIn() {
-        IdJag idJag = service.create(request(), client(120), user()).blockingGet();
+        IdJag idJag = service.create(request(), client(120), user(), executionContext).blockingGet();
 
         assertThat(idJag.expiresIn()).isEqualTo(120);
         assertThat(idJag.value()).isEqualTo("signed-assertion");
@@ -187,7 +363,7 @@ class IdJagServiceImplTest {
         OAuth2Request oAuth2Request = request();
         oAuth2Request.setExchangeExpiration(Date.from(Instant.now().plusSeconds(30)));
 
-        IdJag idJag = service.create(oAuth2Request, client(300), user()).blockingGet();
+        IdJag idJag = service.create(oAuth2Request, client(300), user(), executionContext).blockingGet();
         JWT assertion = capturedAssertion();
 
         assertThat(assertion.getExp() - assertion.getIat()).isLessThanOrEqualTo(30);
@@ -199,7 +375,7 @@ class IdJagServiceImplTest {
         OAuth2Request oAuth2Request = request();
         oAuth2Request.setExchangeExpiration(Date.from(Instant.now().plusSeconds(3600)));
 
-        service.create(oAuth2Request, client(300), user()).blockingGet();
+        service.create(oAuth2Request, client(300), user(), executionContext).blockingGet();
         JWT assertion = capturedAssertion();
 
         assertThat(assertion.getExp() - assertion.getIat()).isEqualTo(300);
@@ -211,7 +387,7 @@ class IdJagServiceImplTest {
         OAuth2Request oAuth2Request = request();
         oAuth2Request.setExchangeExpiration(subjectExpiration);
 
-        service.create(oAuth2Request, client(300), user()).blockingGet();
+        service.create(oAuth2Request, client(300), user(), executionContext).blockingGet();
 
         assertThat(capturedAssertion().getExp()).isEqualTo(subjectExpiration.toInstant().getEpochSecond());
     }
@@ -222,7 +398,7 @@ class IdJagServiceImplTest {
         oAuth2Request.setDelegation(true);
         oAuth2Request.setActClaim(Map.of(Claims.SUB, "actor-sub"));
 
-        service.create(oAuth2Request, client(300), user()).blockingGet();
+        service.create(oAuth2Request, client(300), user(), executionContext).blockingGet();
 
         assertThat(capturedAssertion().get(Claims.ACT)).isEqualTo(Map.of(Claims.SUB, "actor-sub"));
     }
@@ -234,8 +410,8 @@ class IdJagServiceImplTest {
 
     @Test
     void shouldMintADistinctJtiPerAssertion() {
-        service.create(request(), client(300), user()).blockingGet();
-        service.create(request(), client(300), user()).blockingGet();
+        service.create(request(), client(300), user(), executionContext).blockingGet();
+        service.create(request(), client(300), user(), executionContext).blockingGet();
 
         verify(jwtService, times(2)).encode(assertionCaptor.capture(), any(Client.class));
         assertThat(assertionCaptor.getAllValues().get(0).getJti())
@@ -248,7 +424,7 @@ class IdJagServiceImplTest {
         oAuth2Request.setOrigin("https://gateway.example.com/domain");
         when(openIDDiscoveryService.getIssuer("https://gateway.example.com/domain")).thenReturn("https://gateway.example.com/domain/oidc");
 
-        service.create(oAuth2Request, client(300), user()).blockingGet();
+        service.create(oAuth2Request, client(300), user(), executionContext).blockingGet();
 
         assertThat(capturedAssertion().getIss()).isEqualTo("https://gateway.example.com/domain/oidc");
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagServiceImplTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/idjag/IdJagServiceImplTest.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.common.jwt.JwtType;
 import io.gravitee.am.common.oauth2.Parameters;
 import io.gravitee.am.gateway.handler.common.jwt.JWTService;
+import io.gravitee.am.gateway.handler.oauth2.exception.InvalidScopeException;
 import io.gravitee.am.gateway.handler.oauth2.service.request.OAuth2Request;
 import io.gravitee.am.gateway.handler.oauth2.service.token.tokenexchange.IdJagTarget;
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryService;
@@ -38,11 +39,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,7 +90,14 @@ class IdJagServiceImplTest {
     private static OAuth2Request request() {
         OAuth2Request oAuth2Request = new OAuth2Request();
         oAuth2Request.setClientId("agent-at-am");
-        oAuth2Request.setIdJagTarget(new IdJagTarget(AUDIENCE, RESOURCE, "agent-at-acme"));
+        oAuth2Request.setIdJagTarget(new IdJagTarget(AUDIENCE, RESOURCE, "agent-at-acme",
+                Map.of("calendar.read", "read:calendar", "calendar.write", "write:calendar")));
+        return oAuth2Request;
+    }
+
+    private static OAuth2Request requestGranting(String... domainScopes) {
+        OAuth2Request oAuth2Request = request();
+        oAuth2Request.setScopes(Set.of(domainScopes));
         return oAuth2Request;
     }
 
@@ -130,8 +140,29 @@ class IdJagServiceImplTest {
     }
 
     @Test
-    void shouldNotCarryAScopeClaim() {
-        assertThat(mintedAssertion()).doesNotContainKey(Claims.SCOPE);
+    void shouldOmitTheScopeClaimWhenNoScopeIsGranted() {
+        IdJag idJag = service.create(request(), client(300), user()).blockingGet();
+
+        assertThat(capturedAssertion()).doesNotContainKey(Claims.SCOPE);
+        assertThat(idJag.scope()).isNull();
+    }
+
+    @Test
+    void shouldCarryTheGrantedScopesInThePartnersVocabulary() {
+        IdJag idJag = service.create(requestGranting("calendar.read", "calendar.write"), client(300), user()).blockingGet();
+        Object scopeClaim = capturedAssertion().get(Claims.SCOPE);
+
+        assertThat(((String) scopeClaim).split(" ")).containsExactlyInAnyOrder("read:calendar", "write:calendar");
+        assertThat(idJag.scope()).isEqualTo(scopeClaim);
+    }
+
+    @Test
+    void shouldRefuseToMintAGrantedScopeWithNoMapping() {
+        service.create(requestGranting("calendar.read", "calendar.delete"), client(300), user())
+                .test()
+                .assertError(error -> error instanceof InvalidScopeException && error.getMessage().contains("calendar.delete"));
+
+        verify(jwtService, never()).encode(any(JWT.class), any(Client.class));
     }
 
     @Test

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CrossAppAccessSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CrossAppAccessSettings.java
@@ -54,9 +54,10 @@ public class CrossAppAccessSettings {
     @Schema(description = "Resource servers this authority exposes behind that authorization server.")
     private List<CrossAppAccessResourceServer> resourceServers;
 
-    @Schema(description = "Expression evaluated against the user profile (variable \"user\") to produce the "
-            + "optional \"aud_sub\" claim. The claim is omitted when the expression yields nothing.",
-            example = "{#user.email}", maxLength = AUD_SUB_MAPPING_MAX_LENGTH)
+    @Schema(description = "Expression producing the optional \"aud_sub\" claim, with the user profile available as "
+            + "context.attributes['user']. The claim is omitted when the expression yields nothing, and issuance is "
+            + "refused when the expression fails.",
+            example = "{#context.attributes['user'].email}", maxLength = AUD_SUB_MAPPING_MAX_LENGTH)
     private String audSubMapping;
 
     @Schema(description = "One-to-one mapping from domain scope to the name this authority knows it by. "

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CrossAppAccessSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/CrossAppAccessSettings.java
@@ -60,7 +60,7 @@ public class CrossAppAccessSettings {
     private String audSubMapping;
 
     @Schema(description = "One-to-one mapping from domain scope to the name this authority knows it by. "
-            + "Unmapped domain scopes are dropped (fail-closed).")
+            + "A requested domain scope with no mapping is refused.")
     private Map<String, String> scopeMappings;
 
     public CrossAppAccessSettings(CrossAppAccessSettings other) {

--- a/gravitee-am-test/api/management/models/CrossAppAccessSettings.ts
+++ b/gravitee-am-test/api/management/models/CrossAppAccessSettings.ts
@@ -41,7 +41,7 @@ import {
  */
 export interface CrossAppAccessSettings {
   /**
-   * Expression evaluated against the user profile (variable "user") to produce the optional "aud_sub" claim. The claim is omitted when the expression yields nothing.
+   * Expression producing the optional "aud_sub" claim, with the user profile available as context.attributes['user']. The claim is omitted when the expression yields nothing, and issuance is refused when the expression fails.
    * @type {string}
    * @memberof CrossAppAccessSettings
    */

--- a/gravitee-am-test/api/management/models/CrossAppAccessSettings.ts
+++ b/gravitee-am-test/api/management/models/CrossAppAccessSettings.ts
@@ -59,7 +59,7 @@ export interface CrossAppAccessSettings {
    */
   resourceServers?: Array<CrossAppAccessResourceServer>;
   /**
-   * One-to-one mapping from domain scope to the name this authority knows it by. Unmapped domain scopes are dropped (fail-closed).
+   * One-to-one mapping from domain scope to the name this authority knows it by. A requested domain scope with no mapping is refused.
    * @type {{ [key: string]: string; }}
    * @memberof CrossAppAccessSettings
    */

--- a/gravitee-am-test/specs/gateway/token-exchange/fixtures/id-jag-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/fixtures/id-jag-fixture.ts
@@ -21,7 +21,7 @@ import { safeDeleteDomain, startDomain, waitForOidcReady } from '@management-com
 import { createDomain } from '@management-commands/domain-management-commands';
 import { getAllIdps } from '@management-commands/idp-management-commands';
 import { buildCreateAndTestUser } from '@management-commands/user-management-commands';
-import { createTrustedDomain } from '../../../management/domain/fixtures/cross-app-access-fixture';
+import { createTrustedDomain, updateTrustedDomain } from '../../../management/domain/fixtures/cross-app-access-fixture';
 import { getAllCertificates } from '@management-commands/certificate-management-commands';
 import { updateApplication } from '@management-commands/application-management-commands';
 import { createTestApp } from '@utils-commands/application-commands';
@@ -59,7 +59,13 @@ export interface IdJagFixture {
   trustDomainId: string;
   subjectTokens: (scope?: string) => Promise<{ accessToken: string; idToken?: string; expiresIn: number }>;
   requestIdJag: (subjectToken: string, extraParams?: string, subjectTokenType?: string) => request.Test;
-  setCrossAppAccess: (crossAppAccessSettings: Record<string, unknown>, idJagValiditySeconds?: number) => Promise<void>;
+  setCrossAppAccess: (
+    crossAppAccessSettings: Record<string, unknown>,
+    idJagValiditySeconds?: number,
+    tokenCustomClaims?: Record<string, unknown>[],
+  ) => Promise<void>;
+  setAudSubMapping: (audSubMapping: string) => Promise<void>;
+  bothResourceServerSettings: () => Record<string, unknown>;
   setDomainAllowsIdJag: (allowed: boolean) => Promise<void>;
   awaitTokenAudit: (status: 'SUCCESS' | 'FAILURE', matches: (detail: any) => boolean) => Promise<any>;
   cleanUp: () => Promise<void>;
@@ -94,20 +100,35 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
 
   const audience = 'https://auth.acme.com/id-jag';
   const trustedKey = createTrustedIssuerKeyMaterial();
-  const trustDomain: any = await createTrustedDomain(domain.id, accessToken, {
-    name: uniqueName('acme-authority'),
+  const trustDomainName = uniqueName('acme-authority');
+  const scopeMappings = { profile: 'read:profile', email: 'read:email' };
+  const trustDomainBody = (crossAppAccess: Record<string, unknown>) => ({
+    name: trustDomainName,
     domainIdentifier: audience,
     keyMaterial: { source: 'PEM', certificate: trustedKey.certificatePem },
-    crossAppAccess: {
+    crossAppAccess,
+  });
+  const trustDomain: any = await createTrustedDomain(
+    domain.id,
+    accessToken,
+    trustDomainBody({
       enabled: true,
       resourceServers: [
         { name: 'Calendar', resource: 'https://calendar.acme.com' },
         { name: 'Mail', resource: 'https://mail.acme.com' },
       ],
-      scopeMappings: { profile: 'read:profile', email: 'read:email' },
-    },
-  });
+      scopeMappings,
+    }),
+  );
   const [calendar, mail] = trustDomain.crossAppAccess.resourceServers as IdJagResourceServer[];
+
+  const bothResourceServerSettings = () => ({
+    enabled: true,
+    resourceServers: [
+      { trustDomainId: trustDomain.id, resourceServerId: calendar.id, clientId: 'agent-at-acme-calendar' },
+      { trustDomainId: trustDomain.id, resourceServerId: mail.id, clientId: 'agent-at-acme-mail' },
+    ],
+  });
 
   const idpSet = await getAllIdps(domain.id, accessToken);
   const defaultIdp = idpSet.values().next().value;
@@ -123,13 +144,7 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
         grantTypes: ['password', 'refresh_token', 'urn:ietf:params:oauth:grant-type:token-exchange'],
         scopeSettings: DOMAIN_SCOPES,
         idJagValiditySeconds: 300,
-        crossAppAccessSettings: {
-          enabled: true,
-          resourceServers: [
-            { trustDomainId: trustDomain.id, resourceServerId: calendar.id, clientId: 'agent-at-acme-calendar' },
-            { trustDomainId: trustDomain.id, resourceServerId: mail.id, clientId: 'agent-at-acme-mail' },
-          ],
-        },
+        crossAppAccessSettings: bothResourceServerSettings(),
       },
     },
     identityProviders: new Set([{ identity: defaultIdp.id, priority: 0 }]),
@@ -169,7 +184,11 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
       { 'Content-type': 'application/x-www-form-urlencoded', Authorization: `Basic ${basicAuth}` },
     );
 
-  const setCrossAppAccess = async (crossAppAccessSettings: Record<string, unknown>, idJagValiditySeconds = 300) => {
+  const setCrossAppAccess = async (
+    crossAppAccessSettings: Record<string, unknown>,
+    idJagValiditySeconds = 300,
+    tokenCustomClaims: Record<string, unknown>[] = [],
+  ) => {
     await waitForSyncAfter(domain.id, () =>
       updateApplication(domain.id, accessToken, {
         certificate,
@@ -180,9 +199,21 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
             scopeSettings: DOMAIN_SCOPES,
             idJagValiditySeconds,
             crossAppAccessSettings,
+            tokenCustomClaims,
           },
         },
       } as any, application.id),
+    );
+  };
+
+  const setAudSubMapping = async (audSubMapping: string) => {
+    await waitForSyncAfter(domain.id, () =>
+      updateTrustedDomain(
+        domain.id,
+        accessToken,
+        trustDomain.id,
+        trustDomainBody({ enabled: true, resourceServers: [calendar, mail], scopeMappings, audSubMapping }),
+      ),
     );
   };
 
@@ -229,6 +260,8 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
     subjectTokens,
     requestIdJag,
     setCrossAppAccess,
+    setAudSubMapping,
+    bothResourceServerSettings,
     setDomainAllowsIdJag,
     awaitTokenAudit,
     cleanUp: () => safeDeleteDomain(domain.id, accessToken),

--- a/gravitee-am-test/specs/gateway/token-exchange/fixtures/id-jag-fixture.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/fixtures/id-jag-fixture.ts
@@ -104,6 +104,7 @@ export const setupIdJagFixture = async (): Promise<IdJagFixture> => {
         { name: 'Calendar', resource: 'https://calendar.acme.com' },
         { name: 'Mail', resource: 'https://mail.acme.com' },
       ],
+      scopeMappings: { profile: 'read:profile', email: 'read:email' },
     },
   });
   const [calendar, mail] = trustDomain.crossAppAccess.resourceServers as IdJagResourceServer[];

--- a/gravitee-am-test/specs/gateway/token-exchange/id-jag-identity.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/id-jag-identity.jest.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import { setup } from '../../test-fixture';
+import { ID_JAG_TOKEN_TYPE, IdJagFixture, setupIdJagFixture } from './fixtures/id-jag-fixture';
+
+setup(300000);
+
+const EMAIL = "{#context.attributes['user'].email}";
+const USERNAME = "{#context.attributes['user'].username}";
+const NOTHING = "{#context.attributes['user'].additionalInformation['acme_id']}";
+const BROKEN = "{#context.attributes['user'].noSuchProperty}";
+
+let fixture: IdJagFixture;
+
+const decode = (token: string) => jwt.decode(token) as any;
+
+const idJagClaim = (claimName: string, claimValue: string) => ({ tokenType: 'ID_JAG', claimName, claimValue });
+
+const configure = async (audSubMapping: string, tokenCustomClaims: Record<string, unknown>[] = []) => {
+  await fixture.setAudSubMapping(audSubMapping);
+  await fixture.setCrossAppAccess(fixture.bothResourceServerSettings(), 300, tokenCustomClaims);
+};
+
+const requestAssertion = async (expectedStatus: number) => {
+  const { accessToken } = await fixture.subjectTokens();
+  const target = `&audience=${encodeURIComponent(fixture.audience)}&resource=${encodeURIComponent(fixture.calendar.resource)}`;
+  return fixture.requestIdJag(accessToken, target).expect(expectedStatus);
+};
+
+const mintedClaims = async () => decode((await requestAssertion(200)).body.access_token);
+
+beforeAll(async () => {
+  fixture = await setupIdJagFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe("ID-JAG issuance - aud_sub from the trusted domain's expression", () => {
+  it('should carry the value the expression produces over the user profile', async () => {
+    await configure(EMAIL);
+
+    expect((await mintedClaims()).aud_sub).toBe(fixture.user.email);
+  });
+
+  it('should omit the claim and still issue when the expression yields nothing', async () => {
+    await configure(NOTHING);
+
+    expect(await mintedClaims()).not.toHaveProperty('aud_sub');
+  });
+
+  it('should refuse issuance when the expression fails outright, and audit it', async () => {
+    await configure(BROKEN);
+
+    const response = await requestAssertion(400);
+
+    expect(response.body.error).toBe('invalid_grant');
+    const audit = await fixture.awaitTokenAudit('FAILURE', (detail) => JSON.stringify(detail).includes('aud_sub mapping'));
+    expect(audit.outcome.message).toContain(fixture.audience);
+    expect(audit.outcome.message).toContain(ID_JAG_TOKEN_TYPE);
+  });
+});
+
+describe("ID-JAG issuance - the application's own ID-JAG claims", () => {
+  it('should be applied to the assertion', async () => {
+    await configure(EMAIL, [idJagClaim('tenant', 'acme-tenant')]);
+
+    const claims = await mintedClaims();
+
+    expect(claims.tenant).toBe('acme-tenant');
+    expect(claims.aud_sub).toBe(fixture.user.email);
+  });
+
+  it("should let an aud_sub claim take precedence over the trusted domain's expression", async () => {
+    await configure(BROKEN, [idJagClaim('aud_sub', USERNAME)]);
+
+    expect((await mintedClaims()).aud_sub).toBe(fixture.user.username);
+  });
+
+  it('should let a sub claim override the AM user id', async () => {
+    await configure(EMAIL, [idJagClaim('sub', USERNAME)]);
+
+    expect((await mintedClaims()).sub).toBe(fixture.user.username);
+  });
+
+  it("should ignore a claim naming one of the assertion's own identity claims", async () => {
+    await configure(
+      EMAIL,
+      ['iss', 'aud', 'client_id', 'jti', 'exp', 'iat'].map((claimName) => idJagClaim(claimName, 'forged')),
+    );
+
+    const claims = await mintedClaims();
+
+    expect(claims.iss).toBe(fixture.oidc.issuer);
+    expect(claims.aud).toBe(fixture.audience);
+    expect(claims.client_id).toBe('agent-at-acme-calendar');
+    expect(claims.jti).not.toBe('forged');
+    expect(typeof claims.exp).toBe('number');
+    expect(typeof claims.iat).toBe('number');
+  });
+});
+
+describe('Custom claims on access tokens and ID tokens', () => {
+  it('should stay lenient when their expression fails', async () => {
+    await configure(EMAIL, [
+      { tokenType: 'ACCESS_TOKEN', claimName: 'broken', claimValue: BROKEN },
+      { tokenType: 'ID_TOKEN', claimName: 'broken', claimValue: BROKEN },
+    ]);
+
+    const { accessToken, idToken } = await fixture.subjectTokens();
+
+    expect(decode(accessToken)).not.toHaveProperty('broken');
+    expect(decode(idToken)).not.toHaveProperty('broken');
+  });
+});

--- a/gravitee-am-test/specs/gateway/token-exchange/id-jag-issuance.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/id-jag-issuance.jest.spec.ts
@@ -37,14 +37,7 @@ const calendarWith = (scope?: string) =>
 
 const scopesOf = (scope: string) => scope.split(' ').sort();
 
-const bothResourceServers = () =>
-  fixture.setCrossAppAccess({
-    enabled: true,
-    resourceServers: [
-      { trustDomainId: fixture.trustDomainId, resourceServerId: fixture.calendar.id, clientId: 'agent-at-acme-calendar' },
-      { trustDomainId: fixture.trustDomainId, resourceServerId: fixture.mail.id, clientId: 'agent-at-acme-mail' },
-    ],
-  });
+const bothResourceServers = () => fixture.setCrossAppAccess(fixture.bothResourceServerSettings());
 
 beforeAll(async () => {
   fixture = await setupIdJagFixture();

--- a/gravitee-am-test/specs/gateway/token-exchange/id-jag-issuance.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/id-jag-issuance.jest.spec.ts
@@ -18,6 +18,7 @@ import jwt from 'jsonwebtoken';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { setup } from '../../test-fixture';
 import { ID_JAG_JOSE_TYPE, ID_JAG_TOKEN_TYPE, IdJagFixture, setupIdJagFixture } from './fixtures/id-jag-fixture';
+import { ID_TOKEN_TYPE } from './fixtures/token-exchange-fixture';
 
 setup(300000);
 
@@ -30,6 +31,11 @@ const audienceParam = () => `&audience=${encodeURIComponent(fixture.audience)}`;
 const resourceParam = (resource: string) => `&resource=${encodeURIComponent(resource)}`;
 
 const errorOf = (response: any) => response.body.error;
+
+const calendarWith = (scope?: string) =>
+  audienceParam() + resourceParam(fixture.calendar.resource) + (scope ? `&scope=${encodeURIComponent(scope)}` : '');
+
+const scopesOf = (scope: string) => scope.split(' ').sort();
 
 const bothResourceServers = () =>
   fixture.setCrossAppAccess({
@@ -100,19 +106,10 @@ describe('ID-JAG issuance - the assertion an agent takes to a partner', () => {
     const { idToken } = await fixture.subjectTokens();
 
     const response = await fixture
-      .requestIdJag(idToken, audienceParam() + resourceParam(fixture.calendar.resource), 'urn:ietf:params:oauth:token-type:id_token')
+      .requestIdJag(idToken, audienceParam() + resourceParam(fixture.calendar.resource), ID_TOKEN_TYPE)
       .expect(200);
 
     expect(decode(response.body.access_token).payload.resource).toBe(fixture.calendar.resource);
-  });
-
-  it('should carry no scope claim while scopes are untranslated', async () => {
-    const { accessToken } = await fixture.subjectTokens();
-
-    const response = await fixture.requestIdJag(accessToken, audienceParam() + resourceParam(fixture.calendar.resource)).expect(200);
-
-    expect(decode(response.body.access_token).payload.scope).toBeUndefined();
-    expect(response.body.scope).toBeUndefined();
   });
 
   it('should select the named resource server among those behind the audience', async () => {
@@ -201,16 +198,6 @@ describe('ID-JAG issuance - every check fails closed', () => {
     expect(errorOf(response)).toBe('invalid_target');
   });
 
-  it('should refuse a request naming scope while scopes are untranslated', async () => {
-    const { accessToken } = await fixture.subjectTokens();
-
-    const response = await fixture
-      .requestIdJag(accessToken, `${audienceParam()}${resourceParam(fixture.calendar.resource)}&scope=openid`)
-      .expect(400);
-
-    expect(errorOf(response)).toBe('invalid_request');
-  });
-
   it('should refuse an application whose Cross App Access block is disabled', async () => {
     await fixture.setCrossAppAccess({
       enabled: false,
@@ -221,6 +208,68 @@ describe('ID-JAG issuance - every check fails closed', () => {
     const response = await fixture.requestIdJag(accessToken, audienceParam() + resourceParam(fixture.calendar.resource)).expect(400);
 
     expect(errorOf(response)).toBe('unauthorized_client');
+  });
+});
+
+describe("ID-JAG issuance - scopes travel in the partner's vocabulary", () => {
+  beforeAll(bothResourceServers);
+
+  it('should carry a requested domain scope under the name the trusted domain maps it to', async () => {
+    const { accessToken } = await fixture.subjectTokens();
+
+    const response = await fixture.requestIdJag(accessToken, calendarWith('profile')).expect(200);
+
+    expect(decode(response.body.access_token).payload.scope).toBe('read:profile');
+    expect(response.body.scope).toBe('read:profile');
+  });
+
+  it('should grant the full mapped set when the request names no scope', async () => {
+    const { accessToken } = await fixture.subjectTokens();
+
+    const response = await fixture.requestIdJag(accessToken, calendarWith()).expect(200);
+
+    expect(scopesOf(decode(response.body.access_token).payload.scope)).toEqual(['read:email', 'read:profile']);
+    expect(scopesOf(response.body.scope)).toEqual(['read:email', 'read:profile']);
+  });
+
+  it('should refuse a requested scope with no mapping rather than narrow the assertion', async () => {
+    const { accessToken } = await fixture.subjectTokens();
+
+    const response = await fixture.requestIdJag(accessToken, calendarWith('profile openid')).expect(400);
+
+    expect(errorOf(response)).toBe('invalid_scope');
+  });
+
+  it('should audit a refused scope under the name the agent asked for', async () => {
+    const { accessToken } = await fixture.subjectTokens();
+    const unmappedScope = `unmapped-${Date.now()}`;
+    await fixture.requestIdJag(accessToken, calendarWith(unmappedScope)).expect(400);
+
+    const audit = await fixture.awaitTokenAudit('FAILURE', (detail) => JSON.stringify(detail).includes(unmappedScope));
+
+    expect(audit.outcome.message).toContain(`"SCOPE":"${unmappedScope}"`);
+    expect(audit.outcome.message).toContain(ID_JAG_TOKEN_TYPE);
+  });
+
+  it('should grant the same scopes whether the subject token is an ID token or an access token', async () => {
+    const { accessToken, idToken } = await fixture.subjectTokens('openid');
+
+    const fromAccessToken = await fixture.requestIdJag(accessToken, calendarWith('email')).expect(200);
+    const fromIdToken = await fixture.requestIdJag(idToken, calendarWith('email'), ID_TOKEN_TYPE).expect(200);
+
+    expect(decode(fromAccessToken.body.access_token).payload.scope).toBe('read:email');
+    expect(decode(fromIdToken.body.access_token).payload.scope).toBe('read:email');
+  });
+
+  it("should audit the security domain's own scope names, not the partner's", async () => {
+    const { accessToken } = await fixture.subjectTokens();
+    const response = await fixture.requestIdJag(accessToken, calendarWith('profile')).expect(200);
+    const assertionId = decode(response.body.access_token).payload.jti;
+
+    const audit = await fixture.awaitTokenAudit('SUCCESS', (detail) => JSON.stringify(detail).includes(assertionId));
+
+    expect(audit.outcome.message).toContain('"path":"/SCOPE","value":"profile"');
+    expect(JSON.stringify(audit)).not.toContain('read:profile');
   });
 });
 

--- a/gravitee-am-test/specs/gateway/token-exchange/id-jag-metadata.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/token-exchange/id-jag-metadata.jest.spec.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { waitForOidcReady } from '@management-commands/domain-management-commands';
+import { setup } from '../../test-fixture';
+import { ID_JAG_TOKEN_TYPE, IdJagFixture, setupIdJagFixture } from './fixtures/id-jag-fixture';
+
+setup(300000);
+
+const IDENTITY_CHAINING_REQUESTED_TOKEN_TYPES = 'identity_chaining_requested_token_types_supported';
+
+let fixture: IdJagFixture;
+
+const fetchDiscoveryDocument = async (): Promise<Record<string, unknown>> =>
+  (await waitForOidcReady(fixture.domain.hrid, { timeoutMs: 30000, intervalMs: 500 })).body;
+
+beforeAll(async () => {
+  fixture = await setupIdJagFixture();
+});
+
+afterAll(async () => {
+  if (fixture) {
+    await fixture.cleanUp();
+  }
+});
+
+describe('ID-JAG issuance - advertised in the authorization server metadata', () => {
+  it('should name the ID-JAG token type while the domain permits it', async () => {
+    await fixture.setDomainAllowsIdJag(true);
+
+    expect((await fetchDiscoveryDocument())[IDENTITY_CHAINING_REQUESTED_TOKEN_TYPES]).toEqual([ID_JAG_TOKEN_TYPE]);
+  });
+
+  it('should drop only that field, rather than empty it, once the domain stops permitting it', async () => {
+    await fixture.setDomainAllowsIdJag(true);
+    const { [IDENTITY_CHAINING_REQUESTED_TOKEN_TYPES]: advertised, ...everythingElse } = await fetchDiscoveryDocument();
+
+    await fixture.setDomainAllowsIdJag(false);
+
+    expect(advertised).toEqual([ID_JAG_TOKEN_TYPE]);
+    expect(await fetchDiscoveryDocument()).toEqual(everythingElse);
+  });
+});

--- a/gravitee-am-test/specs/management/domain/cross-app-access-validation.jest.spec.ts
+++ b/gravitee-am-test/specs/management/domain/cross-app-access-validation.jest.spec.ts
@@ -47,7 +47,7 @@ describe('Cross App Access - the block round-trips through the management API', 
 
     expect(reloaded.crossAppAccess.enabled).toBe(true);
     expect(reloaded.domainIdentifier).toBe('https://issuer.example.com/roundtrip');
-    expect(reloaded.crossAppAccess.audSubMapping).toBe('{#user.email}');
+    expect(reloaded.crossAppAccess.audSubMapping).toBe("{#context.attributes['user'].email}");
     expect(reloaded.crossAppAccess.scopeMappings).toEqual({ 'domain:read': 'calendar.read' });
     expect(reloaded.crossAppAccess.resourceServers).toHaveLength(1);
     expect(reloaded.crossAppAccess.resourceServers[0].name).toBe('Calendar');

--- a/gravitee-am-test/specs/management/domain/fixtures/cross-app-access-fixture.ts
+++ b/gravitee-am-test/specs/management/domain/fixtures/cross-app-access-fixture.ts
@@ -102,6 +102,13 @@ const callTrustedDomains = async (
 export const createTrustedDomain = (domainId: string, accessToken: string, body: Record<string, unknown>): Promise<TrustedDomainResponse> =>
   callTrustedDomains(trustedDomainsUrl(domainId), 'POST', accessToken, body);
 
+export const updateTrustedDomain = (
+  domainId: string,
+  accessToken: string,
+  trustDomainId: string,
+  body: Record<string, unknown>,
+): Promise<TrustedDomainResponse> => callTrustedDomains(trustedDomainsUrl(domainId, trustDomainId), 'PUT', accessToken, body);
+
 export const setupCrossAppAccessFixture = async (): Promise<CrossAppAccessFixture> => {
   const accessToken = await requestAdminAccessToken();
   const trustedKey = createTrustedIssuerKeyMaterial();
@@ -118,7 +125,7 @@ export const setupCrossAppAccessFixture = async (): Promise<CrossAppAccessFixtur
     crossAppAccess: (resource: string, overrides: Record<string, unknown> = {}) => ({
       enabled: true,
       resourceServers: [{ name: 'Calendar', resource }],
-      audSubMapping: '{#user.email}',
+      audSubMapping: "{#context.attributes['user'].email}",
       scopeMappings: { 'domain:read': 'calendar.read' },
       ...overrides,
     }),

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
@@ -432,11 +432,11 @@
           [(ngModel)]="audSubMapping"
           (ngModelChange)="onFieldChange()"
           [disabled]="!editMode"
-          placeholder="{#user.email}"
+          placeholder="{#context.attributes['user'].email}"
         />
         <mat-hint>
-          Evaluated over the user profile to produce the "aud_sub" claim, for every resource server of this authority. The claim is omitted
-          when the expression yields nothing.
+          Produces the "aud_sub" claim for every resource server of this authority, with the user profile at context.attributes['user']. The
+          claim is omitted when the expression yields nothing, and issuance is refused when the expression fails.
         </mat-hint>
       </mat-form-field>
 

--- a/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/trust-domains/form/trust-domain-form.component.html
@@ -442,7 +442,7 @@
 
       <h5 class="sub-section-title">Scope mappings</h5>
       <mat-hint class="section-hint">
-        Map domain scopes to the names this authority knows them by. Unmapped domain scopes are dropped.
+        Map domain scopes to the names this authority knows them by. A requested domain scope with no mapping is refused.
       </mat-hint>
       <div class="staging-row">
         <mat-form-field *ngIf="domainScopes?.length" appearance="outline" class="staging-field">


### PR DESCRIPTION
1. Set `aud_sub` to `{#context.attributes['user'].email}`
2. Set Custom claims ID_JAG xxx -> xxx2
3. Setup scope mapping on Trusted Domain (oidc -> hahah)

Obratin the access_token with openid scope for user with email u1@u1.com
Exchange ID_JAG, confirm claims:

```
"aud_sub": "u1@u1.com"
"xxx": "xxx2"
"scope": "hahah"
```