### PR TITLE
test: application certificate signs issued tokens (AM-5420)

### DIFF
--- a/gravitee-am-test/specs/gateway/application-certificate/app-certificate-signing.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/application-certificate/app-certificate-signing.jest.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  AppCertificateFixture,
+  assignCertificate,
+  fetchJwks,
+  kidOf,
+  requestClientCredentialsToken,
+  requestPasswordTokens,
+  setupAppCertificateFixture,
+  SigningCertificate,
+  verifySignature,
+} from './fixtures/app-certificate-fixture';
+
+setup(200000);
+
+/**
+ * Application > Settings > Certificates: a domain certificate assigned to an application signs
+ * that application's tokens. Each check ties the token to the certificate's own public key as
+ * published by the management API, not merely to "a key that differs from before".
+ */
+let fixture: AppCertificateFixture;
+
+beforeAll(async () => {
+  fixture = await setupAppCertificateFixture();
+});
+
+afterAll(async () => {
+  await fixture?.cleanUp();
+});
+
+const expectSignedWith = async (token: string, certificate: SigningCertificate) => {
+  expect(kidOf(token)).toEqual(certificate.alias);
+  await expect(verifySignature(token, certificate.publicKey)).resolves.toBeDefined();
+};
+
+describe('Application certificate - access tokens are signed with the assigned certificate', () => {
+  it('should sign with the JKS certificate assigned to the application', async () => {
+    const token = await requestClientCredentialsToken(fixture, fixture.jksApp);
+    await expectSignedWith(token, fixture.jks);
+  });
+
+  it('should sign with the PKCS12 certificate assigned to the application', async () => {
+    const token = await requestClientCredentialsToken(fixture, fixture.pkcs12App);
+    await expectSignedWith(token, fixture.pkcs12);
+  });
+
+  it('should publish the assigned certificate keys in the domain JWKS under the token kid', async () => {
+    const token = await requestClientCredentialsToken(fixture, fixture.jksApp);
+    const jwks = await fetchJwks(fixture);
+    expect(jwks).toContainEqual(expect.objectContaining({ kid: kidOf(token), n: fixture.jks.jwk.n }));
+  });
+});
+
+describe('Application certificate - the assignment is what selects the signer', () => {
+  it('should not sign with an assigned certificate when the application has none', async () => {
+    const token = await requestClientCredentialsToken(fixture, fixture.defaultApp);
+    expect([fixture.jks.alias, fixture.pkcs12.alias]).not.toContain(kidOf(token));
+    await expect(verifySignature(token, fixture.jks.publicKey)).rejects.toThrow('signature verification failed');
+    await expect(verifySignature(token, fixture.pkcs12.publicKey)).rejects.toThrow('signature verification failed');
+  });
+
+  it('should not verify a JKS-signed token with the PKCS12 certificate key', async () => {
+    const token = await requestClientCredentialsToken(fixture, fixture.jksApp);
+    await expect(verifySignature(token, fixture.pkcs12.publicKey)).rejects.toThrow('signature verification failed');
+  });
+
+  it('should sign with the new certificate once the application is reassigned', async () => {
+    const before = await requestClientCredentialsToken(fixture, fixture.reassignApp);
+    await expectSignedWith(before, fixture.jks);
+
+    await assignCertificate(fixture, fixture.reassignApp, fixture.pkcs12.id);
+
+    const after = await requestClientCredentialsToken(fixture, fixture.reassignApp);
+    await expectSignedWith(after, fixture.pkcs12);
+  });
+});
+
+describe('Application certificate - ID tokens', () => {
+  it('should sign the ID token with the assigned certificate too', async () => {
+    const { accessToken, idToken } = await requestPasswordTokens(fixture, fixture.pkcs12App);
+    await expectSignedWith(accessToken, fixture.pkcs12);
+    await expectSignedWith(idToken, fixture.pkcs12);
+  });
+});

--- a/gravitee-am-test/specs/gateway/application-certificate/fixtures/app-certificate-fixture.ts
+++ b/gravitee-am-test/specs/gateway/application-certificate/fixtures/app-certificate-fixture.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 import { expect } from '@jest/globals';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 import * as jose from 'jose';
 import { Domain } from '@management-models/Domain';
 import { Application } from '@management-models/Application';
@@ -28,7 +26,7 @@ import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
 import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
 import { applicationBase64Token } from '@gateway-commands/utils';
 import { buildCertificate } from '@api-fixtures/certificates';
-import { createPKCS12CertificateRequest } from '../../../management/certificates/fixtures/certificates-fixture';
+import { createBundledPKCS12CertificateRequest } from '../../../management/certificates/fixtures/certificates-fixture';
 import { uniqueName } from '@utils-commands/misc';
 import { Fixture } from '../../../test-fixture';
 
@@ -80,7 +78,12 @@ export const setupAppCertificateFixture = async (): Promise<AppCertificateFixtur
     });
 
     const jks = await createSigningCertificate(domain, accessToken, buildCertificate(0), APP_CERTIFICATE.JKS_ALIAS);
-    const pkcs12 = await createSigningCertificate(domain, accessToken, pkcs12Request(), APP_CERTIFICATE.PKCS12_ALIAS);
+    const pkcs12 = await createSigningCertificate(
+      domain,
+      accessToken,
+      createBundledPKCS12CertificateRequest(),
+      APP_CERTIFICATE.PKCS12_ALIAS,
+    );
     // Two distinct key pairs, otherwise a token could not tell the tests which certificate signed it
     expect(pkcs12.jwk.n).not.toEqual(jks.jwk.n);
 
@@ -113,17 +116,6 @@ export const setupAppCertificateFixture = async (): Promise<AppCertificateFixtur
     }
     throw error;
   }
-};
-
-const pkcs12Request = () => {
-  const p12 = join(__dirname, '../../../management/certificates/fixtures/test.p12');
-  return createPKCS12CertificateRequest({
-    password: 'changeit',
-    alias: APP_CERTIFICATE.PKCS12_ALIAS,
-    content: readFileSync(p12).toString('base64'),
-    type: 'pkcs12-am-certificate',
-    contentType: 'application/x-pkcs12',
-  });
 };
 
 async function createSigningCertificate(domain: Domain, accessToken: string, request, alias: string): Promise<SigningCertificate> {

--- a/gravitee-am-test/specs/gateway/application-certificate/fixtures/app-certificate-fixture.ts
+++ b/gravitee-am-test/specs/gateway/application-certificate/fixtures/app-certificate-fixture.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as jose from 'jose';
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import { DomainOidcConfig, safeDeleteDomain, setupDomainForTest } from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, patchApplication, updateApplication } from '@management-commands/application-management-commands';
+import { createCertificate, getPublicKeys } from '@management-commands/certificate-management-commands';
+import { createIdp, deleteIdp } from '@management-commands/idp-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { performGet, performPost } from '@gateway-commands/oauth-oidc-commands';
+import { applicationBase64Token } from '@gateway-commands/utils';
+import { buildCertificate } from '@api-fixtures/certificates';
+import { createPKCS12CertificateRequest } from '../../../management/certificates/fixtures/certificates-fixture';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+export const APP_CERTIFICATE = {
+  DOMAIN_PREFIX: 'app-certificate',
+  // Keystore aliases become the `kid` of the keys they sign with
+  JKS_ALIAS: 'mytestkey',
+  PKCS12_ALIAS: 'test',
+  USER_PASSWORD: '#CoMpL3X-P@SsW0Rd',
+} as const;
+
+export interface SigningCertificate {
+  id: string;
+  alias: string;
+  // Public key from the certificate as published by the management API, ready for signature verification
+  publicKey: jose.KeyLike;
+  jwk: jose.JWK;
+}
+
+export interface AppCertificateFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  jks: SigningCertificate;
+  pkcs12: SigningCertificate;
+  jksApp: Application;
+  pkcs12App: Application;
+  // No certificate assigned: signs with the domain's default certificate
+  defaultApp: Application;
+  // Starts on the JKS certificate; the reassignment test moves it to PKCS12
+  reassignApp: Application;
+  user: { username: string; password: string };
+}
+
+export const setupAppCertificateFixture = async (): Promise<AppCertificateFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  let domain: Domain | null = null;
+  try {
+    const started = await setupDomainForTest(uniqueName(APP_CERTIFICATE.DOMAIN_PREFIX, true), { accessToken, waitForStart: true });
+    domain = started.domain;
+
+    await deleteIdp(domain.id, accessToken, 'default-idp-' + domain.id);
+    const user = { username: uniqueName('cert-user', true), password: APP_CERTIFICATE.USER_PASSWORD };
+    const idp = await createIdp(domain.id, accessToken, {
+      external: false,
+      type: 'inline-am-idp',
+      domainWhitelist: [],
+      configuration: JSON.stringify({ users: [{ firstname: 'Cert', lastname: 'User', ...user }] }),
+      name: 'app-certificate-idp',
+    });
+
+    const jks = await createSigningCertificate(domain, accessToken, buildCertificate(0), APP_CERTIFICATE.JKS_ALIAS);
+    const pkcs12 = await createSigningCertificate(domain, accessToken, pkcs12Request(), APP_CERTIFICATE.PKCS12_ALIAS);
+    // Two distinct key pairs, otherwise a token could not tell the tests which certificate signed it
+    expect(pkcs12.jwk.n).not.toEqual(jks.jwk.n);
+
+    const jksApp = await createTestApp(domain, accessToken, idp.id, 'jks-app', jks.id);
+    const pkcs12App = await createTestApp(domain, accessToken, idp.id, 'pkcs12-app', pkcs12.id);
+    const defaultApp = await createTestApp(domain, accessToken, idp.id, 'default-app');
+    // The last mutation is wrapped so the gateway has picked up everything created above
+    const reassignApp = await waitForSyncAfter(domain.id, () => createTestApp(domain, accessToken, idp.id, 'reassign-app', jks.id));
+
+    return {
+      accessToken,
+      domain,
+      oidc: started.oidcConfig,
+      jks,
+      pkcs12,
+      jksApp,
+      pkcs12App,
+      defaultApp,
+      reassignApp,
+      user,
+      cleanUp: async () => {
+        if (domain?.id && accessToken) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      await safeDeleteDomain(domain.id, accessToken).catch((e) => console.error('Cleanup failed:', e));
+    }
+    throw error;
+  }
+};
+
+const pkcs12Request = () => {
+  const p12 = join(__dirname, '../../../management/certificates/fixtures/test.p12');
+  return createPKCS12CertificateRequest({
+    password: 'changeit',
+    alias: APP_CERTIFICATE.PKCS12_ALIAS,
+    content: readFileSync(p12).toString('base64'),
+    type: 'pkcs12-am-certificate',
+    contentType: 'application/x-pkcs12',
+  });
+};
+
+async function createSigningCertificate(domain: Domain, accessToken: string, request, alias: string): Promise<SigningCertificate> {
+  const certificate = await createCertificate(domain.id, accessToken, request);
+  const keys = await getPublicKeys(domain.id, accessToken, certificate.id);
+  const pem = keys.find((key) => key.fmt === 'PEM')?.payload;
+  expect(pem).toEqual(expect.stringContaining('-----BEGIN CERTIFICATE-----'));
+  const publicKey = await jose.importX509(pem, 'RS256');
+  return { id: certificate.id, alias, publicKey, jwk: await jose.exportJWK(publicKey) };
+}
+
+async function createTestApp(
+  domain: Domain,
+  accessToken: string,
+  idpId: string,
+  name: string,
+  certificateId?: string,
+): Promise<Application> {
+  const created = await createApplication(domain.id, accessToken, {
+    name: uniqueName(name, true),
+    type: 'WEB',
+    redirectUris: ['https://example.com/callback'],
+  });
+  const updated = await updateApplication(
+    domain.id,
+    accessToken,
+    {
+      settings: {
+        oauth: {
+          redirectUris: ['https://example.com/callback'],
+          grantTypes: ['client_credentials', 'password'],
+          scopeSettings: [{ scope: 'openid', defaultScope: false }],
+        },
+      },
+      identityProviders: new Set([{ identity: idpId, priority: 0 }]),
+    },
+    created.id,
+  );
+  const app = certificateId ? await patchApplication(domain.id, accessToken, { certificate: certificateId }, created.id) : updated;
+  // Responses to updates omit the secret; keep the one issued on creation for Basic auth
+  app.settings.oauth.clientSecret = created.settings.oauth.clientSecret;
+  return app;
+}
+
+/** Points the application at another domain certificate and waits for the gateway to pick it up. */
+export const assignCertificate = (fixture: AppCertificateFixture, app: Application, certificateId: string) =>
+  waitForSyncAfter(fixture.domain.id, () =>
+    patchApplication(fixture.domain.id, fixture.accessToken, { certificate: certificateId }, app.id),
+  );
+
+export const requestClientCredentialsToken = async (fixture: AppCertificateFixture, app: Application): Promise<string> => {
+  const response = await performPost(fixture.oidc.token_endpoint, '', 'grant_type=client_credentials', {
+    'Content-type': 'application/x-www-form-urlencoded',
+    Authorization: 'Basic ' + applicationBase64Token(app),
+  }).expect(200);
+  return response.body.access_token;
+};
+
+export const requestPasswordTokens = async (fixture: AppCertificateFixture, app: Application) => {
+  const { username, password } = fixture.user;
+  const response = await performPost(
+    fixture.oidc.token_endpoint,
+    '',
+    `grant_type=password&username=${username}&password=${encodeURIComponent(password)}&scope=openid`,
+    { 'Content-type': 'application/x-www-form-urlencoded', Authorization: 'Basic ' + applicationBase64Token(app) },
+  ).expect(200);
+  return { accessToken: response.body.access_token as string, idToken: response.body.id_token as string };
+};
+
+export const kidOf = (token: string): string => jose.decodeProtectedHeader(token).kid;
+
+/** Resolves when the token's signature verifies with the given public key, rejects otherwise. */
+export const verifySignature = (token: string, publicKey: jose.KeyLike) => jose.jwtVerify(token, publicKey);
+
+export const fetchJwks = async (fixture: AppCertificateFixture): Promise<jose.JWK[]> => {
+  const response = await performGet(fixture.oidc.jwks_uri).expect(200);
+  return response.body.keys;
+};

--- a/gravitee-am-test/specs/management/certificates/fixtures/certificates-fixture.ts
+++ b/gravitee-am-test/specs/management/certificates/fixtures/certificates-fixture.ts
@@ -82,6 +82,16 @@ export const createJksCertificateRequest = (payload: CertificatePayload): any =>
   return createBaseCertificateRequest(payload, content);
 };
 
+/** Request for the test.p12 keystore shipped next to this fixture (alias `test`). */
+export const createBundledPKCS12CertificateRequest = (): any =>
+  createPKCS12CertificateRequest({
+    password: 'changeit',
+    alias: 'test',
+    content: read('test.p12'),
+    type: 'pkcs12-am-certificate',
+    contentType: 'application/x-pkcs12',
+  });
+
 export const createPKCS12CertificateRequest = (payload: CertificatePayload): any => {
   const size = new TextEncoder().encode(payload.content).length;
   const content = {


### PR DESCRIPTION
## :id: Reference related issue.
https://gravitee.atlassian.net/browse/AM-5420

## :pencil2: A description of the changes proposed in the pull request

Adds 7 Jest tests in a new `specs/gateway/application-certificate/` folder proving that a domain certificate assigned to an application signs that application's tokens:

- JKS and PKCS12 certificates assigned to an app — the token `kid` is the certificate's and the signature verifies with its public key
- the assigned key is published in the domain JWKS under that `kid`
- an app with no certificate does not sign with either, and a JKS-signed token does not verify with the PKCS12 key
- reassigning an app moves the signer; ID tokens follow the same certificate

Certificate CRUD and assignment were already covered; the existing tests only checked that the `kid` changed. AWS Secret Manager / CloudHSM certificates are out of scope (EE plugins requiring AWS credentials). No existing file is modified.

## :memo: Test scenarios
Green locally against MongoDB.

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA
