### PR TITLE
test: application OAuth 2.0 / OIDC settings (AM-5418)

### DIFF
--- a/gravitee-am-test/specs/gateway/application-oauth-settings/app-oauth-settings.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/application-oauth-settings/app-oauth-settings.jest.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { waitFor } from '@management-commands/domain-management-commands';
+import { decodeJwt } from '@utils-commands/jwt';
+import { setup } from '../../test-fixture';
+import {
+  APP_OAUTH_SETTINGS,
+  AppOAuthSettingsFixture,
+  authorize,
+  consentPageUrl,
+  expectAuthorizationCodeRedirect,
+  requestPasswordToken,
+  requestRefreshedToken,
+  setScopeSettings,
+  setupAppOAuthSettingsFixture,
+  signInAndConsent,
+} from './fixtures/app-oauth-settings-fixture';
+
+setup(200000);
+
+/**
+ * Application > Settings > OAuth 2.0 / OIDC: the per-application settings that change what the
+ * gateway issues — consent duration on a scope, the scope list itself, and refresh token validity.
+ * Access/ID token validity and the refresh grant itself are covered by the token-claims and
+ * refresh-token specs.
+ */
+const { CONSENT_SCOPE, TOGGLE_SCOPE, SHORT_CONSENT_SECONDS, LONG_CONSENT_SECONDS, REFRESH_VALIDITY_SECONDS } = APP_OAUTH_SETTINGS;
+const PAST_SHORT_CONSENT_MS = (SHORT_CONSENT_SECONDS + 1) * 1000;
+const PAST_REFRESH_VALIDITY_MS = (REFRESH_VALIDITY_SECONDS + 1) * 1000;
+
+let fixture: AppOAuthSettingsFixture;
+
+beforeAll(async () => {
+  fixture = await setupAppOAuthSettingsFixture();
+});
+
+afterAll(async () => {
+  await fixture?.cleanUp();
+});
+
+describe('Application OAuth settings - consent duration on a scope', () => {
+  it('should ask for consent again once the application-level approval duration has elapsed', async () => {
+    const user = fixture.users[0];
+    await setScopeSettings(fixture, fixture.consentApp, [
+      { scope: CONSENT_SCOPE, defaultScope: true, scopeApproval: SHORT_CONSENT_SECONDS },
+    ]);
+
+    const { session, callback } = await signInAndConsent(fixture, fixture.consentApp, user, [CONSENT_SCOPE]);
+    expectAuthorizationCodeRedirect(callback);
+
+    // Control: while the approval is live the consent page is skipped
+    const withinDuration = await authorize(fixture, fixture.consentApp, session);
+    expectAuthorizationCodeRedirect(withinDuration);
+
+    await waitFor(PAST_SHORT_CONSENT_MS);
+
+    const afterDuration = await authorize(fixture, fixture.consentApp, session);
+    expect(afterDuration.headers['location']).toContain(consentPageUrl(fixture));
+  });
+
+  it('should keep reusing consent after the approval duration is raised', async () => {
+    const user = fixture.users[1];
+    await setScopeSettings(fixture, fixture.consentApp, [
+      { scope: CONSENT_SCOPE, defaultScope: true, scopeApproval: LONG_CONSENT_SECONDS },
+    ]);
+
+    const { session, callback } = await signInAndConsent(fixture, fixture.consentApp, user, [CONSENT_SCOPE]);
+    expectAuthorizationCodeRedirect(callback);
+
+    // Same wait that expires the short approval: with the long one the consent page must stay skipped
+    await waitFor(PAST_SHORT_CONSENT_MS);
+
+    const afterShortWait = await authorize(fixture, fixture.consentApp, session);
+    expectAuthorizationCodeRedirect(afterShortWait);
+  });
+});
+
+describe('Application OAuth settings - adding and removing a scope', () => {
+  const user = () => fixture.users[0];
+
+  it('should issue a token carrying a scope once it is added to the application', async () => {
+    await setScopeSettings(fixture, fixture.scopeApp, [
+      { scope: 'openid', defaultScope: true },
+      { scope: TOGGLE_SCOPE, defaultScope: false },
+    ]);
+
+    const response = await requestPasswordToken(fixture, fixture.scopeApp, user(), TOGGLE_SCOPE).expect(200);
+    expect(response.body.scope).toEqual(TOGGLE_SCOPE);
+  });
+
+  it('should reject the same scope request once it is removed from the application', async () => {
+    await setScopeSettings(fixture, fixture.scopeApp, [{ scope: 'openid', defaultScope: true }]);
+
+    const rejected = await requestPasswordToken(fixture, fixture.scopeApp, user(), TOGGLE_SCOPE).expect(400);
+    expect(rejected.body).toEqual({ error: 'invalid_scope', error_description: `Invalid scope(s): ${TOGGLE_SCOPE}` });
+
+    // Control: the remaining scope is still issued, so it is the removal that is enforced, not the app being broken
+    const stillIssued = await requestPasswordToken(fixture, fixture.scopeApp, user()).expect(200);
+    expect(stillIssued.body.scope).toEqual('openid');
+  });
+});
+
+describe('Application OAuth settings - refresh token validity', () => {
+  const user = () => fixture.users[1];
+
+  it('should refresh while the refresh token is still within its validity', async () => {
+    const issued = await requestPasswordToken(fixture, fixture.refreshApp, user()).expect(200);
+    expect(issued.body.refresh_token).toEqual(expect.any(String));
+    // The setting is specific to the refresh token: the access token keeps its own default
+    const accessToken = decodeJwt(issued.body.access_token);
+    expect(accessToken.exp - accessToken.iat).toEqual(APP_OAUTH_SETTINGS.DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS);
+    const refreshToken = decodeJwt(issued.body.refresh_token);
+    expect(refreshToken.exp - refreshToken.iat).toEqual(REFRESH_VALIDITY_SECONDS);
+
+    const refreshed = await requestRefreshedToken(fixture, fixture.refreshApp, issued.body.refresh_token).expect(200);
+    expect(refreshed.body.access_token).toEqual(expect.any(String));
+    expect(refreshed.body.access_token).not.toEqual(issued.body.access_token);
+  });
+
+  it('should reject the refresh grant once the refresh token validity has elapsed', async () => {
+    const issued = await requestPasswordToken(fixture, fixture.refreshApp, user()).expect(200);
+
+    await waitFor(PAST_REFRESH_VALIDITY_MS);
+
+    const rejected = await requestRefreshedToken(fixture, fixture.refreshApp, issued.body.refresh_token).expect(400);
+    expect(rejected.body.error).toEqual('invalid_grant');
+    // "expired" when the stored token is still there, "invalid" once the store's TTL purge has removed it
+    expect(rejected.body.error_description).toMatch(/^Refresh token is (expired|invalid)$/);
+  });
+});

--- a/gravitee-am-test/specs/gateway/application-oauth-settings/fixtures/app-oauth-settings-fixture.ts
+++ b/gravitee-am-test/specs/gateway/application-oauth-settings/fixtures/app-oauth-settings-fixture.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { DomainOidcConfig, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, patchApplication, updateApplication } from '@management-commands/application-management-commands';
+import { createIdp, deleteIdp } from '@management-commands/idp-management-commands';
+import { createScope } from '@management-commands/scope-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { extractXsrfTokenAndActionResponse, performFormPost, performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export const APP_OAUTH_SETTINGS = {
+  DOMAIN_PREFIX: 'app-oauth-settings',
+  REDIRECT_URI: 'https://example.com/callback',
+  // Domain scopes with no expiry of their own, so only the application setting drives consent duration
+  CONSENT_SCOPE: 'orders',
+  TOGGLE_SCOPE: 'reports',
+  SHORT_CONSENT_SECONDS: 2,
+  LONG_CONSENT_SECONDS: 3600,
+  REFRESH_VALIDITY_SECONDS: 5,
+  DEFAULT_ACCESS_TOKEN_VALIDITY_SECONDS: 7200,
+  USER_PASSWORD: '#CoMpL3X-P@SsW0Rd',
+} as const;
+
+export interface TestUser {
+  username: string;
+  password: string;
+}
+
+export interface AppOAuthSettingsFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  // authorization_code app whose consent scope carries an application-level approval duration
+  consentApp: Application;
+  // password-grant app whose scope list is added to and removed from by the tests
+  scopeApp: Application;
+  // password + refresh_token app with a deliberately short refresh token validity
+  refreshApp: Application;
+  users: TestUser[];
+}
+
+export const setupAppOAuthSettingsFixture = async (): Promise<AppOAuthSettingsFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+  try {
+    const started = await setupDomainForTest(uniqueName(APP_OAUTH_SETTINGS.DOMAIN_PREFIX, true), { accessToken, waitForStart: true });
+    domain = started.domain;
+
+    await deleteIdp(domain.id, accessToken, 'default-idp-' + domain.id);
+    const users: TestUser[] = [0, 1].map((i) => ({
+      username: uniqueName(`oauth-settings-user-${i}`, true),
+      password: APP_OAUTH_SETTINGS.USER_PASSWORD,
+    }));
+    const idp = await createIdp(domain.id, accessToken, {
+      external: false,
+      type: 'inline-am-idp',
+      domainWhitelist: [],
+      configuration: JSON.stringify({
+        users: users.map((u) => ({ firstname: 'OAuth', lastname: 'Settings', username: u.username, password: u.password })),
+      }),
+      name: 'app-oauth-settings-idp',
+    });
+    const identityProviders = [{ identity: idp.id, priority: 0 }];
+
+    for (const key of [APP_OAUTH_SETTINGS.CONSENT_SCOPE, APP_OAUTH_SETTINGS.TOGGLE_SCOPE]) {
+      const scope = await createScope(domain.id, accessToken, { key, name: key, description: key });
+      expect(scope.key).toEqual(key);
+    }
+
+    const consentApp = await createTestApp(domain, accessToken, 'consent-app', {
+      grantTypes: ['authorization_code'],
+      scopeSettings: [
+        { scope: APP_OAUTH_SETTINGS.CONSENT_SCOPE, defaultScope: true, scopeApproval: APP_OAUTH_SETTINGS.SHORT_CONSENT_SECONDS },
+      ],
+      identityProviders,
+    });
+    const scopeApp = await createTestApp(domain, accessToken, 'scope-app', {
+      grantTypes: ['password'],
+      scopeSettings: [{ scope: 'openid', defaultScope: true }],
+      identityProviders,
+    });
+    // The last mutation is wrapped so the gateway has picked up everything created above
+    const refreshApp = await waitForSyncAfter(domain.id, () =>
+      createTestApp(domain, accessToken, 'refresh-app', {
+        grantTypes: ['password', 'refresh_token'],
+        scopeSettings: [{ scope: 'openid', defaultScope: true }],
+        refreshTokenValiditySeconds: APP_OAUTH_SETTINGS.REFRESH_VALIDITY_SECONDS,
+        identityProviders,
+      }),
+    );
+
+    return {
+      accessToken,
+      domain,
+      oidc: started.oidcConfig,
+      consentApp,
+      scopeApp,
+      refreshApp,
+      users,
+      cleanUp: async () => {
+        if (domain?.id && accessToken) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      await safeDeleteDomain(domain.id, accessToken).catch((e) => console.error('Cleanup failed:', e));
+    }
+    throw error;
+  }
+};
+
+interface AppOAuthOptions {
+  grantTypes: string[];
+  scopeSettings: Array<{ scope: string; defaultScope: boolean; scopeApproval?: number }>;
+  refreshTokenValiditySeconds?: number;
+  identityProviders: Array<{ identity: string; priority: number }>;
+}
+
+async function createTestApp(domain: Domain, accessToken: string, name: string, options: AppOAuthOptions): Promise<Application> {
+  const created = await createApplication(domain.id, accessToken, {
+    name: uniqueName(name, true),
+    type: 'WEB',
+    redirectUris: [APP_OAUTH_SETTINGS.REDIRECT_URI],
+  });
+  const oauth: Record<string, unknown> = {
+    redirectUris: [APP_OAUTH_SETTINGS.REDIRECT_URI],
+    grantTypes: options.grantTypes,
+    scopeSettings: options.scopeSettings,
+  };
+  if (options.refreshTokenValiditySeconds !== undefined) {
+    oauth.refreshTokenValiditySeconds = options.refreshTokenValiditySeconds;
+  }
+  const updated = await updateApplication(
+    domain.id,
+    accessToken,
+    { settings: { oauth }, identityProviders: new Set(options.identityProviders) },
+    created.id,
+  );
+  // The PUT response omits the secret; keep the one issued on creation for Basic auth
+  updated.settings.oauth.clientSecret = created.settings.oauth.clientSecret;
+  return updated;
+}
+
+/** Replaces the application's scope list and waits for the gateway to pick it up. */
+export const setScopeSettings = (
+  fixture: AppOAuthSettingsFixture,
+  app: Application,
+  scopeSettings: Array<{ scope: string; defaultScope: boolean; scopeApproval?: number }>,
+) =>
+  waitForSyncAfter(fixture.domain.id, () =>
+    patchApplication(fixture.domain.id, fixture.accessToken, { settings: { oauth: { scopeSettings } } }, app.id),
+  );
+
+export const requestPasswordToken = (fixture: AppOAuthSettingsFixture, app: Application, user: TestUser, scope?: string) =>
+  performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${user.username}&password=${encodeURIComponent(user.password)}` + (scope ? `&scope=${scope}` : ''),
+    { 'Content-type': 'application/x-www-form-urlencoded', Authorization: 'Basic ' + applicationBase64Token(app) },
+  );
+
+export const requestRefreshedToken = (fixture: AppOAuthSettingsFixture, app: Application, refreshToken: string) =>
+  performPost(fixture.oidc.token_endpoint, '', `grant_type=refresh_token&refresh_token=${refreshToken}`, {
+    'Content-type': 'application/x-www-form-urlencoded',
+    Authorization: 'Basic ' + applicationBase64Token(app),
+  });
+
+export interface AuthorizedSession {
+  // Gateway session cookie of the signed-in user, for re-running /oauth/authorize without logging in again
+  cookie: string | string[];
+}
+
+/** Starts an authorization_code request; with a session cookie the login step is skipped. */
+export const authorize = (fixture: AppOAuthSettingsFixture, app: Application, session?: AuthorizedSession) => {
+  const clientId = app.settings.oauth.clientId;
+  const params = `?response_type=code&client_id=${clientId}&redirect_uri=${APP_OAUTH_SETTINGS.REDIRECT_URI}`;
+  return performGet(fixture.oidc.authorization_endpoint, params, session ? { Cookie: session.cookie } : null).expect(302);
+};
+
+export const consentPageUrl = (fixture: AppOAuthSettingsFixture) => `${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/oauth/consent`;
+
+/**
+ * Signs the user in, approves the requested scopes on the consent page and returns the session
+ * along with the final redirect back to the application (which must carry an authorization code).
+ */
+export const signInAndConsent = async (fixture: AppOAuthSettingsFixture, app: Application, user: TestUser, scopes: string[]) => {
+  const authResponse = await authorize(fixture, app);
+  expect(authResponse.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/login`);
+
+  const loginForm = await extractXsrfTokenAndActionResponse(authResponse);
+  const postLogin = await performFormPost(
+    loginForm.action,
+    '',
+    { 'X-XSRF-TOKEN': loginForm.token, username: user.username, password: user.password, client_id: app.settings.oauth.clientId },
+    { Cookie: loginForm.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+  const session: AuthorizedSession = { cookie: postLogin.headers['set-cookie'] };
+
+  const postLoginRedirect = await performGet(postLogin.headers['location'], '', { Cookie: session.cookie }).expect(302);
+  expect(postLoginRedirect.headers['location']).toContain(consentPageUrl(fixture));
+
+  const consentForm = await extractXsrfTokenAndActionResponse(postLoginRedirect);
+  const approvals = Object.fromEntries(scopes.map((scope) => [`scope.${scope}`, true]));
+  const postConsent = await performFormPost(
+    consentForm.action,
+    '',
+    { 'X-XSRF-TOKEN': consentForm.token, ...approvals, user_oauth_approval: true },
+    { Cookie: consentForm.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+
+  const callback = await performGet(postConsent.headers['location'], '', { Cookie: session.cookie }).expect(302);
+  return { session, callback };
+};
+
+export const expectAuthorizationCodeRedirect = (response) => {
+  expect(response.headers['location']).toContain(`${APP_OAUTH_SETTINGS.REDIRECT_URI}?`);
+  expect(response.headers['location']).toMatch(/code=[-_a-zA-Z0-9]+/);
+};


### PR DESCRIPTION
## :id: Reference related issue.
https://gravitee.atlassian.net/browse/AM-5418

## :pencil2: A description of the changes proposed in the pull request

Adds 6 Jest tests in a new `specs/gateway/application-oauth-settings/` folder for the application OAuth 2.0 / OIDC settings that had no integration coverage:

- consent duration on a scope (`scopeApproval`) — consent re-requested once it elapses, reused after it is raised
- scope added to / removed from the application — token issued, then `invalid_scope`
- refresh token validity — refresh works within it, `invalid_grant` after it

The rest of the ticket (refresh-token grant, access/ID token expiry) was already covered by existing specs and is not duplicated. No existing file is modified.

## :memo: Test scenarios
Green locally against MongoDB; both time-based tests fail when their wait is removed.

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA


