### PR TITLE
test: gateway bot detection with the reCAPTCHA plugin (AM-6761)

### DIFF
--- a/gravitee-am-test/specs/gateway/bot-detection/fixtures/recaptcha-fixture.ts
+++ b/gravitee-am-test/specs/gateway/bot-detection/fixtures/recaptcha-fixture.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+import crossFetch from 'cross-fetch';
+import { Domain } from '@management-models/Domain';
+import { Application } from '@management-models/Application';
+import {
+  DomainOidcConfig,
+  patchDomain,
+  safeDeleteDomain,
+  setupDomainForTest,
+  waitForOidcReady,
+} from '@management-commands/domain-management-commands';
+import { requestAdminAccessToken } from '@management-commands/token-management-commands';
+import { createApplication, updateApplication } from '@management-commands/application-management-commands';
+import { createBotDetection } from '@management-commands/bot-detection-management-commands';
+import { createUser } from '@management-commands/user-management-commands';
+import { waitForSyncAfter } from '@gateway-commands/monitoring-commands';
+import { extractXsrfToken, extractXsrfTokenAndActionResponse, performFormPost, performGet } from '@gateway-commands/oauth-oidc-commands';
+import { uniqueName } from '@utils-commands/misc';
+import { Fixture } from '../../../test-fixture';
+
+/**
+ * Google's siteverify is replaced by WireMock: the reCAPTCHA plugin's serviceUrl points at a stub
+ * that answers according to the token it is asked to verify, so every verdict is reproducible.
+ */
+export const RECAPTCHA = {
+  DOMAIN_PREFIX: 'bot-detection',
+  SECRET_KEY: 'recaptcha-secret-under-test',
+  MIN_SCORE: 0.5,
+  TOKEN_PARAMETER: 'X-Recaptcha-Token',
+  TOKENS: {
+    HUMAN: 'token-human',
+    BOT: 'token-bot',
+    REJECTED: 'token-rejected',
+    OUTAGE: 'token-outage',
+  },
+  ERROR_PAGE_QUERY: 'error=technical_error&error_description=Something+goes+wrong.+Please+try+again.',
+  USER_PASSWORD: '#CoMpL3X-P@SsW0Rd',
+  REDIRECT_URI: 'https://example.com/callback',
+} as const;
+
+const WIREMOCK_ADMIN = (process.env.SFR_URL || 'http://localhost:8181') + '/__admin';
+const WIREMOCK_INTERNAL = process.env.INTERNAL_SFR_URL || 'http://wiremock:8080';
+
+export interface RecaptchaFixture extends Fixture {
+  domain: Domain;
+  oidc: DomainOidcConfig;
+  application: Application;
+  user: { username: string; password: string; email: string };
+  // Path of the siteverify stub, unique to this fixture so request lookups only see its own calls
+  siteVerifyPath: string;
+}
+
+export const setupRecaptchaFixture = async (): Promise<RecaptchaFixture> => {
+  const accessToken = await requestAdminAccessToken();
+  const siteVerifyPath = `/recaptcha/${uniqueName('siteverify', true)}`;
+  const stubIds = await registerSiteVerifyStubs(siteVerifyPath);
+  let domain: Domain | null = null;
+  try {
+    const started = await setupDomainForTest(uniqueName(RECAPTCHA.DOMAIN_PREFIX, true), { accessToken, waitForStart: true });
+    domain = started.domain;
+
+    const botDetection = await createBotDetection(domain.id, accessToken, {
+      name: 'recaptcha-under-test',
+      type: 'google-recaptcha-v3-am-bot-detection',
+      detectionType: 'CAPTCHA',
+      configuration: JSON.stringify({
+        siteKey: 'site-key-under-test',
+        secretKey: RECAPTCHA.SECRET_KEY,
+        serviceUrl: WIREMOCK_INTERNAL + siteVerifyPath,
+        tokenParameterName: RECAPTCHA.TOKEN_PARAMETER,
+        minScore: RECAPTCHA.MIN_SCORE,
+      }),
+    });
+
+    // A real user on the default IdP, so forgot-password can resolve it by email
+    const user = {
+      username: uniqueName('recaptcha-user', true),
+      password: RECAPTCHA.USER_PASSWORD,
+      email: `${uniqueName('recaptcha-user', true)}@test.gravitee.io`,
+    };
+    await createUser(domain.id, accessToken, { firstName: 'Recaptcha', lastName: 'User', ...user });
+
+    const application = await createTestApp(domain, accessToken, `default-idp-${domain.id}`);
+
+    // Domain-level settings are a route redeploy on the gateway: wait for sync, then for routing to be live
+    await waitForSyncAfter(domain.id, () =>
+      patchDomain(domain.id, accessToken, {
+        loginSettings: { forgotPasswordEnabled: true },
+        accountSettings: { useBotDetection: true, botDetectionPlugin: botDetection.id },
+      }),
+    );
+    await waitForOidcReady(domain.hrid, { timeoutMs: 5000, intervalMs: 200 });
+
+    return {
+      accessToken,
+      domain,
+      oidc: started.oidcConfig,
+      application,
+      user,
+      siteVerifyPath,
+      cleanUp: async () => {
+        if (domain?.id && accessToken) {
+          await safeDeleteDomain(domain.id, accessToken);
+        }
+        await removeStubs(stubIds);
+      },
+    };
+  } catch (error) {
+    if (domain?.id && accessToken) {
+      await safeDeleteDomain(domain.id, accessToken).catch((e) => console.error('Cleanup failed:', e));
+    }
+    await removeStubs(stubIds).catch((e) => console.error('WireMock cleanup failed:', e));
+    throw error;
+  }
+};
+
+async function createTestApp(domain: Domain, accessToken: string, idpId: string): Promise<Application> {
+  const created = await createApplication(domain.id, accessToken, {
+    name: uniqueName('recaptcha-app', true),
+    type: 'WEB',
+    redirectUris: [RECAPTCHA.REDIRECT_URI],
+  });
+  const updated = await updateApplication(
+    domain.id,
+    accessToken,
+    {
+      settings: {
+        oauth: {
+          redirectUris: [RECAPTCHA.REDIRECT_URI],
+          grantTypes: ['authorization_code'],
+          scopeSettings: [{ scope: 'openid', defaultScope: true }],
+        },
+      },
+      identityProviders: new Set([{ identity: idpId, priority: 0 }]),
+    },
+    created.id,
+  );
+  updated.settings.oauth.clientSecret = created.settings.oauth.clientSecret;
+  return updated;
+}
+
+/** One stub per token value; the plugin posts `secret=...&response=<token>` as a form. */
+async function registerSiteVerifyStubs(siteVerifyPath: string): Promise<string[]> {
+  const verdicts: Array<[string, number, string]> = [
+    [RECAPTCHA.TOKENS.HUMAN, 200, JSON.stringify({ success: true, score: 0.9 })],
+    [RECAPTCHA.TOKENS.BOT, 200, JSON.stringify({ success: true, score: 0.1 })],
+    [RECAPTCHA.TOKENS.REJECTED, 200, JSON.stringify({ success: false, 'error-codes': ['invalid-input-response'] })],
+    [RECAPTCHA.TOKENS.OUTAGE, 500, 'siteverify unavailable'],
+  ];
+  const ids: string[] = [];
+  for (const [token, status, body] of verdicts) {
+    const response = await crossFetch(`${WIREMOCK_ADMIN}/mappings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        request: { method: 'POST', urlPath: siteVerifyPath, bodyPatterns: [{ contains: `response=${token}` }] },
+        response: { status, headers: { 'Content-Type': 'application/json' }, body },
+      }),
+    });
+    expect(response.status).toEqual(201);
+    ids.push((await response.json()).id);
+  }
+  return ids;
+}
+
+const removeStubs = async (ids: string[]) => {
+  for (const id of ids) {
+    await crossFetch(`${WIREMOCK_ADMIN}/mappings/${id}`, { method: 'DELETE' });
+  }
+};
+
+/** The verify calls the gateway made to this fixture's stub, oldest first. */
+export const siteVerifyCalls = async (fixture: RecaptchaFixture): Promise<Array<{ body: string }>> => {
+  const response = await crossFetch(`${WIREMOCK_ADMIN}/requests/find`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ method: 'POST', urlPath: fixture.siteVerifyPath }),
+  });
+  expect(response.status).toEqual(200);
+  return (await response.json()).requests;
+};
+
+/** Submits the login form with the given reCAPTCHA token and returns the gateway's redirect. */
+export const submitLogin = async (fixture: RecaptchaFixture, recaptchaToken?: string) => {
+  const clientId = fixture.application.settings.oauth.clientId;
+  const authResponse = await performGet(
+    fixture.oidc.authorization_endpoint,
+    `?response_type=code&client_id=${clientId}&redirect_uri=${RECAPTCHA.REDIRECT_URI}`,
+  ).expect(302);
+  const loginForm = await extractXsrfTokenAndActionResponse(authResponse);
+  return performFormPost(
+    loginForm.action,
+    '',
+    {
+      'X-XSRF-TOKEN': loginForm.token,
+      username: fixture.user.username,
+      password: fixture.user.password,
+      client_id: clientId,
+      ...(recaptchaToken !== undefined && { [RECAPTCHA.TOKEN_PARAMETER]: recaptchaToken }),
+    },
+    { Cookie: loginForm.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+};
+
+/** Submits the forgot-password form with the given reCAPTCHA token and returns the gateway's redirect. */
+export const submitForgotPassword = async (fixture: RecaptchaFixture, recaptchaToken?: string) => {
+  const clientId = fixture.application.settings.oauth.clientId;
+  const uri = `/${fixture.domain.hrid}/forgotPassword`;
+  const form = await extractXsrfToken(process.env.AM_GATEWAY_URL + uri, `?client_id=${clientId}`);
+  return performFormPost(
+    process.env.AM_GATEWAY_URL,
+    uri,
+    {
+      'X-XSRF-TOKEN': form.token,
+      email: fixture.user.email,
+      client_id: clientId,
+      ...(recaptchaToken !== undefined && { [RECAPTCHA.TOKEN_PARAMETER]: recaptchaToken }),
+    },
+    { Cookie: form.headers['set-cookie'], 'Content-type': 'application/x-www-form-urlencoded' },
+  ).expect(302);
+};
+
+export const expectBotRejection = (fixture: RecaptchaFixture, response) => {
+  expect(response.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/error?`);
+  expect(response.headers['location']).toContain(RECAPTCHA.ERROR_PAGE_QUERY);
+};

--- a/gravitee-am-test/specs/gateway/bot-detection/recaptcha-bot-detection.jest.spec.ts
+++ b/gravitee-am-test/specs/gateway/bot-detection/recaptcha-bot-detection.jest.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { setup } from '../../test-fixture';
+import {
+  expectBotRejection,
+  RECAPTCHA,
+  RecaptchaFixture,
+  setupRecaptchaFixture,
+  siteVerifyCalls,
+  submitForgotPassword,
+  submitLogin,
+} from './fixtures/recaptcha-fixture';
+
+setup(200000);
+
+/**
+ * Bot detection on the gateway with the Google reCAPTCHA v3 plugin. The gateway forwards the
+ * form's reCAPTCHA token to the plugin's serviceUrl (a WireMock stub here) and only lets the
+ * request through when the verdict is a success with a score at or above the plugin's minScore.
+ * A rejected request is sent to the error page; the gateway deliberately does not say why.
+ */
+let fixture: RecaptchaFixture;
+
+beforeAll(async () => {
+  fixture = await setupRecaptchaFixture();
+});
+
+afterAll(async () => {
+  await fixture?.cleanUp();
+});
+
+const { TOKENS } = RECAPTCHA;
+
+describe('Bot detection - login is let through or blocked by the reCAPTCHA verdict', () => {
+  it('should let a login through when the token scores above the minimum', async () => {
+    const response = await submitLogin(fixture, TOKENS.HUMAN);
+    expect(response.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/oauth/authorize?`);
+  });
+
+  it('should block a login when the token scores below the minimum', async () => {
+    const response = await submitLogin(fixture, TOKENS.BOT);
+    expectBotRejection(fixture, response);
+  });
+
+  it('should block a login when Google does not accept the token', async () => {
+    const response = await submitLogin(fixture, TOKENS.REJECTED);
+    expectBotRejection(fixture, response);
+  });
+
+  it('should block a login when the verify service is unavailable', async () => {
+    const response = await submitLogin(fixture, TOKENS.OUTAGE);
+    expectBotRejection(fixture, response);
+  });
+
+  it('should block a login with no token without calling the verify service', async () => {
+    const callsBefore = (await siteVerifyCalls(fixture)).length;
+
+    const response = await submitLogin(fixture);
+    expectBotRejection(fixture, response);
+
+    expect((await siteVerifyCalls(fixture)).length).toEqual(callsBefore);
+  });
+});
+
+describe('Bot detection - the verify call', () => {
+  it('should send the configured secret and the submitted token to the verify service', async () => {
+    await submitLogin(fixture, TOKENS.HUMAN);
+
+    const calls = await siteVerifyCalls(fixture);
+    const last = calls[calls.length - 1];
+    expect(last.body).toContain(`secret=${RECAPTCHA.SECRET_KEY}`);
+    expect(last.body).toContain(`response=${TOKENS.HUMAN}`);
+  });
+});
+
+describe('Bot detection - forgot password is guarded the same way', () => {
+  it('should let a forgot-password request through when the token scores above the minimum', async () => {
+    const response = await submitForgotPassword(fixture, TOKENS.HUMAN);
+    expect(response.headers['location']).toContain(`${process.env.AM_GATEWAY_URL}/${fixture.domain.hrid}/forgotPassword?`);
+    expect(response.headers['location']).toContain('success=forgot_password_completed');
+  });
+
+  it('should block a forgot-password request when the token scores below the minimum', async () => {
+    const response = await submitForgotPassword(fixture, TOKENS.BOT);
+    expectBotRejection(fixture, response);
+  });
+});

--- a/gravitee-am-test/specs/management/bot-detection/bot-detection-crud.jest.spec.ts
+++ b/gravitee-am-test/specs/management/bot-detection/bot-detection-crud.jest.spec.ts
@@ -18,7 +18,7 @@ import { afterAll, beforeAll, expect } from '@jest/globals';
 import { requestAdminAccessToken } from '@management-commands/token-management-commands';
 import { createDomain, safeDeleteDomain, setupDomainForTest, startDomain } from '@management-commands/domain-management-commands';
 import { delay } from '@utils-commands/misc';
-import { setup } from '../test-fixture';
+import { setup } from '../../test-fixture';
 import {
   createBotDetection,
   deleteBotDetection,


### PR DESCRIPTION
## :id: Reference related issue.
https://gravitee.atlassian.net/browse/AM-6761

## :pencil2: A description of the changes proposed in the pull request

- Moves the existing bot-detection CRUD spec from `specs/gateway/` to `specs/management/bot-detection/` (content unchanged apart from its relative import)
- Adds 8 Jest tests in a new `specs/gateway/bot-detection/` folder for the Google reCAPTCHA v3 plugin on the gateway. The plugin's `serviceUrl` is pointed at a WireMock stub that answers per token, so every verdict is reproducible without Google credentials:
  - login let through on a passing score; blocked on a low score, a rejected token, a verify-service outage, and a missing token (which never calls the verify service)
  - the verify call carries the configured secret and the submitted token
  - forgot-password is guarded the same way

## :memo: Test scenarios
Green locally against MongoDB; with bot detection disabled the six blocking tests fail and the two pass-through tests still pass.

## :computer: Add screenshots for UI
NA

## :books: Any other comments that will help with documentation
NA
