### PR TITLE
chore: local-stack chaos mode

### DIFF
--- a/docker/local-stack/README.md
+++ b/docker/local-stack/README.md
@@ -106,9 +106,112 @@ docker login graviteeio.azurecr.io
 | `--cloud` | cockpit mock; management API in managed-cloud mode (Cockpit command path) |
 | `--with a,b,…` | opt-in individually: `ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud` |
 | `--db mongo\|psql` | choose the backend database (default `mongo`) |
+| `--chaos` | + toxiproxy, interposed on AM's outbound connections — see [Fault injection](#fault-injection) |
 
 SPIRE is only needed by the env-guarded gateway tests (`RUN_SPIRE_TESTS=true`); start it with
 `--with spire`.
+
+## Fault injection
+
+`--chaos` starts [toxiproxy](https://github.com/Shopify/toxiproxy) and routes AM's outbound
+connections through it, so they can be broken and restored while the stack keeps running.
+It is off unless you ask for it, and changes nothing about how the stack behaves until you
+inject something.
+
+```bash
+./local-stack.sh up --db psql --chaos
+
+./local-stack.sh chaos status            # what is proxied, and what is disrupting it
+./local-stack.sh chaos cut postgres      # black hole: callers hang until they time out
+./local-stack.sh chaos reject postgres   # refused: immediate connection reset
+./local-stack.sh chaos heal postgres     # or: chaos heal --all
+```
+
+`cut` and `reject` are different failures and tend to expose different bugs. `cut` stops data
+flowing without closing anything, so an open pool connection looks healthy and blocks until
+some timeout fires — a silent failover, or a partition. `reject` disables the listener, so
+connections are refused straight away — the service restarted, or its port closed.
+
+`cut` is one-way: it blocks responses, not requests. A query sent during a cut still reaches
+the database and commits — the caller just never learns the outcome, which is what a real
+partition looks like and where retry bugs live. For a two-way stall, add the upstream half:
+
+```bash
+curl -s -X POST http://localhost:8474/proxies/mongo/toxics \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cut_up","type":"timeout","stream":"upstream","attributes":{"timeout":0}}'
+```
+
+Note also that `docker stop <db>` is **not** an equivalent test: a stopped container loses its
+DNS alias, so AM sees a name-resolution failure rather than a refused, reset, or hung socket —
+a different code path, reached before any pool or retry logic.
+
+### What gets proxied
+
+| Target | Fronts | Present when |
+|--------|--------|--------------|
+| `postgres` | PostgreSQL, for every AM JDBC scope | `--db psql` |
+| `mongo` | MongoDB, for every AM repository scope | `--db mongo` (default) |
+| `smtp` | the fake SMTP server | always |
+| `cockpit` | the Cockpit mock the management API dials out to | `--cloud` |
+
+Each proxy listens on the **same port as the service it fronts**, so redirecting AM is a pure
+host substitution (`postgres` → `toxiproxy`) and the connection strings stay readable.
+
+Two exclusions:
+
+- **The host.** Only the admin API is published; the proxy listeners stay on the compose
+  network. A jest or playwright run on your machine keeps its *direct* route to the database,
+  so it can still assert against the data while AM's own connection is cut.
+- **`gateway-migrator`.** It is a one-shot liquibase run that has to finish before the gateway
+  starts, so putting it behind the proxy would only add a way for the stack to fail at boot.
+
+Not covered: **LDAP and external HTTP identity providers**. Those addresses live in per-domain
+configuration in the database (`ldap://openldap:1389`, `http://wiremock:8080`), written by the
+test or the Console rather than by compose, so there is nothing central to redirect. Breaking
+one means pointing that identity provider at a proxy you add yourself.
+
+### Everything else toxiproxy can do
+
+The script wraps disrupt-and-resume and stops there. Its other toxics are available on the
+API directly:
+
+```bash
+# 800ms ± 100ms on every response
+curl -s -X POST http://localhost:8474/proxies/postgres/toxics \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"slow","type":"latency","attributes":{"latency":800,"jitter":100}}'
+
+# throttle to 10 KB/s
+curl -s -X POST http://localhost:8474/proxies/postgres/toxics \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"thin","type":"bandwidth","attributes":{"rate":10}}'
+```
+
+`chaos heal` clears toxics it did not create, so anything you add by hand still has a one-word
+undo. The full toxic reference — `latency`, `bandwidth`, `slow_close`, `timeout`, `reset_peer`,
+`slicer`, `limit_data`, plus `toxicity` and `stream` on all of them — is in the
+[toxiproxy README](https://github.com/Shopify/toxiproxy#toxics).
+
+### Making recovery observable
+
+Connection-pool defaults are tuned for production, not for a manual test window: with
+`maxLifeTime` at default you may wait a long time to watch a pool recover. Shorten the
+timings in your gitignored `dev/docker-compose.local.yml` (merged last, so it wins) for as
+long as you need them:
+
+```yaml
+services:
+  gateway:
+    environment:
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_VALIDATIONQUERY=SELECT 1
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_MAXVALIDATIONTIME=3000
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_MAXLIFETIME=20000
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_TCPKEEPALIVE=true
+```
+
+Repeat per scope (`OAUTH2`, `MANAGEMENT`, `DATAPLANES_0`) as needed. With these applied you
+are no longer observing production timings.
 
 ## Customising configuration (gravitee.yml settings)
 
@@ -139,6 +242,7 @@ for source-built and `--version` images.
 | Mailbox (fake SMTP) | http://localhost:5080 | SMTP on `:5025` |
 | WireMock | http://localhost:8181 | SFR/CIMD mocks |
 | MongoDB / PostgreSQL | `:27017` / `:5432` | per `--db` |
+| Toxiproxy admin API | http://localhost:8474 | with `--chaos` |
 
 Admin login: **`admin` / `adminadmin`** — organization & environment: **`DEFAULT`**.
 
@@ -185,6 +289,9 @@ npm --prefix gravitee-am-test run pw:ci         # CI mode
 | Stale code, or a service crashes on boot | `./local-stack.sh up --build` (full clean rebuild — see Build above). |
 | Port already in use | Stop the conflicting process or run `./local-stack.sh down` first. |
 | A container won't become healthy | `./local-stack.sh logs management` (or `gateway`) to inspect the boot error. |
+| `toxiproxy is not reachable` | The stack was started without `--chaos`. Restart it with the flag. |
+| `toxiproxy is up but has no proxy named …` | Proxies are seeded from `dev/toxiproxy.json` at container start; restart the stack after editing it. |
+| AM still failing after you finished testing | `./local-stack.sh chaos heal --all` — a toxic survives until you remove it. |
 
 ## Advanced
 

--- a/docker/local-stack/dev/docker-compose.chaos.cloud.yml
+++ b/docker/local-stack/dev/docker-compose.chaos.cloud.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Routes the management API's Cockpit connection through toxiproxy (--chaos with --cloud).
+
+services:
+  management:
+    environment:
+      - GRAVITEE_CLOUD_CONNECTOR_WS_ENDPOINTS_0=http://toxiproxy:8085

--- a/docker/local-stack/dev/docker-compose.chaos.mongo.yml
+++ b/docker/local-stack/dev/docker-compose.chaos.mongo.yml
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Routes AM's MongoDB connections through toxiproxy (--chaos with --db mongo).
+#
+# The gateway reads OAUTH_2 where the management API reads OAUTH2 — not a typo.
+
+services:
+  gateway:
+    environment:
+      - GRAVITEE_REPOSITORIES_MANAGEMENT_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - GRAVITEE_REPOSITORIES_OAUTH_2_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - GRAVITEE_REPOSITORIES_GATEWAY_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+
+  management:
+    environment:
+      - GRAVITEE_REPOSITORIES_MANAGEMENT_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - GRAVITEE_REPOSITORIES_OAUTH2_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - GRAVITEE_REPOSITORIES_GATEWAY_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - GRAVITEE_DATAPLANES_0_MONGODB_URI=mongodb://toxiproxy:27017/graviteeam?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000

--- a/docker/local-stack/dev/docker-compose.chaos.postgres.yml
+++ b/docker/local-stack/dev/docker-compose.chaos.postgres.yml
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Routes AM's JDBC connections through toxiproxy (--chaos with --db psql).
+#
+# gateway-migrator stays on postgres: it is a one-shot liquibase run that gates gateway
+# start-up.
+
+services:
+  gateway:
+    environment:
+      - GRAVITEE_REPOSITORIES_MANAGEMENT_JDBC_HOST=toxiproxy
+      - GRAVITEE_REPOSITORIES_OAUTH2_JDBC_HOST=toxiproxy
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_HOST=toxiproxy
+      - GRAVITEE_DATAPLANES_0_JDBC_HOST=toxiproxy
+
+  management:
+    environment:
+      - GRAVITEE_REPOSITORIES_MANAGEMENT_JDBC_HOST=toxiproxy
+      - GRAVITEE_REPOSITORIES_OAUTH2_JDBC_HOST=toxiproxy
+      - GRAVITEE_REPOSITORIES_GATEWAY_JDBC_HOST=toxiproxy
+      - GRAVITEE_DATAPLANES_0_JDBC_HOST=toxiproxy

--- a/docker/local-stack/dev/docker-compose.chaos.yml
+++ b/docker/local-stack/dev/docker-compose.chaos.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fault injection for AM's outbound connections (./local-stack.sh up --chaos).
+#
+# Each proxy listens on the same port as the service it fronts, so redirecting AM is a host
+# substitution (postgres -> toxiproxy). Only the admin API is published; the listeners stay
+# on the compose network, leaving a test run on the host its direct route to the database.
+#
+# Disrupt and resume with ./local-stack.sh chaos — see README.md.
+
+services:
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    command: ["-host=0.0.0.0", "-config=/config/toxiproxy.json"]
+    volumes:
+      - ./toxiproxy.json:/config/toxiproxy.json:ro
+    ports:
+      - 8474:8474   # admin API
+
+  gateway:
+    depends_on:
+      toxiproxy:
+        condition: service_started
+    environment:
+      - GRAVITEE_EMAIL_HOST=toxiproxy
+
+  management:
+    depends_on:
+      toxiproxy:
+        condition: service_started
+    environment:
+      - GRAVITEE_EMAIL_HOST=toxiproxy

--- a/docker/local-stack/dev/toxiproxy.json
+++ b/docker/local-stack/dev/toxiproxy.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "mongo",
+    "listen": "0.0.0.0:27017",
+    "upstream": "mongodb:27017",
+    "enabled": true
+  },
+  {
+    "name": "postgres",
+    "listen": "0.0.0.0:5432",
+    "upstream": "postgres:5432",
+    "enabled": true
+  },
+  {
+    "name": "smtp",
+    "listen": "0.0.0.0:5025",
+    "upstream": "smtp:5025",
+    "enabled": true
+  },
+  {
+    "name": "cockpit",
+    "listen": "0.0.0.0:8085",
+    "upstream": "cockpit-mock:8085",
+    "enabled": true
+  }
+]

--- a/docker/local-stack/local-stack.sh
+++ b/docker/local-stack/local-stack.sh
@@ -19,6 +19,7 @@
 #   ./local-stack.sh up                       # build from current code, start (lean, mongo)
 #   ./local-stack.sh up --full                # everything the e2e/jest suites need + Console
 #   ./local-stack.sh up --version 4.12.x-latest --ui   # pull a released/nightly image instead
+#   ./local-stack.sh up --chaos               # + fault injection on AM's db/smtp links
 #   ./local-stack.sh down                      # tear everything down
 #
 # Run `./local-stack.sh help` for the full reference.
@@ -103,6 +104,7 @@ DETACH=1
 LICENSE_FILE="$DEV/license/gravitee-universe-v4.key"
 # opt-in extras (plain vars — keep this script bash-3.2 compatible, macOS default)
 WANT_UI=0; WANT_WIREMOCK=1; WANT_CIBA=0; WANT_OPENFGA=0; WANT_KAFKA=0; WANT_MTLS=0; WANT_SPIRE=0; WANT_CLOUD=0; WANT_KEYCLOAK=0; WANT_LDAP=0
+WANT_CHAOS=0             # --chaos: interpose toxiproxy on AM's outbound connections
 
 want_set() { # want_set <name> <value>
   case "$1" in
@@ -129,6 +131,7 @@ COMMANDS
   logs      Follow logs (optionally for one service: logs gateway)
   status    Show container status (docker compose ps)
   pull      Pull the AM images for --version without starting
+  chaos     Disrupt/resume AM's proxied connections (needs --chaos; see below)
   help      Show this help
 
 MODE
@@ -153,6 +156,21 @@ SERVICES
                        management API at it (console/cloud command path, e.g.
                        Cockpit access points -> entrypoints)
 
+FAULT INJECTION
+  --chaos              route AM's outbound connections through toxiproxy so they can
+                       be broken on demand. Covers the database (per --db), SMTP, and
+                       the Cockpit link when combined with --cloud. Proxy listeners
+                       stay on the compose network, so a test run on the host keeps
+                       its direct route to the database.
+
+                       ./local-stack.sh chaos status
+                       ./local-stack.sh chaos cut postgres      # black hole; callers hang
+                       ./local-stack.sh chaos reject postgres   # refused; immediate reset
+                       ./local-stack.sh chaos heal postgres     # or: heal --all
+
+                       Latency, bandwidth and the rest of toxiproxy stay on its own API
+                       at localhost:8474 — see README.md. `chaos heal` resets those too.
+
 DATABASE
   --db mongo|psql      backend database (default: mongo)
 
@@ -171,6 +189,7 @@ EXAMPLES
   ./local-stack.sh up --db psql --ui
   ./local-stack.sh up --with ui,openfga
   ./local-stack.sh up --version 4.12.x-latest --ui
+  ./local-stack.sh up --db psql --chaos
   ./local-stack.sh down
 
 URLs / credentials once up:
@@ -187,13 +206,14 @@ EOF
 # ---------------------------------------------------------------------------
 COMMAND="up"
 case "${1:-}" in
-  up|down|logs|status|pull|help) COMMAND="$1"; shift ;;
+  up|down|logs|status|pull|chaos|help) COMMAND="$1"; shift ;;
   -h|--help|"") : ;;                      # default to `up`, help handled below
   -*) : ;;                                # leading flag => `up`
   *) COMMAND="$1"; shift ;;
 esac
 
 LOGS_SVC=""
+CHAOS_ARGS=()          # verb + target for the `chaos` command
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)   VERSION="${2:?--version needs a tag}"; shift 2 ;;
@@ -207,13 +227,18 @@ while [ $# -gt 0 ]; do
                    want_set "$s" 1 || die "unknown --with service: $s"
                  done; shift 2 ;;
     --cloud)     WANT_CLOUD=1; shift ;;
+    --chaos)     WANT_CHAOS=1; shift ;;
     --keycloak)  WANT_KEYCLOAK=1; shift ;;
     --build)     BUILD_MODE="force"; shift ;;
     --quick|--no-build) BUILD_MODE="skip"; shift ;;
     --license)   LICENSE_FILE="${2:?--license needs a path}"; shift 2 ;;
     --no-detach) DETACH=0; shift ;;
-    -h|--help)   usage; exit 0 ;;
+    -h|--help)   if [ "$COMMAND" = "chaos" ]; then CHAOS_ARGS+=("$1"); shift
+                 else usage; exit 0; fi ;;
+    --all)       [ "$COMMAND" = "chaos" ] || die "--all is only valid as: chaos heal --all"
+                 CHAOS_ARGS+=("$1"); shift ;;
     *)           if [ "$COMMAND" = "logs" ] && [ -z "$LOGS_SVC" ]; then LOGS_SVC="$1"; shift
+                 elif [ "$COMMAND" = "chaos" ]; then CHAOS_ARGS+=("$1"); shift
                  else die "unknown argument: $1 (see ./local-stack.sh help)"; fi ;;
   esac
 done
@@ -245,6 +270,10 @@ ALL_FILES=(
   -f "$DEV/docker-compose.spire.yml"
   -f "$DEV/docker-compose.cloud.yml"
   -f "$DEV/docker-compose.images.yml"
+  -f "$DEV/docker-compose.chaos.yml"
+  -f "$DEV/docker-compose.chaos.mongo.yml"
+  -f "$DEV/docker-compose.chaos.postgres.yml"
+  -f "$DEV/docker-compose.chaos.cloud.yml"
 )
 
 # Optional, gitignored per-dev override (custom env vars, volume-mounted gravitee.yml,
@@ -262,6 +291,13 @@ build_compose_files() {
   if [ "$WANT_SPIRE" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.spire.yml"); fi
   if [ "$WANT_CLOUD" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.cloud.yml"); fi
   if [ "$WANT_KEYCLOAK" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.keycloak.yml"); fi
+  # Chaos must follow the db/cloud overlays it redirects — compose applies files in order.
+  if [ "$WANT_CHAOS" -eq 1 ]; then
+    COMPOSE_FILES+=(-f "$DEV/docker-compose.chaos.yml")
+    if [ "$DB" = "mongo" ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.chaos.mongo.yml")
+    else COMPOSE_FILES+=(-f "$DEV/docker-compose.chaos.postgres.yml"); fi
+    if [ "$WANT_CLOUD" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.chaos.cloud.yml"); fi
+  fi
   if [ "$PULLED" -eq 1 ]; then COMPOSE_FILES+=(-f "$DEV/docker-compose.images.yml"); fi
   if [ -f "$LOCAL_OVERRIDE" ]; then COMPOSE_FILES+=(-f "$LOCAL_OVERRIDE"); fi   # per-dev overrides win
 }
@@ -281,6 +317,7 @@ build_service_list() {
   [ "$WANT_LDAP" -eq 1 ]     && SERVICES+=(openldap openldap-init)
   [ "$WANT_CLOUD" -eq 1 ]    && SERVICES+=(cockpit-mock)
   [ "$WANT_KEYCLOAK" -eq 1 ] && SERVICES+=(keycloak)
+  [ "$WANT_CHAOS" -eq 1 ]    && SERVICES+=(toxiproxy)
   if [ "$WANT_SPIRE" -eq 1 ]; then
     SERVICES+=(spire-perms-init spire-server spire-bootstrap spire-agent spire-oidc)
   fi
@@ -505,6 +542,7 @@ print_ready() {
   printf '  Management API http://localhost:8093/management\n'
   [ "$WANT_UI" -eq 1 ] && printf '  Console UI     http://localhost:4200\n'
   [ "$WANT_KEYCLOAK" -eq 1 ] && printf '  Keycloak       http://localhost:8180  (admin/admin)\n'
+  [ "$WANT_CHAOS" -eq 1 ] && printf '  Toxiproxy API  http://localhost:8474  (./local-stack.sh chaos status)\n'
   printf '  Mailbox        http://localhost:5080\n'
   printf '  Admin login    admin / adminadmin   (org/env: DEFAULT)\n'
   printf '%s  Stop with: ./local-stack.sh down%s\n\n' "$C_DIM" "$C_RST"
@@ -517,6 +555,147 @@ start_stack() { # start_stack <compose up args...>
   printf '     To retry a clean rebuild:\n' >&2
   printf '         ./local-stack.sh up --build\n' >&2
   exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Chaos (toxiproxy) — disrupt and resume AM's outbound connections
+# ---------------------------------------------------------------------------
+
+TOXIPROXY_API="http://localhost:8474"
+CHAOS_TOXIC="local_stack_cut"
+
+# chaos_api dies on any non-2xx; chaos_curl returns non-zero, for probes that handle it.
+chaos_curl() { curl -fsS --max-time 5 "$@"; }
+
+chaos_api() { # chaos_api <curl args...>
+  local out status
+  out="$(curl -sS --max-time 5 -w '\n%{http_code}' "$@" 2>&1)" || die "toxiproxy API unreachable: $out"
+  status="${out##*$'\n'}"
+  case "$status" in
+    2*) printf '%s' "${out%$'\n'*}" ;;
+    *)  die "toxiproxy API returned HTTP $status: ${out%$'\n'*}" ;;
+  esac
+}
+
+chaos_targets() { sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$DEV/toxiproxy.json"; }
+
+# Split on commas first — a greedy sed would otherwise match only the last name.
+chaos_toxic_names() { # chaos_toxic_names <target>
+  chaos_curl "$TOXIPROXY_API/proxies/$1/toxics" 2>/dev/null \
+    | tr ',' '\n' | sed -n 's/.*"name":"\([^"]*\)".*/\1/p' || true
+}
+
+chaos_require_up() {
+  if chaos_curl "$TOXIPROXY_API/version" >/dev/null 2>&1; then return 0; fi
+  die "toxiproxy is not reachable on $TOXIPROXY_API
+     Start the stack with fault injection enabled:  ./local-stack.sh up --chaos"
+}
+
+chaos_check_target() { # chaos_check_target <name>
+  local t
+  for t in $(chaos_targets); do
+    if [ "$t" = "$1" ]; then return 0; fi
+  done
+  die "unknown chaos target: $1
+     Known targets: $(chaos_targets | tr '\n' ' ')"
+}
+
+chaos_check_live() { # chaos_check_live <target>
+  if chaos_curl "$TOXIPROXY_API/proxies/$1" >/dev/null 2>&1; then return 0; fi
+  die "toxiproxy is up but has no proxy named '$1'.
+     Proxies are seeded from dev/toxiproxy.json when the container starts, so a target
+     added since then needs a restart:  ./local-stack.sh up --chaos"
+}
+
+chaos_clear_toxics() { # chaos_clear_toxics <target>
+  local t
+  for t in $(chaos_toxic_names "$1"); do
+    chaos_curl -X DELETE "$TOXIPROXY_API/proxies/$1/toxics/$t" >/dev/null 2>&1 || true
+  done
+}
+
+chaos_cut() { # chaos_cut <target>
+  chaos_clear_toxics "$1"      # re-cutting an already-cut target must not 409
+  chaos_api -X POST "$TOXIPROXY_API/proxies/$1/toxics" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$CHAOS_TOXIC\",\"type\":\"timeout\",\"stream\":\"downstream\",\"toxicity\":1.0,\"attributes\":{\"timeout\":0}}" \
+    >/dev/null
+  ok "$1 cut — responses black-holed, callers hang until they time out"
+}
+
+chaos_reject() { # chaos_reject <target>
+  chaos_api -X POST "$TOXIPROXY_API/proxies/$1" \
+    -H 'Content-Type: application/json' -d '{"enabled":false}' >/dev/null
+  ok "$1 rejecting — connections refused"
+}
+
+chaos_heal() { # chaos_heal <target>
+  chaos_clear_toxics "$1"
+  chaos_api -X POST "$TOXIPROXY_API/proxies/$1" \
+    -H 'Content-Type: application/json' -d '{"enabled":true}' >/dev/null
+  ok "$1 healed — toxics cleared, listener enabled"
+}
+
+chaos_status() {
+  local p body upstream state toxics
+  printf '%-10s %-20s %-11s %s\n' "TARGET" "UPSTREAM" "STATE" "TOXICS"
+  for p in $(chaos_targets); do
+    if ! body="$(chaos_curl "$TOXIPROXY_API/proxies/$p" 2>/dev/null)"; then
+      printf '%-10s %-20s %-11s %s\n' "$p" "-" "absent" "-"
+      continue
+    fi
+    upstream="$(printf '%s' "$body" | tr ',' '\n' | sed -n 's/.*"upstream":"\([^"]*\)".*/\1/p')"
+    case "$body" in *'"enabled":false'*) state="rejecting" ;; *) state="listening" ;; esac
+    toxics="$(chaos_toxic_names "$p" | tr '\n' ' ' | sed 's/ *$//')"
+    [ -n "$toxics" ] || toxics="-"
+    printf '%-10s %-20s %-11s %s\n' "$p" "$upstream" "$state" "$toxics"
+  done
+}
+
+chaos_usage() {
+  cat <<'EOF'
+./local-stack.sh chaos <verb> [target]
+
+  status                what is proxied, and what is currently disrupting it
+  cut <target>          black-hole it: responses stop, callers hang until their own
+                        timeout fires (a silent failover / network partition)
+  reject <target>       refuse connections outright: immediate reset (the service
+                        went away — a restart, a closed port)
+  heal <target>|--all   clear every toxic and re-enable the listener
+
+Targets are the proxies declared in dev/toxiproxy.json, and need a stack started with
+--chaos. Anything beyond cut/reject — latency, bandwidth, slicer, partial reads — lives on
+the toxiproxy API at localhost:8474; see docker/local-stack/README.md. `heal` also clears
+toxics you added there by hand.
+EOF
+}
+
+cmd_chaos() {
+  local verb="${CHAOS_ARGS[0]:-}" target="${CHAOS_ARGS[1]:-}"
+  case "$verb" in ""|help|-h|--help) chaos_usage; return 0 ;; esac
+  chaos_require_up
+  case "$verb" in
+    status) chaos_status ;;
+    cut|reject|heal)
+      if [ "$verb" = "heal" ] && [ "$target" = "--all" ]; then
+        local p
+        for p in $(chaos_targets); do
+          if chaos_curl "$TOXIPROXY_API/proxies/$p" >/dev/null 2>&1; then chaos_heal "$p"; fi
+        done
+        return 0
+      fi
+      [ -n "$target" ] || die "chaos $verb needs a target (or: chaos heal --all)
+     Known targets: $(chaos_targets | tr '\n' ' ')"
+      chaos_check_target "$target"
+      chaos_check_live "$target"
+      case "$verb" in
+        cut)    chaos_cut "$target" ;;
+        reject) chaos_reject "$target" ;;
+        heal)   chaos_heal "$target" ;;
+      esac
+      ;;
+    *) die "unknown chaos verb: $verb (try: ./local-stack.sh chaos help)" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -571,5 +750,6 @@ case "$COMMAND" in
   logs)   cmd_logs ;;
   status) cmd_status ;;
   pull)   cmd_pull ;;
+  chaos)  cmd_chaos ;;
   *)      usage; exit 1 ;;
 esac

--- a/docs/agent-standards/skills/local-stack/SKILL.md
+++ b/docs/agent-standards/skills/local-stack/SKILL.md
@@ -41,11 +41,12 @@ cd docker/local-stack
 | `--full` | UI + wiremock + ciba + openfga + kafka + mtls (jest-gateway + playwright union). Does **not** include cloud. |
 | `--cloud` | Overlay: cockpit mock + management API in managed-cloud mode. |
 | `--with a,b,…` | Opt-in extras: `ui,wiremock,ciba,openfga,kafka,mtls,spire,cloud`. |
+| `--chaos` | Route AM's outbound connections through toxiproxy so they can be broken on demand. Off by default. |
 | `--build` | Full clean rebuild: wipes stale source-tree plugin caches, `mvn clean install`, `make plugins`. Use when a container crashes on boot. |
 | `--quick` / `--no-build` | Skip Maven; reuse existing zips, just rebuild images. |
 | `--license <path>` | EE license file (default `dev/license/gravitee-universe-v4.key`). |
 
-Other commands: `down`, `logs [svc]`, `status`, `pull --version <tag>`, `help`.
+Other commands: `down`, `logs [svc]`, `status`, `pull --version <tag>`, `chaos <verb>`, `help`.
 
 ## Service set (what to start for which tests)
 
@@ -55,6 +56,40 @@ Other commands: `down`, `logs [svc]`, `status`, `pull --version <tag>`, `help`.
 - **`--full`** — the union the **jest gateway** and **playwright** suites need (not cloud).
 - **`--cloud`** — managed-cloud overlay (Cockpit mock) for the **cloud** jest suite.
 - **`--with spire`** — only for the env-guarded gateway specs (`RUN_SPIRE_TESTS=true`).
+
+## Fault injection (`--chaos`)
+
+Starts toxiproxy between AM and the infrastructure it dials out to, so connections can be
+broken and restored while the stack keeps running. Omitted unless asked for, and inert until
+something is injected.
+
+```bash
+./local-stack.sh up --db psql --chaos
+
+./local-stack.sh chaos status            # what is proxied, and what is disrupting it
+./local-stack.sh chaos cut postgres      # black hole — callers hang until they time out
+./local-stack.sh chaos reject postgres   # refused — immediate connection reset
+./local-stack.sh chaos heal postgres     # or: chaos heal --all
+```
+
+Targets: `postgres` / `mongo` (per `--db`), `smtp` (always), `cockpit` (with `--cloud`).
+
+- `cut` vs `reject` are different failures: `cut` stops data without closing anything, so a
+  pool connection looks healthy and blocks until some timeout fires (silent failover);
+  `reject` disables the listener, so connections are refused immediately (service restarted).
+- `cut` is **one-way** — it blocks responses, not requests, so a query sent during a cut still
+  reaches the database and commits. Add a matching `upstream` toxic for a two-way stall.
+- `docker stop <db>` is not an equivalent test: a stopped container loses its DNS alias, so AM
+  sees name resolution fail rather than a refused, reset, or hung socket.
+- **Only the admin API (`:8474`) is published.** Proxy listeners stay on the compose network,
+  so a jest/playwright run on the host keeps its direct route to the database and can assert
+  against the data while AM's connection is cut.
+- **LDAP and external HTTP IdPs are not covered** — their addresses are per-domain config in
+  the database (`ldap://openldap:1389`, `http://wiremock:8080`), not compose env, so there is
+  nothing central to redirect.
+- Anything beyond `cut`/`reject` (latency, bandwidth, slicer, …) is deliberately not wrapped:
+  use the toxiproxy API on `localhost:8474`. `chaos heal` clears those toxics too.
+- A toxic survives until removed — `chaos heal --all` before concluding AM is broken.
 
 ## URLs & credentials (once up)
 


### PR DESCRIPTION
## :pencil2: A description of the changes proposed in the pull request
Add `./local-stack.sh up --chaos` mode. This lets you break AM's database, SMTP, and Cockpit connections on demand (and put them back) while keeping nodes up and without restarting them.

Unlike stopping a container, it reproduces production-like failures: connections that hang, refuse, or reset rather than hostnames that stop resolving.

## :memo: Test scenarios 
See local-stack README.md.

## :computer: Add screenshots for UI
n/a

## :books: Any other comments that will help with documentation
n/a

## :man: :woman:@mentions of the person or team responsible for reviewing proposed changes
@gravitee-io/am 